### PR TITLE
Simplify READMEs, move usage to skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,53 +4,27 @@ A collection of CLI tools and skills designed to be useful for LLM agents.
 
 ## Packages
 
-### browser-cli
-
-Control Firefox browser from the command line. Useful for web automation, scraping, and testing.
-
-```bash
-nix run github:Mic92/mics-skills#browser-cli
-```
-
-### db-cli
-
-CLI tool for searching Deutsche Bahn train connections.
-
-```bash
-nix run github:Mic92/mics-skills#db-cli
-```
-
-### gmaps-cli
-
-CLI tool to search for places using Google Maps API.
-
-```bash
-nix run github:Mic92/mics-skills#gmaps-cli
-```
-
-### kagi-search
-
-CLI tool for searching Kagi using session tokens.
-
-```bash
-nix run github:Mic92/mics-skills#kagi-search
-```
-
-### pexpect-cli
-
-Persistent pexpect sessions for automating interactive terminal applications.
-
-```bash
-nix run github:Mic92/mics-skills#pexpect-cli
-```
+| Package                     | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| [browser-cli](browser-cli/) | Control Firefox browser from the command line                   |
+| [db-cli](db-cli/)           | Search Deutsche Bahn train connections                          |
+| [gmaps-cli](gmaps-cli/)     | Search for places and get directions using Google Maps          |
+| [kagi-search](kagi-search/) | Search the web using Kagi with Quick Answer AI summaries        |
+| [pexpect-cli](pexpect-cli/) | Persistent pexpect sessions for interactive terminal automation |
 
 ## Skills
 
-The `skills/` directory contains Claude skill definitions that can be used with
-Claude Code or similar LLM coding assistants:
+The `skills/` directory contains Claude skill definitions for use with Claude
+Code or similar LLM coding assistants. Each skill provides usage examples and
+references the package README for setup instructions.
 
-- `skills/browser-cli/SKILL.md` - Instructions for using browser-cli
-- `skills/pexpect-cli/SKILL.md` - Instructions for using pexpect-cli
+| Skill                                      | Description                                       |
+| ------------------------------------------ | ------------------------------------------------- |
+| [browser-cli](skills/browser-cli/SKILL.md) | Web automation, scraping, testing                 |
+| [db-cli](skills/db-cli/SKILL.md)           | Train route and schedule search                   |
+| [gmaps-cli](skills/gmaps-cli/SKILL.md)     | Place search and directions                       |
+| [kagi-search](skills/kagi-search/SKILL.md) | Web search with AI summaries                      |
+| [pexpect-cli](skills/pexpect-cli/SKILL.md) | SSH, database, and interactive program automation |
 
 ## Installation
 
@@ -59,6 +33,10 @@ Claude Code or similar LLM coding assistants:
 ```bash
 # Run a tool directly
 nix run github:Mic92/mics-skills#browser-cli
+nix run github:Mic92/mics-skills#db-cli
+nix run github:Mic92/mics-skills#gmaps-cli
+nix run github:Mic92/mics-skills#kagi-search
+nix run github:Mic92/mics-skills#pexpect-cli
 
 # Add to your flake inputs
 {
@@ -66,10 +44,11 @@ nix run github:Mic92/mics-skills#browser-cli
 }
 ```
 
-### Development
+## Development
 
 ```bash
 nix develop
+nix fmt
 nix flake check
 ```
 

--- a/browser-cli/README.md
+++ b/browser-cli/README.md
@@ -18,7 +18,7 @@ Browser CLI consists of three components:
 ### For Nix Users
 
 ```bash
-nix run github:Mic92/dotfiles#browser-cli -- --help
+nix run github:Mic92/mics-skills#browser-cli -- --help
 ```
 
 ### Manual Installation
@@ -37,182 +37,8 @@ nix run github:Mic92/dotfiles#browser-cli -- --help
 
 ## Usage
 
-### Basic Usage
-
-```bash
-# List managed tabs
-browser-cli --list
-
-# Open a page
-browser-cli <<'EOF'
-await tab("https://example.com")
-EOF
-
-# Get page snapshot
-browser-cli <<'EOF'
-snap()
-EOF
-
-# Execute in a specific tab
-browser-cli abc123 <<'EOF'
-snap()
-EOF
-```
-
-### JavaScript API
-
-The API is optimized for token efficiency. Use `snap()` to get page state.
-
-#### Snapshot Output Format
-
-```
-Page: Example Site
-URL: https://example.com
-
-[1] heading "Welcome"
-[2] input[email] "Email" [required]
-[3] input[password] "Password" [required]
-[4] checkbox "Remember me"
-[5] button "Sign In"
-[6] link "Forgot password?"
-```
-
-- `[N]` - Reference number for use with click(), type(), etc.
-- Role and accessible name shown
-- Attributes in brackets: `[disabled]`, `[checked]`, `[required]`, etc.
-- Input values shown as `value="..."`
-
-#### Element Interaction (using refs)
-
-```bash
-# Get snapshot first to see available refs
-browser-cli <<'EOF'
-snap()
-EOF
-
-# Use refs from snapshot
-browser-cli <<'EOF'
-await click(1)                    // Click element [1]
-await click(1, {double: true})    // Double click
-await type(2, "user@example.com") // Type into element [2]
-await type(2, "new", {clear: true}) // Clear first, then type
-await hover(3)                    // Hover over element [3]
-await drag(4, 5)                  // Drag from [4] to [5]
-await select(6, "option-value")  // Select dropdown option
-EOF
-
-# Can still use CSS selectors when needed
-browser-cli <<'EOF'
-await click("#submit-button")
-await click("Sign In", "text")
-await type("input[name='email']", "user@example.com")
-EOF
-```
-
-#### Keyboard
-
-```bash
-browser-cli <<'EOF'
-key("Enter")
-key("Tab")
-key("Escape")
-EOF
-```
-
-#### Page Inspection
-
-```bash
-# Get snapshot with all interactive elements
-browser-cli <<'EOF'
-snap()
-EOF
-
-# Filtered snapshots
-browser-cli <<'EOF'
-snap({forms: true})       // Only form elements
-snap({links: true})       // Only links
-snap({buttons: true})     // Only buttons
-snap({text: "login"})     // Elements containing "login"
-snap({near: 3})           // Elements near ref [3]
-EOF
-
-# Console logs
-browser-cli <<'EOF'
-logs()
-EOF
-```
-
-#### Waiting
-
-```bash
-browser-cli <<'EOF'
-await wait(1000)              // Wait 1 second
-await wait("text", "Success") // Wait for text to appear
-await wait("gone", "Loading") // Wait for text to disappear
-EOF
-```
-
-#### Screenshots
-
-```bash
-browser-cli <<'EOF'
-await shot()                  // Screenshot, returns data URL
-await shot("/tmp/page.png")   // Screenshot to specific path
-EOF
-```
-
-#### Tab Management
-
-```bash
-browser-cli <<'EOF'
-await tab()                      // Create new tab
-await tab("https://example.com") // Create with URL
-await tabs()                     // List all tabs
-EOF
-```
-
-### Examples
-
-```bash
-# Search on Google
-browser-cli <<'EOF'
-await tab("https://google.com")
-snap()
-EOF
-# Output shows [12] combobox "Suche"
-
-browser-cli <<'EOF'
-await type(12, "hello world")
-snap()
-EOF
-# Shows diff: Added (autocomplete options), Changed (input value)
-
-# Form filling with refs
-browser-cli <<'EOF'
-await tab("https://example.com/login")
-snap()
-EOF
-# Output: [1] input "Email", [2] input "Password", [3] button "Sign In"
-
-browser-cli <<'EOF'
-await type(1, "user@test.com")
-await type(2, "secret123")
-await click(3)
-snap()
-EOF
-
-# Wait for dynamic content
-browser-cli <<'EOF'
-await click(5)
-await wait("text", "Success")
-snap()
-EOF
-
-# Take a screenshot
-browser-cli <<'EOF'
-await shot("/tmp/page.png")
-EOF
-```
+See [skills/browser-cli/SKILL.md](../skills/browser-cli/SKILL.md) for usage
+examples and JavaScript API reference.
 
 ## Architecture
 
@@ -222,57 +48,6 @@ EOF
 │  (stdin)    │                     │   Server     │    Messaging    │            │
 └─────────────┘                     └──────────────┘                 └────────────┘
 ```
-
-## API Reference
-
-### Interaction
-
-| Function                         | Description     |
-| -------------------------------- | --------------- |
-| `click(ref)`                     | Click element   |
-| `click(ref, {double: true})`     | Double click    |
-| `type(ref, text)`                | Type into input |
-| `type(ref, text, {clear: true})` | Clear first     |
-| `key(name)`                      | Press key       |
-| `hover(ref)`                     | Hover element   |
-| `drag(from, to)`                 | Drag and drop   |
-| `select(ref, value)`             | Select option   |
-
-### Inspection
-
-| Function             | Description                             |
-| -------------------- | --------------------------------------- |
-| `snap()`             | Get page snapshot (diff after 1st call) |
-| `snap({full: true})` | Force full snapshot                     |
-| `snap({...})`        | Filtered snapshot                       |
-| `logs()`             | Get console logs                        |
-| `find(ref)`          | Find DOM element                        |
-
-### Waiting
-
-| Function            | Description               |
-| ------------------- | ------------------------- |
-| `wait(ms)`          | Wait milliseconds         |
-| `wait("idle")`      | Wait for DOM to stabilize |
-| `wait("text", str)` | Wait for text             |
-| `wait("gone", str)` | Wait for text gone        |
-
-### Media
-
-| Function              | Description            |
-| --------------------- | ---------------------- |
-| `shot()`              | Screenshot             |
-| `shot(path)`          | Screenshot to path     |
-| `download(url)`       | Download file          |
-| `download(url, name)` | Download with filename |
-
-### Tabs
-
-| Function   | Description      |
-| ---------- | ---------------- |
-| `tab()`    | New tab          |
-| `tab(url)` | New tab with URL |
-| `tabs()`   | List tabs        |
 
 ## Development
 
@@ -321,4 +96,4 @@ Refs are reset on each snapshot. If you get "Element [N] not found", call
 
 ## License
 
-This project is part of the dotfiles repository and follows its licensing terms.
+MIT

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,19 @@
       ];
 
       perSystem =
-        { pkgs, ... }:
         {
+          pkgs,
+          self',
+          lib,
+          ...
+        }:
+        {
+          checks =
+            let
+              packages = lib.mapAttrs' (n: lib.nameValuePair "package-${n}") self'.packages;
+            in
+            packages;
+
           packages = {
             browser-cli = pkgs.python3.pkgs.callPackage ./browser-cli { };
             browser-cli-extension = (pkgs.callPackages ./firefox-extensions { }).browser-cli-extension;

--- a/gmaps-cli/README.md
+++ b/gmaps-cli/README.md
@@ -38,70 +38,14 @@ Maps API.
 
 ## Usage
 
-### Search for a specific place
-
-```bash
-gmaps-cli search "Nobu Malibu"
-```
-
-Output:
-
-```
-Nobu Malibu
-22706 Pacific Coast Hwy, Malibu, CA 90265, USA
-34.0259216, -118.6819819
-Rating: 4.4 (1234 reviews)
-```
-
-### Search for places nearby
-
-```bash
-gmaps-cli nearby "coffee" --limit 5
-
-# Search near specific location
-gmaps-cli nearby "restaurants" --location "34.0522,-118.2437" --limit 3
-```
-
-Output:
-
-```
-1. Blue Bottle Coffee
-   123 Main St, Los Angeles, CA 90012, USA
-   Rating: 4.5 $$
-
-2. Starbucks
-   456 Broadway, Los Angeles, CA 90013, USA
-   Rating: 4.0 $$
-```
-
-### Get directions
-
-```bash
-gmaps-cli route "Los Angeles" "San Francisco"
-
-# Different travel modes
-gmaps-cli route "Times Square" "Central Park" --mode walking
-gmaps-cli route "Brooklyn" "Manhattan" --mode transit
-```
-
-Output:
-
-```
-Route from Los Angeles, CA, USA to San Francisco, CA, USA
-Distance: 382 mi
-Duration: 5 hours 48 mins
-
-Directions:
-
-1. Head northwest on N Spring St toward W Temple St
-   0.3 mi - 2 mins
-
-2. Use the left 2 lanes to turn left onto US-101 N
-   170 mi - 2 hours 31 mins
-```
+See [skills/gmaps-cli/SKILL.md](../skills/gmaps-cli/SKILL.md) for usage examples.
 
 ## Configuration
 
 The configuration is stored in `~/.config/gmaps-cli/config.json`. It contains
 the command used to retrieve your API key, ensuring the key itself is never
 stored in plaintext.
+
+## License
+
+MIT

--- a/kagi-search/README.md
+++ b/kagi-search/README.md
@@ -15,28 +15,6 @@ Create `~/.config/kagi/config.json`:
 }
 ```
 
-## Usage
-
-```bash
-# Search using password manager (includes Quick Answer by default)
-kagi-search "search query"
-
-# With explicit token
-kagi-search -t "TOKEN" "search query"
-
-# JSON output
-kagi-search -j "search query" | jq '.results[0].url'
-
-# Extract Quick Answer from JSON
-kagi-search -j "search query" | jq '.quick_answer.markdown'
-
-# Limit results
-kagi-search -n 5 "search query"
-
-# Enable debug logging
-kagi-search -d "search query"
-```
-
 ## Getting Your Token
 
 1. Log in to [Kagi](https://kagi.com)
@@ -44,6 +22,11 @@ kagi-search -d "search query"
 3. Generate and copy session link
 4. Store in password manager
 
-# Filter list for kagi:
+## Usage
 
-https://codeberg.org/bbbhltz/16CompaniesFilters/raw/branch/main/16companies.txt
+See [skills/kagi-search/SKILL.md](../skills/kagi-search/SKILL.md) for usage
+examples.
+
+## License
+
+MIT

--- a/pexpect-cli/README.md
+++ b/pexpect-cli/README.md
@@ -12,7 +12,6 @@ manager.
 - **Real-time output**: Stream output to pueue logs as commands execute
 - **Isolated queue**: All sessions run in a dedicated `pexpect` group
 - **Simple interface**: Execute Python code via stdin
-- **XDG compliant**: Stores sockets in XDG_RUNTIME_DIR with secure fallback
 
 ## Architecture
 
@@ -21,219 +20,46 @@ manager.
 - **pexpect-cli**: Client that sends Python code to the server via Unix sockets
 - **Session ID**: Unique UUID-based identifiers (not pueue task IDs)
 - **Pueue group**: All sessions run in the `pexpect` group for isolation
-- **Logging**: Server streams output to stdout in real-time, captured by pueue
-- **Streaming**: Output is both displayed in real-time and returned to client
 
 ## Installation
 
 With Nix:
 
 ```bash
-nix run github:Mic92/dotfiles#pexpect-cli
+nix run github:Mic92/mics-skills#pexpect-cli
 ```
 
 Or add to your NixOS/home-manager configuration.
 
 ## Usage
 
-### Start a new session
-
-```bash
-$ pexpect-cli --start
-5901c22d
-```
-
-The session ID is a unique 8-character hex string. Optionally add a label:
-
-```bash
-$ pexpect-cli --start --name ssh-prod
-a3f4b2c1
-```
-
-### Execute code in a session
-
-Code is read from stdin:
-
-```bash
-# Using echo
-$ echo 'child = pexpect.spawn("bash")' | pexpect-cli 5901c22d
-
-# Using heredoc
-$ pexpect-cli 5901c22d <<EOF
-child.sendline('pwd')
-child.expect('\$')
-print(child.before.decode())
-EOF
-
-# From a file
-$ pexpect-cli 5901c22d < script.py
-```
-
-### Monitor sessions
-
-All sessions run in the `pexpect` group for easy isolation:
-
-```bash
-# View all pexpect sessions
-$ pueue status --group pexpect
-
-# Follow live output in real-time
-$ pueue follow <task-id>
-
-# View full logs
-$ pueue log <task-id>
-
-# List sessions with pexpect-cli
-$ pexpect-cli --list
-5901c22d: Running
-a3f4b2c1: Running (ssh-prod)
-```
-
-**Finding task IDs**: When you start a session, note the task ID from
-`pueue status --group pexpect`. The task ID is shown in the first column
-(different from session ID).
-
-### Stop a session
-
-```bash
-$ pexpect-cli --stop 5901c22d
-
-# Or use pueue directly with the task ID
-$ pueue kill <task-id>
-```
-
-### One-shot execution (no persistence)
-
-If no session ID is provided, code runs in a temporary namespace:
-
-```bash
-$ echo 'print(pexpect.spawn("echo hello").read().decode())' | pexpect-cli
-hello
-```
-
-## Examples
-
-### Interactive SSH session
-
-```bash
-# Start session
-$ session=$(pexpect-cli --start --name ssh-session)
-
-# Connect to SSH
-$ pexpect-cli $session <<'EOF'
-child = pexpect.spawn('ssh user@example.com')
-child.expect('password:')
-child.sendline('mypassword')
-child.expect('\$')
-print("Connected!")
-EOF
-
-# Run commands
-$ pexpect-cli $session <<'EOF'
-child.sendline('uptime')
-child.expect('\$')
-print(child.before.decode())
-EOF
-
-# Cleanup
-$ pexpect-cli --stop $session
-```
-
-### Database interaction
-
-```bash
-$ session=$(pexpect-cli --start --name db-session)
-
-$ pexpect-cli $session <<'EOF'
-child = pexpect.spawn('sqlite3 mydb.db')
-child.expect('sqlite>')
-child.sendline('.tables')
-child.expect('sqlite>')
-print("Tables:", child.before.decode())
-EOF
-```
-
-### Automating vim
-
-```bash
-$ pexpect-cli --start | read session
-
-$ pexpect-cli $session <<'EOF'
-child = pexpect.spawn('vim test.txt')
-child.expect('.')
-child.send('i')  # Insert mode
-child.send('Hello from pexpect!')
-child.send('\x1b')  # ESC
-child.send(':wq\r')  # Save and quit
-child.expect(pexpect.EOF)
-print("File created")
-EOF
-```
-
-## Available in Namespace
-
-When executing code, the following are available:
-
-- `pexpect`: The pexpect module
-- `child`: Persistent child process variable (initially None, persists across
-  executions in the same session)
+See [skills/pexpect-cli/SKILL.md](../skills/pexpect-cli/SKILL.md) for usage
+examples.
 
 ## Socket Location
 
 Sockets are stored securely with proper permissions (0o700):
 
-- **Preferred**: `$XDG_RUNTIME_DIR/pexpect-cli/{session_id}.sock` (tmpfs,
-  auto-cleanup on logout)
-- **Fallback**: `$XDG_CACHE_HOME/pexpect-cli/sockets/{session_id}.sock` or
-  `~/.cache/pexpect-cli/sockets/{session_id}.sock`
+- **Preferred**: `$XDG_RUNTIME_DIR/pexpect-cli/{session_id}.sock`
+- **Fallback**: `$XDG_CACHE_HOME/pexpect-cli/sockets/{session_id}.sock`
 
-## Advanced Usage
+## Monitoring with Pueue
 
-### Leverage pueue features
-
-Since sessions are pueue tasks in the `pexpect` group, you can use pueue
-features:
+Since sessions are pueue tasks in the `pexpect` group:
 
 ```bash
-# View only pexpect sessions
-$ pueue status --group pexpect
+# View all pexpect sessions
+pueue status --group pexpect
+
+# Follow live output
+pueue follow <task-id>
+
+# View full logs
+pueue log <task-id>
 
 # Kill all pexpect sessions
-$ pueue clean --group pexpect
-
-# Pause/start the pexpect group
-$ pueue pause --group pexpect
-$ pueue start --group pexpect
+pueue clean --group pexpect
 ```
-
-Note: Sessions are automatically added to the `pexpect` group - you don't need
-to manage this manually.
-
-### Multiple parallel sessions
-
-```bash
-# Start 5 sessions in parallel
-$ for i in {1..5}; do
-    pexpect-cli --start --name "worker-$i"
-  done
-
-# Execute in all
-$ pexpect-cli --list | awk '{print $1}' | while read -r id; do
-    echo 'print("hello from", '$id')' | pexpect-cli "$id"
-  done
-```
-
-## Comparison with MCP Version
-
-The original MCP-based implementation was designed for Claude Code integration.
-This CLI version:
-
-- ✅ **Simpler**: ~220 lines vs 340 lines
-- ✅ **No MCP dependency**: Standalone tool
-- ✅ **Better monitoring**: Native pueue integration
-- ✅ **More flexible**: Can be used in scripts, pipelines, etc.
-- ✅ **Cleaner logging**: Uses pueue's logging, no custom log files
-- ✅ **Process management**: Pueue handles all daemon complexity
 
 ## Troubleshooting
 
@@ -241,34 +67,22 @@ This CLI version:
 
 ```bash
 # Check pueue daemon is running
-$ pueue status
+pueue status
 
 # If not, start it
-$ pueued -d
+pueued -d
 ```
 
 ### Socket not found
 
 ```bash
 # Check session is actually running
-$ pueue status
+pueue status --group pexpect
 
 # Check socket location
-$ ls -la $XDG_RUNTIME_DIR/pexpect-cli/
-# or
-$ ls -la ~/.cache/pexpect-cli/sockets/
-```
-
-### View detailed server logs
-
-```bash
-# Follow server output
-$ pueue follow <session-id>
-
-# View full log
-$ pueue log <session-id>
+ls -la $XDG_RUNTIME_DIR/pexpect-cli/
 ```
 
 ## License
 
-This project follows the same license as the parent repository.
+MIT


### PR DESCRIPTION
READMEs now focus on setup/installation/troubleshooting. Usage examples are in the corresponding skill files.