### PR TITLE
browser-cli: add readability.js snapshots

### DIFF
--- a/browser-cli/browser_cli/__init__.py
+++ b/browser-cli/browser_cli/__init__.py
@@ -7,5 +7,6 @@ JS API for browser automation.
 from browser_cli.bridge import NativeMessagingBridge
 from browser_cli.cli import main
 from browser_cli.client import BrowserClient
+from browser_cli.paths import get_socket_path
 
-__all__ = ["BrowserClient", "NativeMessagingBridge", "main"]
+__all__ = ["BrowserClient", "NativeMessagingBridge", "get_socket_path", "main"]

--- a/browser-cli/browser_cli/cli.py
+++ b/browser-cli/browser_cli/cli.py
@@ -229,6 +229,13 @@ async def exec_js(tab_id: str | None, code: str, socket: str | None) -> None:
         print(format_snapshot(result))
 
 
+async def navigate_tab(tab_id: str | None, url: str, socket: str | None) -> None:
+    """Navigate a tab to a URL and wait for load."""
+    client = BrowserClient(socket)
+    await client.send_command("go", {"url": url}, tab_id)
+    print(f"Navigated to {url}")
+
+
 async def list_tabs(socket: str | None) -> None:
     """List all managed tabs."""
     client = BrowserClient(socket)
@@ -333,6 +340,11 @@ Available JS API:
         help="Unix socket path (default: $XDG_RUNTIME_DIR/browser-cli.sock)",
     )
     parser.add_argument(
+        "--go",
+        metavar="URL",
+        help="Navigate the tab to URL and wait for load",
+    )
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="Enable debug logging",
@@ -354,6 +366,8 @@ def main() -> None:
             install_native_host()
         elif args.list:
             asyncio.run(list_tabs(args.socket))
+        elif args.go:
+            asyncio.run(navigate_tab(args.tab_id, args.go, args.socket))
         elif args.tab_id or not sys.stdin.isatty():
             code = sys.stdin.read()
             if not code.strip():

--- a/browser-cli/browser_cli/cli.py
+++ b/browser-cli/browser_cli/cli.py
@@ -121,8 +121,52 @@ def _format_diff(result: dict[str, Any]) -> str | None:
     return "\n".join(lines)
 
 
+def _format_reader_result(result: dict[str, Any]) -> str | None:
+    """Format a reader mode result for display. Returns None if not a reader result."""
+    # Reader mode results have: title, content, length (required)
+    # Optional: byline, siteName, publishedTime
+    if "content" not in result or "length" not in result:
+        return None
+
+    # Must have content as a string (not elements array like snapshot)
+    if not isinstance(result.get("content"), str):
+        return None
+
+    lines: list[str] = []
+
+    # Header with metadata
+    if result.get("title"):
+        lines.append(result["title"])
+        lines.append("=" * len(result["title"]))
+
+    if result.get("byline"):
+        lines.append(f"By: {result['byline']}")
+
+    if result.get("siteName"):
+        lines.append(f"Source: {result['siteName']}")
+
+    if result.get("publishedTime"):
+        lines.append(f"Published: {result['publishedTime']}")
+
+    # Add separator before content if we had any metadata
+    if lines:
+        lines.append("")
+        lines.append("-" * 40)
+        lines.append("")
+
+    # Main content
+    lines.append(result["content"])
+
+    return "\n".join(lines)
+
+
 def _format_snapshot_dict(result: dict[str, Any]) -> str | None:
     """Format a snapshot dict for display. Returns None if not a snapshot."""
+    # Check if it's a reader mode result
+    reader_result = _format_reader_result(result)
+    if reader_result is not None:
+        return reader_result
+
     # Check if it's a SnapshotDiff object
     diff_result = _format_diff(result)
     if diff_result is not None:

--- a/browser-cli/browser_cli/client.py
+++ b/browser-cli/browser_cli/client.py
@@ -2,12 +2,10 @@
 
 import asyncio
 import json
-import os
-import tempfile
-from pathlib import Path
 from typing import Any
 
 from browser_cli.errors import BrowserConnectionError, CommandError
+from browser_cli.paths import get_socket_path
 
 
 class BrowserClient:
@@ -18,10 +16,7 @@ class BrowserClient:
         if socket_path:
             self.socket_path = socket_path
         else:
-            runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-            if not runtime_dir:
-                runtime_dir = tempfile.gettempdir()
-            self.socket_path = str(Path(runtime_dir) / "browser-cli.sock")
+            self.socket_path = str(get_socket_path())
 
         self.message_counter = 0
 

--- a/browser-cli/browser_cli/paths.py
+++ b/browser-cli/browser_cli/paths.py
@@ -1,0 +1,34 @@
+"""Path utilities for browser-cli."""
+
+import os
+from pathlib import Path
+
+
+def get_socket_path() -> Path:
+    """Get secure socket path for browser-cli.
+
+    Uses XDG_RUNTIME_DIR on Linux, which is:
+    - User-owned (mode 0700)
+    - Not world-readable
+    - Cleared on logout
+
+    On macOS, uses $TMPDIR which is a secure per-user directory
+    under /var/folders/ with mode 0700.
+
+    Falls back to XDG_CACHE_HOME/browser-cli/ (~/.cache/browser-cli/)
+    with mode 0700 if runtime dir is unavailable.
+    """
+    # Try XDG_RUNTIME_DIR first (Linux, some macOS setups)
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_dir:
+        return Path(runtime_dir) / "browser-cli.sock"
+
+    # Fallback: use XDG_CACHE_HOME/browser-cli/ with restrictive permissions
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    if not cache_home:
+        cache_home = str(Path.home() / ".cache")
+    fallback_dir = Path(cache_home) / "browser-cli"
+    fallback_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    # Ensure restrictive permissions even if directory existed
+    fallback_dir.chmod(0o700)
+    return fallback_dir / "browser-cli.sock"

--- a/browser-cli/browser_cli/server.py
+++ b/browser-cli/browser_cli/server.py
@@ -12,10 +12,10 @@ import logging.handlers
 import os
 import signal
 import sys
-import tempfile
 from pathlib import Path
 
 from browser_cli.bridge import NativeMessagingBridge
+from browser_cli.paths import get_socket_path
 
 logger = logging.getLogger(__name__)
 
@@ -63,12 +63,8 @@ async def async_main() -> None:
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, signal_handler)
 
-    # Get runtime directory for Unix socket
-    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-    if not runtime_dir:
-        runtime_dir = tempfile.gettempdir()
-
-    socket_path = Path(runtime_dir) / "browser-cli.sock"
+    # Get secure socket path
+    socket_path = get_socket_path()
 
     # Run bridge until stopped
     bridge_task = asyncio.create_task(bridge.start(socket_path))

--- a/browser-cli/extension/Readability.js
+++ b/browser-cli/extension/Readability.js
@@ -1,0 +1,2815 @@
+/*
+ * Copyright (c) 2010 Arc90 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is heavily based on Arc90's readability.js (1.7.1) script
+ * available at: http://code.google.com/p/arc90labs-readability
+ */
+
+/**
+ * Public constructor.
+ * @param {HTMLDocument} doc     The document to parse.
+ * @param {Object}       options The options object.
+ */
+function Readability(doc, options) {
+  // In some older versions, people passed a URI as the first argument. Cope:
+  if (options && options.documentElement) {
+    doc = options;
+    options = arguments[2];
+  } else if (!doc || !doc.documentElement) {
+    throw new Error(
+      "First argument to Readability constructor should be a document object.",
+    );
+  }
+  options = options || {};
+
+  this._doc = doc;
+  this._docJSDOMParser = this._doc.firstChild.__JSDOMParser__;
+  this._articleTitle = null;
+  this._articleByline = null;
+  this._articleDir = null;
+  this._articleSiteName = null;
+  this._attempts = [];
+  this._metadata = {};
+
+  // Configurable options
+  this._debug = !!options.debug;
+  this._maxElemsToParse =
+    options.maxElemsToParse || this.DEFAULT_MAX_ELEMS_TO_PARSE;
+  this._nbTopCandidates =
+    options.nbTopCandidates || this.DEFAULT_N_TOP_CANDIDATES;
+  this._charThreshold = options.charThreshold || this.DEFAULT_CHAR_THRESHOLD;
+  this._classesToPreserve = this.CLASSES_TO_PRESERVE.concat(
+    options.classesToPreserve || [],
+  );
+  this._keepClasses = !!options.keepClasses;
+  this._serializer =
+    options.serializer ||
+    function (el) {
+      return el.innerHTML;
+    };
+  this._disableJSONLD = !!options.disableJSONLD;
+  this._allowedVideoRegex = options.allowedVideoRegex || this.REGEXPS.videos;
+  this._linkDensityModifier = options.linkDensityModifier || 0;
+
+  // Start with all flags set
+  this._flags =
+    this.FLAG_STRIP_UNLIKELYS |
+    this.FLAG_WEIGHT_CLASSES |
+    this.FLAG_CLEAN_CONDITIONALLY;
+
+  // Control whether log messages are sent to the console
+  if (this._debug) {
+    let logNode = function (node) {
+      if (node.nodeType == node.TEXT_NODE) {
+        return `${node.nodeName} ("${node.textContent}")`;
+      }
+      let attrPairs = Array.from(node.attributes || [], function (attr) {
+        return `${attr.name}="${attr.value}"`;
+      }).join(" ");
+      return `<${node.localName} ${attrPairs}>`;
+    };
+    this.log = function () {
+      if (typeof console !== "undefined") {
+        let args = Array.from(arguments, (arg) => {
+          if (arg && arg.nodeType == this.ELEMENT_NODE) {
+            return logNode(arg);
+          }
+          return arg;
+        });
+        args.unshift("Reader: (Readability)");
+        // eslint-disable-next-line no-console
+        console.log(...args);
+      } else if (typeof dump !== "undefined") {
+        /* global dump */
+        var msg = Array.prototype.map
+          .call(arguments, function (x) {
+            return x && x.nodeName ? logNode(x) : x;
+          })
+          .join(" ");
+        dump("Reader: (Readability) " + msg + "\n");
+      }
+    };
+  } else {
+    this.log = function () {};
+  }
+}
+
+Readability.prototype = {
+  FLAG_STRIP_UNLIKELYS: 0x1,
+  FLAG_WEIGHT_CLASSES: 0x2,
+  FLAG_CLEAN_CONDITIONALLY: 0x4,
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+  ELEMENT_NODE: 1,
+  TEXT_NODE: 3,
+
+  // Max number of nodes supported by this parser. Default: 0 (no limit)
+  DEFAULT_MAX_ELEMS_TO_PARSE: 0,
+
+  // The number of top candidates to consider when analysing how
+  // tight the competition is among candidates.
+  DEFAULT_N_TOP_CANDIDATES: 5,
+
+  // Element tags to score by default.
+  DEFAULT_TAGS_TO_SCORE: "section,h2,h3,h4,h5,h6,p,td,pre"
+    .toUpperCase()
+    .split(","),
+
+  // The default number of chars an article must have in order to return a result
+  DEFAULT_CHAR_THRESHOLD: 500,
+
+  // All of the regular expressions in use within readability.
+  // Defined up here so we don't instantiate them repeatedly in loops.
+  REGEXPS: {
+    // NOTE: These two regular expressions are duplicated in
+    // Readability-readerable.js. Please keep both copies in sync.
+    unlikelyCandidates:
+      /-ad-|ai2html|banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|footer|gdpr|header|legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|ad-break|agegate|pagination|pager|popup|yom-remote/i,
+    okMaybeItsACandidate:
+      /and|article|body|column|content|main|mathjax|shadow/i,
+
+    positive:
+      /article|body|content|entry|hentry|h-entry|main|page|pagination|post|text|blog|story/i,
+    negative:
+      /-ad-|hidden|^hid$| hid$| hid |^hid |banner|combx|comment|com-|contact|footer|gdpr|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|widget/i,
+    extraneous:
+      /print|archive|comment|discuss|e[\-]?mail|share|reply|all|login|sign|single|utility/i,
+    byline: /byline|author|dateline|writtenby|p-author/i,
+    replaceFonts: /<(\/?)font[^>]*>/gi,
+    normalize: /\s{2,}/g,
+    videos:
+      /\/\/(www\.)?((dailymotion|youtube|youtube-nocookie|player\.vimeo|v\.qq|bilibili|live.bilibili)\.com|(archive|upload\.wikimedia)\.org|player\.twitch\.tv)/i,
+    shareElements: /(\b|_)(share|sharedaddy)(\b|_)/i,
+    nextLink: /(next|weiter|continue|>([^\|]|$)|»([^\|]|$))/i,
+    prevLink: /(prev|earl|old|new|<|«)/i,
+    tokenize: /\W+/g,
+    whitespace: /^\s*$/,
+    hasContent: /\S$/,
+    hashUrl: /^#.+/,
+    srcsetUrl: /(\S+)(\s+[\d.]+[xw])?(\s*(?:,|$))/g,
+    b64DataUrl: /^data:\s*([^\s;,]+)\s*;\s*base64\s*,/i,
+    // Commas as used in Latin, Sindhi, Chinese and various other scripts.
+    // see: https://en.wikipedia.org/wiki/Comma#Comma_variants
+    commas: /\u002C|\u060C|\uFE50|\uFE10|\uFE11|\u2E41|\u2E34|\u2E32|\uFF0C/g,
+    // See: https://schema.org/Article
+    jsonLdArticleTypes:
+      /^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$/,
+    // used to see if a node's content matches words commonly used for ad blocks or loading indicators
+    adWords:
+      /^(ad(vertising|vertisement)?|pub(licité)?|werb(ung)?|广告|Реклама|Anuncio)$/iu,
+    loadingWords:
+      /^((loading|正在加载|Загрузка|chargement|cargando)(…|\.\.\.)?)$/iu,
+  },
+
+  UNLIKELY_ROLES: [
+    "menu",
+    "menubar",
+    "complementary",
+    "navigation",
+    "alert",
+    "alertdialog",
+    "dialog",
+  ],
+
+  DIV_TO_P_ELEMS: new Set([
+    "BLOCKQUOTE",
+    "DL",
+    "DIV",
+    "IMG",
+    "OL",
+    "P",
+    "PRE",
+    "TABLE",
+    "UL",
+  ]),
+
+  ALTER_TO_DIV_EXCEPTIONS: ["DIV", "ARTICLE", "SECTION", "P", "OL", "UL"],
+
+  PRESENTATIONAL_ATTRIBUTES: [
+    "align",
+    "background",
+    "bgcolor",
+    "border",
+    "cellpadding",
+    "cellspacing",
+    "frame",
+    "hspace",
+    "rules",
+    "style",
+    "valign",
+    "vspace",
+  ],
+
+  DEPRECATED_SIZE_ATTRIBUTE_ELEMS: ["TABLE", "TH", "TD", "HR", "PRE"],
+
+  // The commented out elements qualify as phrasing content but tend to be
+  // removed by readability when put into paragraphs, so we ignore them here.
+  PHRASING_ELEMS: [
+    // "CANVAS", "IFRAME", "SVG", "VIDEO",
+    "ABBR",
+    "AUDIO",
+    "B",
+    "BDO",
+    "BR",
+    "BUTTON",
+    "CITE",
+    "CODE",
+    "DATA",
+    "DATALIST",
+    "DFN",
+    "EM",
+    "EMBED",
+    "I",
+    "IMG",
+    "INPUT",
+    "KBD",
+    "LABEL",
+    "MARK",
+    "MATH",
+    "METER",
+    "NOSCRIPT",
+    "OBJECT",
+    "OUTPUT",
+    "PROGRESS",
+    "Q",
+    "RUBY",
+    "SAMP",
+    "SCRIPT",
+    "SELECT",
+    "SMALL",
+    "SPAN",
+    "STRONG",
+    "SUB",
+    "SUP",
+    "TEXTAREA",
+    "TIME",
+    "VAR",
+    "WBR",
+  ],
+
+  // These are the classes that readability sets itself.
+  CLASSES_TO_PRESERVE: ["page"],
+
+  // These are the list of HTML entities that need to be escaped.
+  HTML_ESCAPE_MAP: {
+    lt: "<",
+    gt: ">",
+    amp: "&",
+    quot: '"',
+    apos: "'",
+  },
+
+  /**
+   * Run any post-process modifications to article content as necessary.
+   *
+   * @param Element
+   * @return void
+   **/
+  _postProcessContent(articleContent) {
+    // Readability cannot open relative uris so we convert them to absolute uris.
+    this._fixRelativeUris(articleContent);
+
+    this._simplifyNestedElements(articleContent);
+
+    if (!this._keepClasses) {
+      // Remove classes.
+      this._cleanClasses(articleContent);
+    }
+  },
+
+  /**
+   * Iterates over a NodeList, calls `filterFn` for each node and removes node
+   * if function returned `true`.
+   *
+   * If function is not passed, removes all the nodes in node list.
+   *
+   * @param NodeList nodeList The nodes to operate on
+   * @param Function filterFn the function to use as a filter
+   * @return void
+   */
+  _removeNodes(nodeList, filterFn) {
+    // Avoid ever operating on live node lists.
+    if (this._docJSDOMParser && nodeList._isLiveNodeList) {
+      throw new Error("Do not pass live node lists to _removeNodes");
+    }
+    for (var i = nodeList.length - 1; i >= 0; i--) {
+      var node = nodeList[i];
+      var parentNode = node.parentNode;
+      if (parentNode) {
+        if (!filterFn || filterFn.call(this, node, i, nodeList)) {
+          parentNode.removeChild(node);
+        }
+      }
+    }
+  },
+
+  /**
+   * Iterates over a NodeList, and calls _setNodeTag for each node.
+   *
+   * @param NodeList nodeList The nodes to operate on
+   * @param String newTagName the new tag name to use
+   * @return void
+   */
+  _replaceNodeTags(nodeList, newTagName) {
+    // Avoid ever operating on live node lists.
+    if (this._docJSDOMParser && nodeList._isLiveNodeList) {
+      throw new Error("Do not pass live node lists to _replaceNodeTags");
+    }
+    for (const node of nodeList) {
+      this._setNodeTag(node, newTagName);
+    }
+  },
+
+  /**
+   * Iterate over a NodeList, which doesn't natively fully implement the Array
+   * interface.
+   *
+   * For convenience, the current object context is applied to the provided
+   * iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return void
+   */
+  _forEachNode(nodeList, fn) {
+    Array.prototype.forEach.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, and return the first node that passes
+   * the supplied test function
+   *
+   * For convenience, the current object context is applied to the provided
+   * test function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The test function.
+   * @return void
+   */
+  _findNode(nodeList, fn) {
+    return Array.prototype.find.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, return true if any of the provided iterate
+   * function calls returns true, false otherwise.
+   *
+   * For convenience, the current object context is applied to the
+   * provided iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return Boolean
+   */
+  _someNode(nodeList, fn) {
+    return Array.prototype.some.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, return true if all of the provided iterate
+   * function calls return true, false otherwise.
+   *
+   * For convenience, the current object context is applied to the
+   * provided iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return Boolean
+   */
+  _everyNode(nodeList, fn) {
+    return Array.prototype.every.call(nodeList, fn, this);
+  },
+
+  _getAllNodesWithTag(node, tagNames) {
+    if (node.querySelectorAll) {
+      return node.querySelectorAll(tagNames.join(","));
+    }
+    return [].concat.apply(
+      [],
+      tagNames.map(function (tag) {
+        var collection = node.getElementsByTagName(tag);
+        return Array.isArray(collection) ? collection : Array.from(collection);
+      }),
+    );
+  },
+
+  /**
+   * Removes the class="" attribute from every element in the given
+   * subtree, except those that match CLASSES_TO_PRESERVE and
+   * the classesToPreserve array from the options object.
+   *
+   * @param Element
+   * @return void
+   */
+  _cleanClasses(node) {
+    var classesToPreserve = this._classesToPreserve;
+    var className = (node.getAttribute("class") || "")
+      .split(/\s+/)
+      .filter((cls) => classesToPreserve.includes(cls))
+      .join(" ");
+
+    if (className) {
+      node.setAttribute("class", className);
+    } else {
+      node.removeAttribute("class");
+    }
+
+    for (node = node.firstElementChild; node; node = node.nextElementSibling) {
+      this._cleanClasses(node);
+    }
+  },
+
+  /**
+   * Tests whether a string is a URL or not.
+   *
+   * @param {string} str The string to test
+   * @return {boolean} true if str is a URL, false if not
+   */
+  _isUrl(str) {
+    try {
+      new URL(str);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  /**
+   * Converts each <a> and <img> uri in the given element to an absolute URI,
+   * ignoring #ref URIs.
+   *
+   * @param Element
+   * @return void
+   */
+  _fixRelativeUris(articleContent) {
+    var baseURI = this._doc.baseURI;
+    var documentURI = this._doc.documentURI;
+    function toAbsoluteURI(uri) {
+      // Leave hash links alone if the base URI matches the document URI:
+      if (baseURI == documentURI && uri.charAt(0) == "#") {
+        return uri;
+      }
+
+      // Otherwise, resolve against base URI:
+      try {
+        return new URL(uri, baseURI).href;
+      } catch (ex) {
+        // Something went wrong, just return the original:
+      }
+      return uri;
+    }
+
+    var links = this._getAllNodesWithTag(articleContent, ["a"]);
+    this._forEachNode(links, function (link) {
+      var href = link.getAttribute("href");
+      if (href) {
+        // Remove links with javascript: URIs, since
+        // they won't work after scripts have been removed from the page.
+        if (href.indexOf("javascript:") === 0) {
+          // if the link only contains simple text content, it can be converted to a text node
+          if (
+            link.childNodes.length === 1 &&
+            link.childNodes[0].nodeType === this.TEXT_NODE
+          ) {
+            var text = this._doc.createTextNode(link.textContent);
+            link.parentNode.replaceChild(text, link);
+          } else {
+            // if the link has multiple children, they should all be preserved
+            var container = this._doc.createElement("span");
+            while (link.firstChild) {
+              container.appendChild(link.firstChild);
+            }
+            link.parentNode.replaceChild(container, link);
+          }
+        } else {
+          link.setAttribute("href", toAbsoluteURI(href));
+        }
+      }
+    });
+
+    var medias = this._getAllNodesWithTag(articleContent, [
+      "img",
+      "picture",
+      "figure",
+      "video",
+      "audio",
+      "source",
+    ]);
+
+    this._forEachNode(medias, function (media) {
+      var src = media.getAttribute("src");
+      var poster = media.getAttribute("poster");
+      var srcset = media.getAttribute("srcset");
+
+      if (src) {
+        media.setAttribute("src", toAbsoluteURI(src));
+      }
+
+      if (poster) {
+        media.setAttribute("poster", toAbsoluteURI(poster));
+      }
+
+      if (srcset) {
+        var newSrcset = srcset.replace(
+          this.REGEXPS.srcsetUrl,
+          function (_, p1, p2, p3) {
+            return toAbsoluteURI(p1) + (p2 || "") + p3;
+          },
+        );
+
+        media.setAttribute("srcset", newSrcset);
+      }
+    });
+  },
+
+  _simplifyNestedElements(articleContent) {
+    var node = articleContent;
+
+    while (node) {
+      if (
+        node.parentNode &&
+        ["DIV", "SECTION"].includes(node.tagName) &&
+        !(node.id && node.id.startsWith("readability"))
+      ) {
+        if (this._isElementWithoutContent(node)) {
+          node = this._removeAndGetNext(node);
+          continue;
+        } else if (
+          this._hasSingleTagInsideElement(node, "DIV") ||
+          this._hasSingleTagInsideElement(node, "SECTION")
+        ) {
+          var child = node.children[0];
+          for (var i = 0; i < node.attributes.length; i++) {
+            child.setAttributeNode(node.attributes[i].cloneNode());
+          }
+          node.parentNode.replaceChild(child, node);
+          node = child;
+          continue;
+        }
+      }
+
+      node = this._getNextNode(node);
+    }
+  },
+
+  /**
+   * Get the article title as an H1.
+   *
+   * @return string
+   **/
+  _getArticleTitle() {
+    var doc = this._doc;
+    var curTitle = "";
+    var origTitle = "";
+
+    try {
+      curTitle = origTitle = doc.title.trim();
+
+      // If they had an element with id "title" in their HTML
+      if (typeof curTitle !== "string") {
+        curTitle = origTitle = this._getInnerText(
+          doc.getElementsByTagName("title")[0],
+        );
+      }
+    } catch (e) {
+      /* ignore exceptions setting the title. */
+    }
+
+    var titleHadHierarchicalSeparators = false;
+    function wordCount(str) {
+      return str.split(/\s+/).length;
+    }
+
+    // If there's a separator in the title, first remove the final part
+    const titleSeparators = /\|\-–—\\\/>»/.source;
+    if (new RegExp(`\\s[${titleSeparators}]\\s`).test(curTitle)) {
+      titleHadHierarchicalSeparators = /\s[\\\/>»]\s/.test(curTitle);
+      let allSeparators = Array.from(
+        origTitle.matchAll(new RegExp(`\\s[${titleSeparators}]\\s`, "gi")),
+      );
+      curTitle = origTitle.substring(0, allSeparators.pop().index);
+
+      // If the resulting title is too short, remove the first part instead:
+      if (wordCount(curTitle) < 3) {
+        curTitle = origTitle.replace(
+          new RegExp(`^[^${titleSeparators}]*[${titleSeparators}]`, "gi"),
+          "",
+        );
+      }
+    } else if (curTitle.includes(": ")) {
+      // Check if we have an heading containing this exact string, so we
+      // could assume it's the full title.
+      var headings = this._getAllNodesWithTag(doc, ["h1", "h2"]);
+      var trimmedTitle = curTitle.trim();
+      var match = this._someNode(headings, function (heading) {
+        return heading.textContent.trim() === trimmedTitle;
+      });
+
+      // If we don't, let's extract the title out of the original title string.
+      if (!match) {
+        curTitle = origTitle.substring(origTitle.lastIndexOf(":") + 1);
+
+        // If the title is now too short, try the first colon instead:
+        if (wordCount(curTitle) < 3) {
+          curTitle = origTitle.substring(origTitle.indexOf(":") + 1);
+          // But if we have too many words before the colon there's something weird
+          // with the titles and the H tags so let's just use the original title instead
+        } else if (wordCount(origTitle.substr(0, origTitle.indexOf(":"))) > 5) {
+          curTitle = origTitle;
+        }
+      }
+    } else if (curTitle.length > 150 || curTitle.length < 15) {
+      var hOnes = doc.getElementsByTagName("h1");
+
+      if (hOnes.length === 1) {
+        curTitle = this._getInnerText(hOnes[0]);
+      }
+    }
+
+    curTitle = curTitle.trim().replace(this.REGEXPS.normalize, " ");
+    // If we now have 4 words or fewer as our title, and either no
+    // 'hierarchical' separators (\, /, > or ») were found in the original
+    // title or we decreased the number of words by more than 1 word, use
+    // the original title.
+    var curTitleWordCount = wordCount(curTitle);
+    if (
+      curTitleWordCount <= 4 &&
+      (!titleHadHierarchicalSeparators ||
+        curTitleWordCount !=
+          wordCount(
+            origTitle.replace(
+              new RegExp(`\\s[${titleSeparators}]\\s`, "g"),
+              "",
+            ),
+          ) -
+            1)
+    ) {
+      curTitle = origTitle;
+    }
+
+    return curTitle;
+  },
+
+  /**
+   * Prepare the HTML document for readability to scrape it.
+   * This includes things like stripping javascript, CSS, and handling terrible markup.
+   *
+   * @return void
+   **/
+  _prepDocument() {
+    var doc = this._doc;
+
+    // Remove all style tags in head
+    this._removeNodes(this._getAllNodesWithTag(doc, ["style"]));
+
+    if (doc.body) {
+      this._replaceBrs(doc.body);
+    }
+
+    this._replaceNodeTags(this._getAllNodesWithTag(doc, ["font"]), "SPAN");
+  },
+
+  /**
+   * Finds the next node, starting from the given node, and ignoring
+   * whitespace in between. If the given node is an element, the same node is
+   * returned.
+   */
+  _nextNode(node) {
+    var next = node;
+    while (
+      next &&
+      next.nodeType != this.ELEMENT_NODE &&
+      this.REGEXPS.whitespace.test(next.textContent)
+    ) {
+      next = next.nextSibling;
+    }
+    return next;
+  },
+
+  /**
+   * Replaces 2 or more successive <br> elements with a single <p>.
+   * Whitespace between <br> elements are ignored. For example:
+   *   <div>foo<br>bar<br> <br><br>abc</div>
+   * will become:
+   *   <div>foo<br>bar<p>abc</p></div>
+   */
+  _replaceBrs(elem) {
+    this._forEachNode(this._getAllNodesWithTag(elem, ["br"]), function (br) {
+      var next = br.nextSibling;
+
+      // Whether 2 or more <br> elements have been found and replaced with a
+      // <p> block.
+      var replaced = false;
+
+      // If we find a <br> chain, remove the <br>s until we hit another node
+      // or non-whitespace. This leaves behind the first <br> in the chain
+      // (which will be replaced with a <p> later).
+      while ((next = this._nextNode(next)) && next.tagName == "BR") {
+        replaced = true;
+        var brSibling = next.nextSibling;
+        next.remove();
+        next = brSibling;
+      }
+
+      // If we removed a <br> chain, replace the remaining <br> with a <p>. Add
+      // all sibling nodes as children of the <p> until we hit another <br>
+      // chain.
+      if (replaced) {
+        var p = this._doc.createElement("p");
+        br.parentNode.replaceChild(p, br);
+
+        next = p.nextSibling;
+        while (next) {
+          // If we've hit another <br><br>, we're done adding children to this <p>.
+          if (next.tagName == "BR") {
+            var nextElem = this._nextNode(next.nextSibling);
+            if (nextElem && nextElem.tagName == "BR") {
+              break;
+            }
+          }
+
+          if (!this._isPhrasingContent(next)) {
+            break;
+          }
+
+          // Otherwise, make this node a child of the new <p>.
+          var sibling = next.nextSibling;
+          p.appendChild(next);
+          next = sibling;
+        }
+
+        while (p.lastChild && this._isWhitespace(p.lastChild)) {
+          p.lastChild.remove();
+        }
+
+        if (p.parentNode.tagName === "P") {
+          this._setNodeTag(p.parentNode, "DIV");
+        }
+      }
+    });
+  },
+
+  _setNodeTag(node, tag) {
+    this.log("_setNodeTag", node, tag);
+    if (this._docJSDOMParser) {
+      node.localName = tag.toLowerCase();
+      node.tagName = tag.toUpperCase();
+      return node;
+    }
+
+    var replacement = node.ownerDocument.createElement(tag);
+    while (node.firstChild) {
+      replacement.appendChild(node.firstChild);
+    }
+    node.parentNode.replaceChild(replacement, node);
+    if (node.readability) {
+      replacement.readability = node.readability;
+    }
+
+    for (var i = 0; i < node.attributes.length; i++) {
+      replacement.setAttributeNode(node.attributes[i].cloneNode());
+    }
+    return replacement;
+  },
+
+  /**
+   * Prepare the article node for display. Clean out any inline styles,
+   * iframes, forms, strip extraneous <p> tags, etc.
+   *
+   * @param Element
+   * @return void
+   **/
+  _prepArticle(articleContent) {
+    this._cleanStyles(articleContent);
+
+    // Check for data tables before we continue, to avoid removing items in
+    // those tables, which will often be isolated even though they're
+    // visually linked to other content-ful elements (text, images, etc.).
+    this._markDataTables(articleContent);
+
+    this._fixLazyImages(articleContent);
+
+    // Clean out junk from the article content
+    this._cleanConditionally(articleContent, "form");
+    this._cleanConditionally(articleContent, "fieldset");
+    this._clean(articleContent, "object");
+    this._clean(articleContent, "embed");
+    this._clean(articleContent, "footer");
+    this._clean(articleContent, "link");
+    this._clean(articleContent, "aside");
+
+    // Clean out elements with little content that have "share" in their id/class combinations from final top candidates,
+    // which means we don't remove the top candidates even they have "share".
+
+    var shareElementThreshold = this.DEFAULT_CHAR_THRESHOLD;
+
+    this._forEachNode(articleContent.children, function (topCandidate) {
+      this._cleanMatchedNodes(topCandidate, function (node, matchString) {
+        return (
+          this.REGEXPS.shareElements.test(matchString) &&
+          node.textContent.length < shareElementThreshold
+        );
+      });
+    });
+
+    this._clean(articleContent, "iframe");
+    this._clean(articleContent, "input");
+    this._clean(articleContent, "textarea");
+    this._clean(articleContent, "select");
+    this._clean(articleContent, "button");
+    this._cleanHeaders(articleContent);
+
+    // Do these last as the previous stuff may have removed junk
+    // that will affect these
+    this._cleanConditionally(articleContent, "table");
+    this._cleanConditionally(articleContent, "ul");
+    this._cleanConditionally(articleContent, "div");
+
+    // replace H1 with H2 as H1 should be only title that is displayed separately
+    this._replaceNodeTags(
+      this._getAllNodesWithTag(articleContent, ["h1"]),
+      "h2",
+    );
+
+    // Remove extra paragraphs
+    this._removeNodes(
+      this._getAllNodesWithTag(articleContent, ["p"]),
+      function (paragraph) {
+        // At this point, nasty iframes have been removed; only embedded video
+        // ones remain.
+        var contentElementCount = this._getAllNodesWithTag(paragraph, [
+          "img",
+          "embed",
+          "object",
+          "iframe",
+        ]).length;
+        return (
+          contentElementCount === 0 && !this._getInnerText(paragraph, false)
+        );
+      },
+    );
+
+    this._forEachNode(
+      this._getAllNodesWithTag(articleContent, ["br"]),
+      function (br) {
+        var next = this._nextNode(br.nextSibling);
+        if (next && next.tagName == "P") {
+          br.remove();
+        }
+      },
+    );
+
+    // Remove single-cell tables
+    this._forEachNode(
+      this._getAllNodesWithTag(articleContent, ["table"]),
+      function (table) {
+        var tbody = this._hasSingleTagInsideElement(table, "TBODY")
+          ? table.firstElementChild
+          : table;
+        if (this._hasSingleTagInsideElement(tbody, "TR")) {
+          var row = tbody.firstElementChild;
+          if (this._hasSingleTagInsideElement(row, "TD")) {
+            var cell = row.firstElementChild;
+            cell = this._setNodeTag(
+              cell,
+              this._everyNode(cell.childNodes, this._isPhrasingContent)
+                ? "P"
+                : "DIV",
+            );
+            table.parentNode.replaceChild(cell, table);
+          }
+        }
+      },
+    );
+  },
+
+  /**
+   * Initialize a node with the readability object. Also checks the
+   * className/id for special names to add to its score.
+   *
+   * @param Element
+   * @return void
+   **/
+  _initializeNode(node) {
+    node.readability = { contentScore: 0 };
+
+    switch (node.tagName) {
+      case "DIV":
+        node.readability.contentScore += 5;
+        break;
+
+      case "PRE":
+      case "TD":
+      case "BLOCKQUOTE":
+        node.readability.contentScore += 3;
+        break;
+
+      case "ADDRESS":
+      case "OL":
+      case "UL":
+      case "DL":
+      case "DD":
+      case "DT":
+      case "LI":
+      case "FORM":
+        node.readability.contentScore -= 3;
+        break;
+
+      case "H1":
+      case "H2":
+      case "H3":
+      case "H4":
+      case "H5":
+      case "H6":
+      case "TH":
+        node.readability.contentScore -= 5;
+        break;
+    }
+
+    node.readability.contentScore += this._getClassWeight(node);
+  },
+
+  _removeAndGetNext(node) {
+    var nextNode = this._getNextNode(node, true);
+    node.remove();
+    return nextNode;
+  },
+
+  /**
+   * Traverse the DOM from node to node, starting at the node passed in.
+   * Pass true for the second parameter to indicate this node itself
+   * (and its kids) are going away, and we want the next node over.
+   *
+   * Calling this in a loop will traverse the DOM depth-first.
+   *
+   * @param {Element} node
+   * @param {boolean} ignoreSelfAndKids
+   * @return {Element}
+   */
+  _getNextNode(node, ignoreSelfAndKids) {
+    // First check for kids if those aren't being ignored
+    if (!ignoreSelfAndKids && node.firstElementChild) {
+      return node.firstElementChild;
+    }
+    // Then for siblings...
+    if (node.nextElementSibling) {
+      return node.nextElementSibling;
+    }
+    // And finally, move up the parent chain *and* find a sibling
+    // (because this is depth-first traversal, we will have already
+    // seen the parent nodes themselves).
+    do {
+      node = node.parentNode;
+    } while (node && !node.nextElementSibling);
+    return node && node.nextElementSibling;
+  },
+
+  // compares second text to first one
+  // 1 = same text, 0 = completely different text
+  // works the way that it splits both texts into words and then finds words that are unique in second text
+  // the result is given by the lower length of unique parts
+  _textSimilarity(textA, textB) {
+    var tokensA = textA
+      .toLowerCase()
+      .split(this.REGEXPS.tokenize)
+      .filter(Boolean);
+    var tokensB = textB
+      .toLowerCase()
+      .split(this.REGEXPS.tokenize)
+      .filter(Boolean);
+    if (!tokensA.length || !tokensB.length) {
+      return 0;
+    }
+    var uniqTokensB = tokensB.filter((token) => !tokensA.includes(token));
+    var distanceB = uniqTokensB.join(" ").length / tokensB.join(" ").length;
+    return 1 - distanceB;
+  },
+
+  /**
+   * Checks whether an element node contains a valid byline
+   *
+   * @param node {Element}
+   * @param matchString {string}
+   * @return boolean
+   */
+  _isValidByline(node, matchString) {
+    var rel = node.getAttribute("rel");
+    var itemprop = node.getAttribute("itemprop");
+    var bylineLength = node.textContent.trim().length;
+
+    return (
+      (rel === "author" ||
+        (itemprop && itemprop.includes("author")) ||
+        this.REGEXPS.byline.test(matchString)) &&
+      !!bylineLength &&
+      bylineLength < 100
+    );
+  },
+
+  _getNodeAncestors(node, maxDepth) {
+    maxDepth = maxDepth || 0;
+    var i = 0,
+      ancestors = [];
+    while (node.parentNode) {
+      ancestors.push(node.parentNode);
+      if (maxDepth && ++i === maxDepth) {
+        break;
+      }
+      node = node.parentNode;
+    }
+    return ancestors;
+  },
+
+  /***
+   * grabArticle - Using a variety of metrics (content score, classname, element types), find the content that is
+   *         most likely to be the stuff a user wants to read. Then return it wrapped up in a div.
+   *
+   * @param page a document to run upon. Needs to be a full document, complete with body.
+   * @return Element
+   **/
+  /* eslint-disable-next-line complexity */
+  _grabArticle(page) {
+    this.log("**** grabArticle ****");
+    var doc = this._doc;
+    var isPaging = page !== null;
+    page = page ? page : this._doc.body;
+
+    // We can't grab an article if we don't have a page!
+    if (!page) {
+      this.log("No body found in document. Abort.");
+      return null;
+    }
+
+    var pageCacheHtml = page.innerHTML;
+
+    while (true) {
+      this.log("Starting grabArticle loop");
+      var stripUnlikelyCandidates = this._flagIsActive(
+        this.FLAG_STRIP_UNLIKELYS,
+      );
+
+      // First, node prepping. Trash nodes that look cruddy (like ones with the
+      // class name "comment", etc), and turn divs into P tags where they have been
+      // used inappropriately (as in, where they contain no other block level elements.)
+      var elementsToScore = [];
+      var node = this._doc.documentElement;
+
+      let shouldRemoveTitleHeader = true;
+
+      while (node) {
+        if (node.tagName === "HTML") {
+          this._articleLang = node.getAttribute("lang");
+        }
+
+        var matchString = node.className + " " + node.id;
+
+        if (!this._isProbablyVisible(node)) {
+          this.log("Removing hidden node - " + matchString);
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // User is not able to see elements applied with both "aria-modal = true" and "role = dialog"
+        if (
+          node.getAttribute("aria-modal") == "true" &&
+          node.getAttribute("role") == "dialog"
+        ) {
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // If we don't have a byline yet check to see if this node is a byline; if it is store the byline and remove the node.
+        if (
+          !this._articleByline &&
+          !this._metadata.byline &&
+          this._isValidByline(node, matchString)
+        ) {
+          // Find child node matching [itemprop="name"] and use that if it exists for a more accurate author name byline
+          var endOfSearchMarkerNode = this._getNextNode(node, true);
+          var next = this._getNextNode(node);
+          var itemPropNameNode = null;
+          while (next && next != endOfSearchMarkerNode) {
+            var itemprop = next.getAttribute("itemprop");
+            if (itemprop && itemprop.includes("name")) {
+              itemPropNameNode = next;
+              break;
+            } else {
+              next = this._getNextNode(next);
+            }
+          }
+          this._articleByline = (itemPropNameNode ?? node).textContent.trim();
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        if (shouldRemoveTitleHeader && this._headerDuplicatesTitle(node)) {
+          this.log(
+            "Removing header: ",
+            node.textContent.trim(),
+            this._articleTitle.trim(),
+          );
+          shouldRemoveTitleHeader = false;
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // Remove unlikely candidates
+        if (stripUnlikelyCandidates) {
+          if (
+            this.REGEXPS.unlikelyCandidates.test(matchString) &&
+            !this.REGEXPS.okMaybeItsACandidate.test(matchString) &&
+            !this._hasAncestorTag(node, "table") &&
+            !this._hasAncestorTag(node, "code") &&
+            node.tagName !== "BODY" &&
+            node.tagName !== "A"
+          ) {
+            this.log("Removing unlikely candidate - " + matchString);
+            node = this._removeAndGetNext(node);
+            continue;
+          }
+
+          if (this.UNLIKELY_ROLES.includes(node.getAttribute("role"))) {
+            this.log(
+              "Removing content with role " +
+                node.getAttribute("role") +
+                " - " +
+                matchString,
+            );
+            node = this._removeAndGetNext(node);
+            continue;
+          }
+        }
+
+        // Remove DIV, SECTION, and HEADER nodes without any content(e.g. text, image, video, or iframe).
+        if (
+          (node.tagName === "DIV" ||
+            node.tagName === "SECTION" ||
+            node.tagName === "HEADER" ||
+            node.tagName === "H1" ||
+            node.tagName === "H2" ||
+            node.tagName === "H3" ||
+            node.tagName === "H4" ||
+            node.tagName === "H5" ||
+            node.tagName === "H6") &&
+          this._isElementWithoutContent(node)
+        ) {
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        if (this.DEFAULT_TAGS_TO_SCORE.includes(node.tagName)) {
+          elementsToScore.push(node);
+        }
+
+        // Turn all divs that don't have children block level elements into p's
+        if (node.tagName === "DIV") {
+          // Put phrasing content into paragraphs.
+          var childNode = node.firstChild;
+          while (childNode) {
+            var nextSibling = childNode.nextSibling;
+            if (this._isPhrasingContent(childNode)) {
+              var fragment = doc.createDocumentFragment();
+              // Collect all consecutive phrasing content into a fragment.
+              do {
+                nextSibling = childNode.nextSibling;
+                fragment.appendChild(childNode);
+                childNode = nextSibling;
+              } while (childNode && this._isPhrasingContent(childNode));
+
+              // Trim leading and trailing whitespace from the fragment.
+              while (
+                fragment.firstChild &&
+                this._isWhitespace(fragment.firstChild)
+              ) {
+                fragment.firstChild.remove();
+              }
+              while (
+                fragment.lastChild &&
+                this._isWhitespace(fragment.lastChild)
+              ) {
+                fragment.lastChild.remove();
+              }
+
+              // If the fragment contains anything, wrap it in a paragraph and
+              // insert it before the next non-phrasing node.
+              if (fragment.firstChild) {
+                var p = doc.createElement("p");
+                p.appendChild(fragment);
+                node.insertBefore(p, nextSibling);
+              }
+            }
+            childNode = nextSibling;
+          }
+
+          // Sites like http://mobile.slate.com encloses each paragraph with a DIV
+          // element. DIVs with only a P element inside and no text content can be
+          // safely converted into plain P elements to avoid confusing the scoring
+          // algorithm with DIVs with are, in practice, paragraphs.
+          if (
+            this._hasSingleTagInsideElement(node, "P") &&
+            this._getLinkDensity(node) < 0.25
+          ) {
+            var newNode = node.children[0];
+            node.parentNode.replaceChild(newNode, node);
+            node = newNode;
+            elementsToScore.push(node);
+          } else if (!this._hasChildBlockElement(node)) {
+            node = this._setNodeTag(node, "P");
+            elementsToScore.push(node);
+          }
+        }
+        node = this._getNextNode(node);
+      }
+
+      /**
+       * Loop through all paragraphs, and assign a score to them based on how content-y they look.
+       * Then add their score to their parent node.
+       *
+       * A score is determined by things like number of commas, class names, etc. Maybe eventually link density.
+       **/
+      var candidates = [];
+      this._forEachNode(elementsToScore, function (elementToScore) {
+        if (
+          !elementToScore.parentNode ||
+          typeof elementToScore.parentNode.tagName === "undefined"
+        ) {
+          return;
+        }
+
+        // If this paragraph is less than 25 characters, don't even count it.
+        var innerText = this._getInnerText(elementToScore);
+        if (innerText.length < 25) {
+          return;
+        }
+
+        // Exclude nodes with no ancestor.
+        var ancestors = this._getNodeAncestors(elementToScore, 5);
+        if (ancestors.length === 0) {
+          return;
+        }
+
+        var contentScore = 0;
+
+        // Add a point for the paragraph itself as a base.
+        contentScore += 1;
+
+        // Add points for any commas within this paragraph.
+        contentScore += innerText.split(this.REGEXPS.commas).length;
+
+        // For every 100 characters in this paragraph, add another point. Up to 3 points.
+        contentScore += Math.min(Math.floor(innerText.length / 100), 3);
+
+        // Initialize and score ancestors.
+        this._forEachNode(ancestors, function (ancestor, level) {
+          if (
+            !ancestor.tagName ||
+            !ancestor.parentNode ||
+            typeof ancestor.parentNode.tagName === "undefined"
+          ) {
+            return;
+          }
+
+          if (typeof ancestor.readability === "undefined") {
+            this._initializeNode(ancestor);
+            candidates.push(ancestor);
+          }
+
+          // Node score divider:
+          // - parent:             1 (no division)
+          // - grandparent:        2
+          // - great grandparent+: ancestor level * 3
+          if (level === 0) {
+            var scoreDivider = 1;
+          } else if (level === 1) {
+            scoreDivider = 2;
+          } else {
+            scoreDivider = level * 3;
+          }
+          ancestor.readability.contentScore += contentScore / scoreDivider;
+        });
+      });
+
+      // After we've calculated scores, loop through all of the possible
+      // candidate nodes we found and find the one with the highest score.
+      var topCandidates = [];
+      for (var c = 0, cl = candidates.length; c < cl; c += 1) {
+        var candidate = candidates[c];
+
+        // Scale the final candidates score based on link density. Good content
+        // should have a relatively small link density (5% or less) and be mostly
+        // unaffected by this operation.
+        var candidateScore =
+          candidate.readability.contentScore *
+          (1 - this._getLinkDensity(candidate));
+        candidate.readability.contentScore = candidateScore;
+
+        this.log("Candidate:", candidate, "with score " + candidateScore);
+
+        for (var t = 0; t < this._nbTopCandidates; t++) {
+          var aTopCandidate = topCandidates[t];
+
+          if (
+            !aTopCandidate ||
+            candidateScore > aTopCandidate.readability.contentScore
+          ) {
+            topCandidates.splice(t, 0, candidate);
+            if (topCandidates.length > this._nbTopCandidates) {
+              topCandidates.pop();
+            }
+            break;
+          }
+        }
+      }
+
+      var topCandidate = topCandidates[0] || null;
+      var neededToCreateTopCandidate = false;
+      var parentOfTopCandidate;
+
+      // If we still have no top candidate, just use the body as a last resort.
+      // We also have to copy the body node so it is something we can modify.
+      if (topCandidate === null || topCandidate.tagName === "BODY") {
+        // Move all of the page's children into topCandidate
+        topCandidate = doc.createElement("DIV");
+        neededToCreateTopCandidate = true;
+        // Move everything (not just elements, also text nodes etc.) into the container
+        // so we even include text directly in the body:
+        while (page.firstChild) {
+          this.log("Moving child out:", page.firstChild);
+          topCandidate.appendChild(page.firstChild);
+        }
+
+        page.appendChild(topCandidate);
+
+        this._initializeNode(topCandidate);
+      } else if (topCandidate) {
+        // Find a better top candidate node if it contains (at least three) nodes which belong to `topCandidates` array
+        // and whose scores are quite closed with current `topCandidate` node.
+        var alternativeCandidateAncestors = [];
+        for (var i = 1; i < topCandidates.length; i++) {
+          if (
+            topCandidates[i].readability.contentScore /
+              topCandidate.readability.contentScore >=
+            0.75
+          ) {
+            alternativeCandidateAncestors.push(
+              this._getNodeAncestors(topCandidates[i]),
+            );
+          }
+        }
+        var MINIMUM_TOPCANDIDATES = 3;
+        if (alternativeCandidateAncestors.length >= MINIMUM_TOPCANDIDATES) {
+          parentOfTopCandidate = topCandidate.parentNode;
+          while (parentOfTopCandidate.tagName !== "BODY") {
+            var listsContainingThisAncestor = 0;
+            for (
+              var ancestorIndex = 0;
+              ancestorIndex < alternativeCandidateAncestors.length &&
+              listsContainingThisAncestor < MINIMUM_TOPCANDIDATES;
+              ancestorIndex++
+            ) {
+              listsContainingThisAncestor += Number(
+                alternativeCandidateAncestors[ancestorIndex].includes(
+                  parentOfTopCandidate,
+                ),
+              );
+            }
+            if (listsContainingThisAncestor >= MINIMUM_TOPCANDIDATES) {
+              topCandidate = parentOfTopCandidate;
+              break;
+            }
+            parentOfTopCandidate = parentOfTopCandidate.parentNode;
+          }
+        }
+        if (!topCandidate.readability) {
+          this._initializeNode(topCandidate);
+        }
+
+        // Because of our bonus system, parents of candidates might have scores
+        // themselves. They get half of the node. There won't be nodes with higher
+        // scores than our topCandidate, but if we see the score going *up* in the first
+        // few steps up the tree, that's a decent sign that there might be more content
+        // lurking in other places that we want to unify in. The sibling stuff
+        // below does some of that - but only if we've looked high enough up the DOM
+        // tree.
+        parentOfTopCandidate = topCandidate.parentNode;
+        var lastScore = topCandidate.readability.contentScore;
+        // The scores shouldn't get too low.
+        var scoreThreshold = lastScore / 3;
+        while (parentOfTopCandidate.tagName !== "BODY") {
+          if (!parentOfTopCandidate.readability) {
+            parentOfTopCandidate = parentOfTopCandidate.parentNode;
+            continue;
+          }
+          var parentScore = parentOfTopCandidate.readability.contentScore;
+          if (parentScore < scoreThreshold) {
+            break;
+          }
+          if (parentScore > lastScore) {
+            // Alright! We found a better parent to use.
+            topCandidate = parentOfTopCandidate;
+            break;
+          }
+          lastScore = parentOfTopCandidate.readability.contentScore;
+          parentOfTopCandidate = parentOfTopCandidate.parentNode;
+        }
+
+        // If the top candidate is the only child, use parent instead. This will help sibling
+        // joining logic when adjacent content is actually located in parent's sibling node.
+        parentOfTopCandidate = topCandidate.parentNode;
+        while (
+          parentOfTopCandidate.tagName != "BODY" &&
+          parentOfTopCandidate.children.length == 1
+        ) {
+          topCandidate = parentOfTopCandidate;
+          parentOfTopCandidate = topCandidate.parentNode;
+        }
+        if (!topCandidate.readability) {
+          this._initializeNode(topCandidate);
+        }
+      }
+
+      // Now that we have the top candidate, look through its siblings for content
+      // that might also be related. Things like preambles, content split by ads
+      // that we removed, etc.
+      var articleContent = doc.createElement("DIV");
+      if (isPaging) {
+        articleContent.id = "readability-content";
+      }
+
+      var siblingScoreThreshold = Math.max(
+        10,
+        topCandidate.readability.contentScore * 0.2,
+      );
+      // Keep potential top candidate's parent node to try to get text direction of it later.
+      parentOfTopCandidate = topCandidate.parentNode;
+      var siblings = parentOfTopCandidate.children;
+
+      for (var s = 0, sl = siblings.length; s < sl; s++) {
+        var sibling = siblings[s];
+        var append = false;
+
+        this.log(
+          "Looking at sibling node:",
+          sibling,
+          sibling.readability
+            ? "with score " + sibling.readability.contentScore
+            : "",
+        );
+        this.log(
+          "Sibling has score",
+          sibling.readability ? sibling.readability.contentScore : "Unknown",
+        );
+
+        if (sibling === topCandidate) {
+          append = true;
+        } else {
+          var contentBonus = 0;
+
+          // Give a bonus if sibling nodes and top candidates have the example same classname
+          if (
+            sibling.className === topCandidate.className &&
+            topCandidate.className !== ""
+          ) {
+            contentBonus += topCandidate.readability.contentScore * 0.2;
+          }
+
+          if (
+            sibling.readability &&
+            sibling.readability.contentScore + contentBonus >=
+              siblingScoreThreshold
+          ) {
+            append = true;
+          } else if (sibling.nodeName === "P") {
+            var linkDensity = this._getLinkDensity(sibling);
+            var nodeContent = this._getInnerText(sibling);
+            var nodeLength = nodeContent.length;
+
+            if (nodeLength > 80 && linkDensity < 0.25) {
+              append = true;
+            } else if (
+              nodeLength < 80 &&
+              nodeLength > 0 &&
+              linkDensity === 0 &&
+              nodeContent.search(/\.( |$)/) !== -1
+            ) {
+              append = true;
+            }
+          }
+        }
+
+        if (append) {
+          this.log("Appending node:", sibling);
+
+          if (!this.ALTER_TO_DIV_EXCEPTIONS.includes(sibling.nodeName)) {
+            // We have a node that isn't a common block level element, like a form or td tag.
+            // Turn it into a div so it doesn't get filtered out later by accident.
+            this.log("Altering sibling:", sibling, "to div.");
+
+            sibling = this._setNodeTag(sibling, "DIV");
+          }
+
+          articleContent.appendChild(sibling);
+          // Fetch children again to make it compatible
+          // with DOM parsers without live collection support.
+          siblings = parentOfTopCandidate.children;
+          // siblings is a reference to the children array, and
+          // sibling is removed from the array when we call appendChild().
+          // As a result, we must revisit this index since the nodes
+          // have been shifted.
+          s -= 1;
+          sl -= 1;
+        }
+      }
+
+      if (this._debug) {
+        this.log("Article content pre-prep: " + articleContent.innerHTML);
+      }
+      // So we have all of the content that we need. Now we clean it up for presentation.
+      this._prepArticle(articleContent);
+      if (this._debug) {
+        this.log("Article content post-prep: " + articleContent.innerHTML);
+      }
+
+      if (neededToCreateTopCandidate) {
+        // We already created a fake div thing, and there wouldn't have been any siblings left
+        // for the previous loop, so there's no point trying to create a new div, and then
+        // move all the children over. Just assign IDs and class names here. No need to append
+        // because that already happened anyway.
+        topCandidate.id = "readability-page-1";
+        topCandidate.className = "page";
+      } else {
+        var div = doc.createElement("DIV");
+        div.id = "readability-page-1";
+        div.className = "page";
+        while (articleContent.firstChild) {
+          div.appendChild(articleContent.firstChild);
+        }
+        articleContent.appendChild(div);
+      }
+
+      if (this._debug) {
+        this.log("Article content after paging: " + articleContent.innerHTML);
+      }
+
+      var parseSuccessful = true;
+
+      // Now that we've gone through the full algorithm, check to see if
+      // we got any meaningful content. If we didn't, we may need to re-run
+      // grabArticle with different flags set. This gives us a higher likelihood of
+      // finding the content, and the sieve approach gives us a higher likelihood of
+      // finding the -right- content.
+      var textLength = this._getInnerText(articleContent, true).length;
+      if (textLength < this._charThreshold) {
+        parseSuccessful = false;
+        // eslint-disable-next-line no-unsanitized/property
+        page.innerHTML = pageCacheHtml;
+
+        this._attempts.push({
+          articleContent,
+          textLength,
+        });
+
+        if (this._flagIsActive(this.FLAG_STRIP_UNLIKELYS)) {
+          this._removeFlag(this.FLAG_STRIP_UNLIKELYS);
+        } else if (this._flagIsActive(this.FLAG_WEIGHT_CLASSES)) {
+          this._removeFlag(this.FLAG_WEIGHT_CLASSES);
+        } else if (this._flagIsActive(this.FLAG_CLEAN_CONDITIONALLY)) {
+          this._removeFlag(this.FLAG_CLEAN_CONDITIONALLY);
+        } else {
+          // No luck after removing flags, just return the longest text we found during the different loops
+          this._attempts.sort(function (a, b) {
+            return b.textLength - a.textLength;
+          });
+
+          // But first check if we actually have something
+          if (!this._attempts[0].textLength) {
+            return null;
+          }
+
+          articleContent = this._attempts[0].articleContent;
+          parseSuccessful = true;
+        }
+      }
+
+      if (parseSuccessful) {
+        // Find out text direction from ancestors of final top candidate.
+        var ancestors = [parentOfTopCandidate, topCandidate].concat(
+          this._getNodeAncestors(parentOfTopCandidate),
+        );
+        this._someNode(ancestors, function (ancestor) {
+          if (!ancestor.tagName) {
+            return false;
+          }
+          var articleDir = ancestor.getAttribute("dir");
+          if (articleDir) {
+            this._articleDir = articleDir;
+            return true;
+          }
+          return false;
+        });
+        return articleContent;
+      }
+    }
+  },
+
+  /**
+   * Converts some of the common HTML entities in string to their corresponding characters.
+   *
+   * @param str {string} - a string to unescape.
+   * @return string without HTML entity.
+   */
+  _unescapeHtmlEntities(str) {
+    if (!str) {
+      return str;
+    }
+
+    var htmlEscapeMap = this.HTML_ESCAPE_MAP;
+    return str
+      .replace(/&(quot|amp|apos|lt|gt);/g, function (_, tag) {
+        return htmlEscapeMap[tag];
+      })
+      .replace(/&#(?:x([0-9a-f]+)|([0-9]+));/gi, function (_, hex, numStr) {
+        var num = parseInt(hex || numStr, hex ? 16 : 10);
+
+        // these character references are replaced by a conforming HTML parser
+        if (num == 0 || num > 0x10ffff || (num >= 0xd800 && num <= 0xdfff)) {
+          num = 0xfffd;
+        }
+
+        return String.fromCodePoint(num);
+      });
+  },
+
+  /**
+   * Try to extract metadata from JSON-LD object.
+   * For now, only Schema.org objects of type Article or its subtypes are supported.
+   * @return Object with any metadata that could be extracted (possibly none)
+   */
+  _getJSONLD(doc) {
+    var scripts = this._getAllNodesWithTag(doc, ["script"]);
+
+    var metadata;
+
+    this._forEachNode(scripts, function (jsonLdElement) {
+      if (
+        !metadata &&
+        jsonLdElement.getAttribute("type") === "application/ld+json"
+      ) {
+        try {
+          // Strip CDATA markers if present
+          var content = jsonLdElement.textContent.replace(
+            /^\s*<!\[CDATA\[|\]\]>\s*$/g,
+            "",
+          );
+          var parsed = JSON.parse(content);
+
+          if (Array.isArray(parsed)) {
+            parsed = parsed.find((it) => {
+              return (
+                it["@type"] &&
+                it["@type"].match(this.REGEXPS.jsonLdArticleTypes)
+              );
+            });
+            if (!parsed) {
+              return;
+            }
+          }
+
+          var schemaDotOrgRegex = /^https?\:\/\/schema\.org\/?$/;
+          var matches =
+            (typeof parsed["@context"] === "string" &&
+              parsed["@context"].match(schemaDotOrgRegex)) ||
+            (typeof parsed["@context"] === "object" &&
+              typeof parsed["@context"]["@vocab"] == "string" &&
+              parsed["@context"]["@vocab"].match(schemaDotOrgRegex));
+
+          if (!matches) {
+            return;
+          }
+
+          if (!parsed["@type"] && Array.isArray(parsed["@graph"])) {
+            parsed = parsed["@graph"].find((it) => {
+              return (it["@type"] || "").match(this.REGEXPS.jsonLdArticleTypes);
+            });
+          }
+
+          if (
+            !parsed ||
+            !parsed["@type"] ||
+            !parsed["@type"].match(this.REGEXPS.jsonLdArticleTypes)
+          ) {
+            return;
+          }
+
+          metadata = {};
+
+          if (
+            typeof parsed.name === "string" &&
+            typeof parsed.headline === "string" &&
+            parsed.name !== parsed.headline
+          ) {
+            // we have both name and headline element in the JSON-LD. They should both be the same but some websites like aktualne.cz
+            // put their own name into "name" and the article title to "headline" which confuses Readability. So we try to check if either
+            // "name" or "headline" closely matches the html title, and if so, use that one. If not, then we use "name" by default.
+
+            var title = this._getArticleTitle();
+            var nameMatches = this._textSimilarity(parsed.name, title) > 0.75;
+            var headlineMatches =
+              this._textSimilarity(parsed.headline, title) > 0.75;
+
+            if (headlineMatches && !nameMatches) {
+              metadata.title = parsed.headline;
+            } else {
+              metadata.title = parsed.name;
+            }
+          } else if (typeof parsed.name === "string") {
+            metadata.title = parsed.name.trim();
+          } else if (typeof parsed.headline === "string") {
+            metadata.title = parsed.headline.trim();
+          }
+          if (parsed.author) {
+            if (typeof parsed.author.name === "string") {
+              metadata.byline = parsed.author.name.trim();
+            } else if (
+              Array.isArray(parsed.author) &&
+              parsed.author[0] &&
+              typeof parsed.author[0].name === "string"
+            ) {
+              metadata.byline = parsed.author
+                .filter(function (author) {
+                  return author && typeof author.name === "string";
+                })
+                .map(function (author) {
+                  return author.name.trim();
+                })
+                .join(", ");
+            }
+          }
+          if (typeof parsed.description === "string") {
+            metadata.excerpt = parsed.description.trim();
+          }
+          if (parsed.publisher && typeof parsed.publisher.name === "string") {
+            metadata.siteName = parsed.publisher.name.trim();
+          }
+          if (typeof parsed.datePublished === "string") {
+            metadata.datePublished = parsed.datePublished.trim();
+          }
+        } catch (err) {
+          this.log(err.message);
+        }
+      }
+    });
+    return metadata ? metadata : {};
+  },
+
+  /**
+   * Attempts to get excerpt and byline metadata for the article.
+   *
+   * @param {Object} jsonld — object containing any metadata that
+   * could be extracted from JSON-LD object.
+   *
+   * @return Object with optional "excerpt" and "byline" properties
+   */
+  _getArticleMetadata(jsonld) {
+    var metadata = {};
+    var values = {};
+    var metaElements = this._doc.getElementsByTagName("meta");
+
+    // property is a space-separated list of values
+    var propertyPattern =
+      /\s*(article|dc|dcterm|og|twitter)\s*:\s*(author|creator|description|published_time|title|site_name)\s*/gi;
+
+    // name is a single value
+    var namePattern =
+      /^\s*(?:(dc|dcterm|og|twitter|parsely|weibo:(article|webpage))\s*[-\.:]\s*)?(author|creator|pub-date|description|title|site_name)\s*$/i;
+
+    // Find description tags.
+    this._forEachNode(metaElements, function (element) {
+      var elementName = element.getAttribute("name");
+      var elementProperty = element.getAttribute("property");
+      var content = element.getAttribute("content");
+      if (!content) {
+        return;
+      }
+      var matches = null;
+      var name = null;
+
+      if (elementProperty) {
+        matches = elementProperty.match(propertyPattern);
+        if (matches) {
+          // Convert to lowercase, and remove any whitespace
+          // so we can match below.
+          name = matches[0].toLowerCase().replace(/\s/g, "");
+          // multiple authors
+          values[name] = content.trim();
+        }
+      }
+      if (!matches && elementName && namePattern.test(elementName)) {
+        name = elementName;
+        if (content) {
+          // Convert to lowercase, remove any whitespace, and convert dots
+          // to colons so we can match below.
+          name = name.toLowerCase().replace(/\s/g, "").replace(/\./g, ":");
+          values[name] = content.trim();
+        }
+      }
+    });
+
+    // get title
+    metadata.title =
+      jsonld.title ||
+      values["dc:title"] ||
+      values["dcterm:title"] ||
+      values["og:title"] ||
+      values["weibo:article:title"] ||
+      values["weibo:webpage:title"] ||
+      values.title ||
+      values["twitter:title"] ||
+      values["parsely-title"];
+
+    if (!metadata.title) {
+      metadata.title = this._getArticleTitle();
+    }
+
+    const articleAuthor =
+      typeof values["article:author"] === "string" &&
+      !this._isUrl(values["article:author"])
+        ? values["article:author"]
+        : undefined;
+
+    // get author
+    metadata.byline =
+      jsonld.byline ||
+      values["dc:creator"] ||
+      values["dcterm:creator"] ||
+      values.author ||
+      values["parsely-author"] ||
+      articleAuthor;
+
+    // get description
+    metadata.excerpt =
+      jsonld.excerpt ||
+      values["dc:description"] ||
+      values["dcterm:description"] ||
+      values["og:description"] ||
+      values["weibo:article:description"] ||
+      values["weibo:webpage:description"] ||
+      values.description ||
+      values["twitter:description"];
+
+    // get site name
+    metadata.siteName = jsonld.siteName || values["og:site_name"];
+
+    // get article published time
+    metadata.publishedTime =
+      jsonld.datePublished ||
+      values["article:published_time"] ||
+      values["parsely-pub-date"] ||
+      null;
+
+    // in many sites the meta value is escaped with HTML entities,
+    // so here we need to unescape it
+    metadata.title = this._unescapeHtmlEntities(metadata.title);
+    metadata.byline = this._unescapeHtmlEntities(metadata.byline);
+    metadata.excerpt = this._unescapeHtmlEntities(metadata.excerpt);
+    metadata.siteName = this._unescapeHtmlEntities(metadata.siteName);
+    metadata.publishedTime = this._unescapeHtmlEntities(metadata.publishedTime);
+
+    return metadata;
+  },
+
+  /**
+   * Check if node is image, or if node contains exactly only one image
+   * whether as a direct child or as its descendants.
+   *
+   * @param Element
+   **/
+  _isSingleImage(node) {
+    while (node) {
+      if (node.tagName === "IMG") {
+        return true;
+      }
+      if (node.children.length !== 1 || node.textContent.trim() !== "") {
+        return false;
+      }
+      node = node.children[0];
+    }
+    return false;
+  },
+
+  /**
+   * Find all <noscript> that are located after <img> nodes, and which contain only one
+   * <img> element. Replace the first image with the image from inside the <noscript> tag,
+   * and remove the <noscript> tag. This improves the quality of the images we use on
+   * some sites (e.g. Medium).
+   *
+   * @param Element
+   **/
+  _unwrapNoscriptImages(doc) {
+    // Find img without source or attributes that might contains image, and remove it.
+    // This is done to prevent a placeholder img is replaced by img from noscript in next step.
+    var imgs = Array.from(doc.getElementsByTagName("img"));
+    this._forEachNode(imgs, function (img) {
+      for (var i = 0; i < img.attributes.length; i++) {
+        var attr = img.attributes[i];
+        switch (attr.name) {
+          case "src":
+          case "srcset":
+          case "data-src":
+          case "data-srcset":
+            return;
+        }
+
+        if (/\.(jpg|jpeg|png|webp)/i.test(attr.value)) {
+          return;
+        }
+      }
+
+      img.remove();
+    });
+
+    // Next find noscript and try to extract its image
+    var noscripts = Array.from(doc.getElementsByTagName("noscript"));
+    this._forEachNode(noscripts, function (noscript) {
+      // Parse content of noscript and make sure it only contains image
+      if (!this._isSingleImage(noscript)) {
+        return;
+      }
+      var tmp = doc.createElement("div");
+      // We're running in the document context, and using unmodified
+      // document contents, so doing this should be safe.
+      // (Also we heavily discourage people from allowing script to
+      // run at all in this document...)
+      // eslint-disable-next-line no-unsanitized/property
+      tmp.innerHTML = noscript.innerHTML;
+
+      // If noscript has previous sibling and it only contains image,
+      // replace it with noscript content. However we also keep old
+      // attributes that might contains image.
+      var prevElement = noscript.previousElementSibling;
+      if (prevElement && this._isSingleImage(prevElement)) {
+        var prevImg = prevElement;
+        if (prevImg.tagName !== "IMG") {
+          prevImg = prevElement.getElementsByTagName("img")[0];
+        }
+
+        var newImg = tmp.getElementsByTagName("img")[0];
+        for (var i = 0; i < prevImg.attributes.length; i++) {
+          var attr = prevImg.attributes[i];
+          if (attr.value === "") {
+            continue;
+          }
+
+          if (
+            attr.name === "src" ||
+            attr.name === "srcset" ||
+            /\.(jpg|jpeg|png|webp)/i.test(attr.value)
+          ) {
+            if (newImg.getAttribute(attr.name) === attr.value) {
+              continue;
+            }
+
+            var attrName = attr.name;
+            if (newImg.hasAttribute(attrName)) {
+              attrName = "data-old-" + attrName;
+            }
+
+            newImg.setAttribute(attrName, attr.value);
+          }
+        }
+
+        noscript.parentNode.replaceChild(tmp.firstElementChild, prevElement);
+      }
+    });
+  },
+
+  /**
+   * Removes script tags from the document.
+   *
+   * @param Element
+   **/
+  _removeScripts(doc) {
+    this._removeNodes(this._getAllNodesWithTag(doc, ["script", "noscript"]));
+  },
+
+  /**
+   * Check if this node has only whitespace and a single element with given tag
+   * Returns false if the DIV node contains non-empty text nodes
+   * or if it contains no element with given tag or more than 1 element.
+   *
+   * @param Element
+   * @param string tag of child element
+   **/
+  _hasSingleTagInsideElement(element, tag) {
+    // There should be exactly 1 element child with given tag
+    if (element.children.length != 1 || element.children[0].tagName !== tag) {
+      return false;
+    }
+
+    // And there should be no text nodes with real content
+    return !this._someNode(element.childNodes, function (node) {
+      return (
+        node.nodeType === this.TEXT_NODE &&
+        this.REGEXPS.hasContent.test(node.textContent)
+      );
+    });
+  },
+
+  _isElementWithoutContent(node) {
+    return (
+      node.nodeType === this.ELEMENT_NODE &&
+      !node.textContent.trim().length &&
+      (!node.children.length ||
+        node.children.length ==
+          node.getElementsByTagName("br").length +
+            node.getElementsByTagName("hr").length)
+    );
+  },
+
+  /**
+   * Determine whether element has any children block level elements.
+   *
+   * @param Element
+   */
+  _hasChildBlockElement(element) {
+    return this._someNode(element.childNodes, function (node) {
+      return (
+        this.DIV_TO_P_ELEMS.has(node.tagName) ||
+        this._hasChildBlockElement(node)
+      );
+    });
+  },
+
+  /***
+   * Determine if a node qualifies as phrasing content.
+   * https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content
+   **/
+  _isPhrasingContent(node) {
+    return (
+      node.nodeType === this.TEXT_NODE ||
+      this.PHRASING_ELEMS.includes(node.tagName) ||
+      ((node.tagName === "A" ||
+        node.tagName === "DEL" ||
+        node.tagName === "INS") &&
+        this._everyNode(node.childNodes, this._isPhrasingContent))
+    );
+  },
+
+  _isWhitespace(node) {
+    return (
+      (node.nodeType === this.TEXT_NODE &&
+        node.textContent.trim().length === 0) ||
+      (node.nodeType === this.ELEMENT_NODE && node.tagName === "BR")
+    );
+  },
+
+  /**
+   * Get the inner text of a node - cross browser compatibly.
+   * This also strips out any excess whitespace to be found.
+   *
+   * @param Element
+   * @param Boolean normalizeSpaces (default: true)
+   * @return string
+   **/
+  _getInnerText(e, normalizeSpaces) {
+    normalizeSpaces =
+      typeof normalizeSpaces === "undefined" ? true : normalizeSpaces;
+    var textContent = e.textContent.trim();
+
+    if (normalizeSpaces) {
+      return textContent.replace(this.REGEXPS.normalize, " ");
+    }
+    return textContent;
+  },
+
+  /**
+   * Get the number of times a string s appears in the node e.
+   *
+   * @param Element
+   * @param string - what to split on. Default is ","
+   * @return number (integer)
+   **/
+  _getCharCount(e, s) {
+    s = s || ",";
+    return this._getInnerText(e).split(s).length - 1;
+  },
+
+  /**
+   * Remove the style attribute on every e and under.
+   * TODO: Test if getElementsByTagName(*) is faster.
+   *
+   * @param Element
+   * @return void
+   **/
+  _cleanStyles(e) {
+    if (!e || e.tagName.toLowerCase() === "svg") {
+      return;
+    }
+
+    // Remove `style` and deprecated presentational attributes
+    for (var i = 0; i < this.PRESENTATIONAL_ATTRIBUTES.length; i++) {
+      e.removeAttribute(this.PRESENTATIONAL_ATTRIBUTES[i]);
+    }
+
+    if (this.DEPRECATED_SIZE_ATTRIBUTE_ELEMS.includes(e.tagName)) {
+      e.removeAttribute("width");
+      e.removeAttribute("height");
+    }
+
+    var cur = e.firstElementChild;
+    while (cur !== null) {
+      this._cleanStyles(cur);
+      cur = cur.nextElementSibling;
+    }
+  },
+
+  /**
+   * Get the density of links as a percentage of the content
+   * This is the amount of text that is inside a link divided by the total text in the node.
+   *
+   * @param Element
+   * @return number (float)
+   **/
+  _getLinkDensity(element) {
+    var textLength = this._getInnerText(element).length;
+    if (textLength === 0) {
+      return 0;
+    }
+
+    var linkLength = 0;
+
+    // XXX implement _reduceNodeList?
+    this._forEachNode(element.getElementsByTagName("a"), function (linkNode) {
+      var href = linkNode.getAttribute("href");
+      var coefficient = href && this.REGEXPS.hashUrl.test(href) ? 0.3 : 1;
+      linkLength += this._getInnerText(linkNode).length * coefficient;
+    });
+
+    return linkLength / textLength;
+  },
+
+  /**
+   * Get an elements class/id weight. Uses regular expressions to tell if this
+   * element looks good or bad.
+   *
+   * @param Element
+   * @return number (Integer)
+   **/
+  _getClassWeight(e) {
+    if (!this._flagIsActive(this.FLAG_WEIGHT_CLASSES)) {
+      return 0;
+    }
+
+    var weight = 0;
+
+    // Look for a special classname
+    if (typeof e.className === "string" && e.className !== "") {
+      if (this.REGEXPS.negative.test(e.className)) {
+        weight -= 25;
+      }
+
+      if (this.REGEXPS.positive.test(e.className)) {
+        weight += 25;
+      }
+    }
+
+    // Look for a special ID
+    if (typeof e.id === "string" && e.id !== "") {
+      if (this.REGEXPS.negative.test(e.id)) {
+        weight -= 25;
+      }
+
+      if (this.REGEXPS.positive.test(e.id)) {
+        weight += 25;
+      }
+    }
+
+    return weight;
+  },
+
+  /**
+   * Clean a node of all elements of type "tag".
+   * (Unless it's a youtube/vimeo video. People love movies.)
+   *
+   * @param Element
+   * @param string tag to clean
+   * @return void
+   **/
+  _clean(e, tag) {
+    var isEmbed = ["object", "embed", "iframe"].includes(tag);
+
+    this._removeNodes(this._getAllNodesWithTag(e, [tag]), function (element) {
+      // Allow youtube and vimeo videos through as people usually want to see those.
+      if (isEmbed) {
+        // First, check the elements attributes to see if any of them contain youtube or vimeo
+        for (var i = 0; i < element.attributes.length; i++) {
+          if (this._allowedVideoRegex.test(element.attributes[i].value)) {
+            return false;
+          }
+        }
+
+        // For embed with <object> tag, check inner HTML as well.
+        if (
+          element.tagName === "object" &&
+          this._allowedVideoRegex.test(element.innerHTML)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  },
+
+  /**
+   * Check if a given node has one of its ancestor tag name matching the
+   * provided one.
+   * @param  HTMLElement node
+   * @param  String      tagName
+   * @param  Number      maxDepth
+   * @param  Function    filterFn a filter to invoke to determine whether this node 'counts'
+   * @return Boolean
+   */
+  _hasAncestorTag(node, tagName, maxDepth, filterFn) {
+    maxDepth = maxDepth || 3;
+    tagName = tagName.toUpperCase();
+    var depth = 0;
+    while (node.parentNode) {
+      if (maxDepth > 0 && depth > maxDepth) {
+        return false;
+      }
+      if (
+        node.parentNode.tagName === tagName &&
+        (!filterFn || filterFn(node.parentNode))
+      ) {
+        return true;
+      }
+      node = node.parentNode;
+      depth++;
+    }
+    return false;
+  },
+
+  /**
+   * Return an object indicating how many rows and columns this table has.
+   */
+  _getRowAndColumnCount(table) {
+    var rows = 0;
+    var columns = 0;
+    var trs = table.getElementsByTagName("tr");
+    for (var i = 0; i < trs.length; i++) {
+      var rowspan = trs[i].getAttribute("rowspan") || 0;
+      if (rowspan) {
+        rowspan = parseInt(rowspan, 10);
+      }
+      rows += rowspan || 1;
+
+      // Now look for column-related info
+      var columnsInThisRow = 0;
+      var cells = trs[i].getElementsByTagName("td");
+      for (var j = 0; j < cells.length; j++) {
+        var colspan = cells[j].getAttribute("colspan") || 0;
+        if (colspan) {
+          colspan = parseInt(colspan, 10);
+        }
+        columnsInThisRow += colspan || 1;
+      }
+      columns = Math.max(columns, columnsInThisRow);
+    }
+    return { rows, columns };
+  },
+
+  /**
+   * Look for 'data' (as opposed to 'layout') tables, for which we use
+   * similar checks as
+   * https://searchfox.org/mozilla-central/rev/f82d5c549f046cb64ce5602bfd894b7ae807c8f8/accessible/generic/TableAccessible.cpp#19
+   */
+  _markDataTables(root) {
+    var tables = root.getElementsByTagName("table");
+    for (var i = 0; i < tables.length; i++) {
+      var table = tables[i];
+      var role = table.getAttribute("role");
+      if (role == "presentation") {
+        table._readabilityDataTable = false;
+        continue;
+      }
+      var datatable = table.getAttribute("datatable");
+      if (datatable == "0") {
+        table._readabilityDataTable = false;
+        continue;
+      }
+      var summary = table.getAttribute("summary");
+      if (summary) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      var caption = table.getElementsByTagName("caption")[0];
+      if (caption && caption.childNodes.length) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      // If the table has a descendant with any of these tags, consider a data table:
+      var dataTableDescendants = ["col", "colgroup", "tfoot", "thead", "th"];
+      var descendantExists = function (tag) {
+        return !!table.getElementsByTagName(tag)[0];
+      };
+      if (dataTableDescendants.some(descendantExists)) {
+        this.log("Data table because found data-y descendant");
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      // Nested tables indicate a layout table:
+      if (table.getElementsByTagName("table")[0]) {
+        table._readabilityDataTable = false;
+        continue;
+      }
+
+      var sizeInfo = this._getRowAndColumnCount(table);
+
+      if (sizeInfo.columns == 1 || sizeInfo.rows == 1) {
+        // single colum/row tables are commonly used for page layout purposes.
+        table._readabilityDataTable = false;
+        continue;
+      }
+
+      if (sizeInfo.rows >= 10 || sizeInfo.columns > 4) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+      // Now just go by size entirely:
+      table._readabilityDataTable = sizeInfo.rows * sizeInfo.columns > 10;
+    }
+  },
+
+  /* convert images and figures that have properties like data-src into images that can be loaded without JS */
+  _fixLazyImages(root) {
+    this._forEachNode(
+      this._getAllNodesWithTag(root, ["img", "picture", "figure"]),
+      function (elem) {
+        // In some sites (e.g. Kotaku), they put 1px square image as base64 data uri in the src attribute.
+        // So, here we check if the data uri is too short, just might as well remove it.
+        if (elem.src && this.REGEXPS.b64DataUrl.test(elem.src)) {
+          // Make sure it's not SVG, because SVG can have a meaningful image in under 133 bytes.
+          var parts = this.REGEXPS.b64DataUrl.exec(elem.src);
+          if (parts[1] === "image/svg+xml") {
+            return;
+          }
+
+          // Make sure this element has other attributes which contains image.
+          // If it doesn't, then this src is important and shouldn't be removed.
+          var srcCouldBeRemoved = false;
+          for (var i = 0; i < elem.attributes.length; i++) {
+            var attr = elem.attributes[i];
+            if (attr.name === "src") {
+              continue;
+            }
+
+            if (/\.(jpg|jpeg|png|webp)/i.test(attr.value)) {
+              srcCouldBeRemoved = true;
+              break;
+            }
+          }
+
+          // Here we assume if image is less than 100 bytes (or 133 after encoded to base64)
+          // it will be too small, therefore it might be placeholder image.
+          if (srcCouldBeRemoved) {
+            var b64starts = parts[0].length;
+            var b64length = elem.src.length - b64starts;
+            if (b64length < 133) {
+              elem.removeAttribute("src");
+            }
+          }
+        }
+
+        // also check for "null" to work around https://github.com/jsdom/jsdom/issues/2580
+        if (
+          (elem.src || (elem.srcset && elem.srcset != "null")) &&
+          !elem.className.toLowerCase().includes("lazy")
+        ) {
+          return;
+        }
+
+        for (var j = 0; j < elem.attributes.length; j++) {
+          attr = elem.attributes[j];
+          if (
+            attr.name === "src" ||
+            attr.name === "srcset" ||
+            attr.name === "alt"
+          ) {
+            continue;
+          }
+          var copyTo = null;
+          if (/\.(jpg|jpeg|png|webp)\s+\d/.test(attr.value)) {
+            copyTo = "srcset";
+          } else if (/^\s*\S+\.(jpg|jpeg|png|webp)\S*\s*$/.test(attr.value)) {
+            copyTo = "src";
+          }
+          if (copyTo) {
+            //if this is an img or picture, set the attribute directly
+            if (elem.tagName === "IMG" || elem.tagName === "PICTURE") {
+              elem.setAttribute(copyTo, attr.value);
+            } else if (
+              elem.tagName === "FIGURE" &&
+              !this._getAllNodesWithTag(elem, ["img", "picture"]).length
+            ) {
+              //if the item is a <figure> that does not contain an image or picture, create one and place it inside the figure
+              //see the nytimes-3 testcase for an example
+              var img = this._doc.createElement("img");
+              img.setAttribute(copyTo, attr.value);
+              elem.appendChild(img);
+            }
+          }
+        }
+      },
+    );
+  },
+
+  _getTextDensity(e, tags) {
+    var textLength = this._getInnerText(e, true).length;
+    if (textLength === 0) {
+      return 0;
+    }
+    var childrenLength = 0;
+    var children = this._getAllNodesWithTag(e, tags);
+    this._forEachNode(
+      children,
+      (child) => (childrenLength += this._getInnerText(child, true).length),
+    );
+    return childrenLength / textLength;
+  },
+
+  /**
+   * Clean an element of all tags of type "tag" if they look fishy.
+   * "Fishy" is an algorithm based on content length, classnames, link density, number of images & embeds, etc.
+   *
+   * @return void
+   **/
+  _cleanConditionally(e, tag) {
+    if (!this._flagIsActive(this.FLAG_CLEAN_CONDITIONALLY)) {
+      return;
+    }
+
+    // Gather counts for other typical elements embedded within.
+    // Traverse backwards so we can remove nodes at the same time
+    // without effecting the traversal.
+    //
+    // TODO: Consider taking into account original contentScore here.
+    this._removeNodes(this._getAllNodesWithTag(e, [tag]), function (node) {
+      // First check if this node IS data table, in which case don't remove it.
+      var isDataTable = function (t) {
+        return t._readabilityDataTable;
+      };
+
+      var isList = tag === "ul" || tag === "ol";
+      if (!isList) {
+        var listLength = 0;
+        var listNodes = this._getAllNodesWithTag(node, ["ul", "ol"]);
+        this._forEachNode(
+          listNodes,
+          (list) => (listLength += this._getInnerText(list).length),
+        );
+        isList = listLength / this._getInnerText(node).length > 0.9;
+      }
+
+      if (tag === "table" && isDataTable(node)) {
+        return false;
+      }
+
+      // Next check if we're inside a data table, in which case don't remove it as well.
+      if (this._hasAncestorTag(node, "table", -1, isDataTable)) {
+        return false;
+      }
+
+      if (this._hasAncestorTag(node, "code")) {
+        return false;
+      }
+
+      // keep element if it has a data tables
+      if (
+        [...node.getElementsByTagName("table")].some(
+          (tbl) => tbl._readabilityDataTable,
+        )
+      ) {
+        return false;
+      }
+
+      var weight = this._getClassWeight(node);
+
+      this.log("Cleaning Conditionally", node);
+
+      var contentScore = 0;
+
+      if (weight + contentScore < 0) {
+        return true;
+      }
+
+      if (this._getCharCount(node, ",") < 10) {
+        // If there are not very many commas, and the number of
+        // non-paragraph elements is more than paragraphs or other
+        // ominous signs, remove the element.
+        var p = node.getElementsByTagName("p").length;
+        var img = node.getElementsByTagName("img").length;
+        var li = node.getElementsByTagName("li").length - 100;
+        var input = node.getElementsByTagName("input").length;
+        var headingDensity = this._getTextDensity(node, [
+          "h1",
+          "h2",
+          "h3",
+          "h4",
+          "h5",
+          "h6",
+        ]);
+
+        var embedCount = 0;
+        var embeds = this._getAllNodesWithTag(node, [
+          "object",
+          "embed",
+          "iframe",
+        ]);
+
+        for (var i = 0; i < embeds.length; i++) {
+          // If this embed has attribute that matches video regex, don't delete it.
+          for (var j = 0; j < embeds[i].attributes.length; j++) {
+            if (this._allowedVideoRegex.test(embeds[i].attributes[j].value)) {
+              return false;
+            }
+          }
+
+          // For embed with <object> tag, check inner HTML as well.
+          if (
+            embeds[i].tagName === "object" &&
+            this._allowedVideoRegex.test(embeds[i].innerHTML)
+          ) {
+            return false;
+          }
+
+          embedCount++;
+        }
+
+        var innerText = this._getInnerText(node);
+
+        // toss any node whose inner text contains nothing but suspicious words
+        if (
+          this.REGEXPS.adWords.test(innerText) ||
+          this.REGEXPS.loadingWords.test(innerText)
+        ) {
+          return true;
+        }
+
+        var contentLength = innerText.length;
+        var linkDensity = this._getLinkDensity(node);
+        var textishTags = ["SPAN", "LI", "TD"].concat(
+          Array.from(this.DIV_TO_P_ELEMS),
+        );
+        var textDensity = this._getTextDensity(node, textishTags);
+        var isFigureChild = this._hasAncestorTag(node, "figure");
+
+        // apply shadiness checks, then check for exceptions
+        const shouldRemoveNode = () => {
+          const errs = [];
+          if (!isFigureChild && img > 1 && p / img < 0.5) {
+            errs.push(`Bad p to img ratio (img=${img}, p=${p})`);
+          }
+          if (!isList && li > p) {
+            errs.push(`Too many li's outside of a list. (li=${li} > p=${p})`);
+          }
+          if (input > Math.floor(p / 3)) {
+            errs.push(`Too many inputs per p. (input=${input}, p=${p})`);
+          }
+          if (
+            !isList &&
+            !isFigureChild &&
+            headingDensity < 0.9 &&
+            contentLength < 25 &&
+            (img === 0 || img > 2) &&
+            linkDensity > 0
+          ) {
+            errs.push(
+              `Suspiciously short. (headingDensity=${headingDensity}, img=${img}, linkDensity=${linkDensity})`,
+            );
+          }
+          if (
+            !isList &&
+            weight < 25 &&
+            linkDensity > 0.2 + this._linkDensityModifier
+          ) {
+            errs.push(
+              `Low weight and a little linky. (linkDensity=${linkDensity})`,
+            );
+          }
+          if (weight >= 25 && linkDensity > 0.5 + this._linkDensityModifier) {
+            errs.push(
+              `High weight and mostly links. (linkDensity=${linkDensity})`,
+            );
+          }
+          if ((embedCount === 1 && contentLength < 75) || embedCount > 1) {
+            errs.push(
+              `Suspicious embed. (embedCount=${embedCount}, contentLength=${contentLength})`,
+            );
+          }
+          if (img === 0 && textDensity === 0) {
+            errs.push(
+              `No useful content. (img=${img}, textDensity=${textDensity})`,
+            );
+          }
+
+          if (errs.length) {
+            this.log("Checks failed", errs);
+            return true;
+          }
+
+          return false;
+        };
+
+        var haveToRemove = shouldRemoveNode();
+
+        // Allow simple lists of images to remain in pages
+        if (isList && haveToRemove) {
+          for (var x = 0; x < node.children.length; x++) {
+            let child = node.children[x];
+            // Don't filter in lists with li's that contain more than one child
+            if (child.children.length > 1) {
+              return haveToRemove;
+            }
+          }
+          let li_count = node.getElementsByTagName("li").length;
+          // Only allow the list to remain if every li contains an image
+          if (img == li_count) {
+            return false;
+          }
+        }
+        return haveToRemove;
+      }
+      return false;
+    });
+  },
+
+  /**
+   * Clean out elements that match the specified conditions
+   *
+   * @param Element
+   * @param Function determines whether a node should be removed
+   * @return void
+   **/
+  _cleanMatchedNodes(e, filter) {
+    var endOfSearchMarkerNode = this._getNextNode(e, true);
+    var next = this._getNextNode(e);
+    while (next && next != endOfSearchMarkerNode) {
+      if (filter.call(this, next, next.className + " " + next.id)) {
+        next = this._removeAndGetNext(next);
+      } else {
+        next = this._getNextNode(next);
+      }
+    }
+  },
+
+  /**
+   * Clean out spurious headers from an Element.
+   *
+   * @param Element
+   * @return void
+   **/
+  _cleanHeaders(e) {
+    let headingNodes = this._getAllNodesWithTag(e, ["h1", "h2"]);
+    this._removeNodes(headingNodes, function (node) {
+      let shouldRemove = this._getClassWeight(node) < 0;
+      if (shouldRemove) {
+        this.log("Removing header with low class weight:", node);
+      }
+      return shouldRemove;
+    });
+  },
+
+  /**
+   * Check if this node is an H1 or H2 element whose content is mostly
+   * the same as the article title.
+   *
+   * @param Element  the node to check.
+   * @return boolean indicating whether this is a title-like header.
+   */
+  _headerDuplicatesTitle(node) {
+    if (node.tagName != "H1" && node.tagName != "H2") {
+      return false;
+    }
+    var heading = this._getInnerText(node, false);
+    this.log("Evaluating similarity of header:", heading, this._articleTitle);
+    return this._textSimilarity(this._articleTitle, heading) > 0.75;
+  },
+
+  _flagIsActive(flag) {
+    return (this._flags & flag) > 0;
+  },
+
+  _removeFlag(flag) {
+    this._flags = this._flags & ~flag;
+  },
+
+  _isProbablyVisible(node) {
+    // Have to null-check node.style and node.className.includes to deal with SVG and MathML nodes.
+    return (
+      (!node.style || node.style.display != "none") &&
+      (!node.style || node.style.visibility != "hidden") &&
+      !node.hasAttribute("hidden") &&
+      //check for "fallback-image" so that wikimedia math images are displayed
+      (!node.hasAttribute("aria-hidden") ||
+        node.getAttribute("aria-hidden") != "true" ||
+        (node.className &&
+          node.className.includes &&
+          node.className.includes("fallback-image")))
+    );
+  },
+
+  /**
+   * Runs readability.
+   *
+   * Workflow:
+   *  1. Prep the document by removing script tags, css, etc.
+   *  2. Build readability's DOM tree.
+   *  3. Grab the article content from the current dom tree.
+   *  4. Replace the current DOM tree with the new one.
+   *  5. Read peacefully.
+   *
+   * @return void
+   **/
+  parse() {
+    // Avoid parsing too large documents, as per configuration option
+    if (this._maxElemsToParse > 0) {
+      var numTags = this._doc.getElementsByTagName("*").length;
+      if (numTags > this._maxElemsToParse) {
+        throw new Error(
+          "Aborting parsing document; " + numTags + " elements found",
+        );
+      }
+    }
+
+    // Unwrap image from noscript
+    this._unwrapNoscriptImages(this._doc);
+
+    // Extract JSON-LD metadata before removing scripts
+    var jsonLd = this._disableJSONLD ? {} : this._getJSONLD(this._doc);
+
+    // Remove script tags from the document.
+    this._removeScripts(this._doc);
+
+    this._prepDocument();
+
+    var metadata = this._getArticleMetadata(jsonLd);
+    this._metadata = metadata;
+    this._articleTitle = metadata.title;
+
+    var articleContent = this._grabArticle();
+    if (!articleContent) {
+      return null;
+    }
+
+    this.log("Grabbed: " + articleContent.innerHTML);
+
+    this._postProcessContent(articleContent);
+
+    // If we haven't found an excerpt in the article's metadata, use the article's
+    // first paragraph as the excerpt. This is used for displaying a preview of
+    // the article's content.
+    if (!metadata.excerpt) {
+      var paragraphs = articleContent.getElementsByTagName("p");
+      if (paragraphs.length) {
+        metadata.excerpt = paragraphs[0].textContent.trim();
+      }
+    }
+
+    var textContent = articleContent.textContent;
+    return {
+      title: this._articleTitle,
+      byline: metadata.byline || this._articleByline,
+      dir: this._articleDir,
+      lang: this._articleLang,
+      content: this._serializer(articleContent),
+      textContent,
+      length: textContent.length,
+      excerpt: metadata.excerpt,
+      siteName: metadata.siteName || this._articleSiteName,
+      publishedTime: metadata.publishedTime,
+    };
+  },
+};
+
+if (typeof module === "object") {
+  /* eslint-disable-next-line no-redeclare */
+  /* global module */
+  module.exports = Readability;
+}

--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -56,7 +56,9 @@ function generateTabId() {
  * Connect to native messaging host
  */
 function connectNativeHost() {
-  if (nativePort) return;
+  if (nativePort) {
+    return;
+  }
 
   console.log("Connecting to native messaging host...");
 
@@ -183,7 +185,9 @@ async function navigate(url, tabId) {
   const managedTabId = tabId || activeTabId;
   if (managedTabId && managedTabs.has(managedTabId)) {
     const managedTab = managedTabs.get(managedTabId);
-    if (managedTab) managedTab.url = url;
+    if (managedTab) {
+      managedTab.url = url;
+    }
   }
 
   return { message: `Navigated to ${url}` };
@@ -295,7 +299,9 @@ async function listTabs() {
       });
     } catch {
       managedTabs.delete(shortId);
-      if (activeTabId === shortId) activeTabId = undefined;
+      if (activeTabId === shortId) {
+        activeTabId = undefined;
+      }
     }
   }
 
@@ -485,6 +491,8 @@ async function handleCommand(message) {
  * @param {string} shortId
  */
 async function enableOnTab(tabId, shortId) {
+  // Inject Readability.js first, then content.js
+  await browser.tabs.executeScript(tabId, { file: "Readability.js" });
   await browser.tabs.executeScript(tabId, { file: "content.js" });
 
   await browser.tabs.executeScript(tabId, {
@@ -561,7 +569,9 @@ async function enableOnTab(tabId, shortId) {
  */
 async function disableOnTab(tabId, shortId) {
   managedTabs.delete(shortId);
-  if (activeTabId === shortId) activeTabId = undefined;
+  if (activeTabId === shortId) {
+    activeTabId = undefined;
+  }
 
   await browser.tabs.executeScript(tabId, {
     code: `(${function () {
@@ -716,7 +726,9 @@ browser.tabs.onRemoved.addListener((tabId) => {
   for (const [shortId, tab] of managedTabs) {
     if (tab.tabId === tabId) {
       managedTabs.delete(shortId);
-      if (activeTabId === shortId) activeTabId = undefined;
+      if (activeTabId === shortId) {
+        activeTabId = undefined;
+      }
       break;
     }
   }

--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -250,6 +250,7 @@ async function saveScreenshotToFile(dataUrl, outputPath) {
     }, 30_000);
 
     messageHandlers[messageId] = {
+      /** @param {{success?: boolean, result?: {screenshot_path: string, message: string}, error?: string}} response */
       resolve: (response) => {
         clearTimeout(timeout);
         if (response.success && response.result) {
@@ -258,11 +259,17 @@ async function saveScreenshotToFile(dataUrl, outputPath) {
           reject(new Error(response.error || "Failed to save screenshot"));
         }
       },
+      /** @param {Error} error */
       reject: (error) => {
         clearTimeout(timeout);
         reject(error);
       },
     };
+
+    if (!nativePort) {
+      reject(new Error("Native messaging disconnected"));
+      return;
+    }
 
     nativePort.postMessage({
       command: "save-screenshot",

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -1,394 +1,401 @@
 /// <reference types="firefox-webext-browser" />
 
-/**
- * Content script for Browser CLI Controller
- * Optimized API for LLM agents with limited context windows
- *
- * @typedef {'css' | 'text' | 'aria-label' | 'placeholder'} SelectorType
- *
- * @typedef {object} ConsoleLog
- * @property {string} type - Log type (log, error, warn, info, debug)
- * @property {string} message - Log message
- * @property {string} timestamp - ISO timestamp
- *
- * @typedef {object} ElementData
- * @property {number} ref - Element reference number
- * @property {string} role - Element role (button, link, input, etc.)
- * @property {string} name - Accessible name
- * @property {string} [value] - Current value (for inputs)
- * @property {string[]} attrs - Attributes like [clickable], [disabled]
- * @property {Element} domElement - Reference to DOM element
- */
-
-/** @type {ConsoleLog[]} Store console logs */
-const consoleLogs = [];
-/** @type {number} */
-const MAX_CONSOLE_LOGS = 1000;
-
-/** @type {HTMLDivElement|undefined} Virtual cursor element */
-let virtualCursor;
-
-/** @type {HTMLInputElement|HTMLTextAreaElement|undefined} Last focused input element */
-let lastFocusedInput;
-
-/** @type {Map<number, Element>} Current ref to element mapping */
-let currentRefMap = new Map();
-
-/** @type {Snapshot|undefined} Last snapshot for diffing */
-let lastSnapshot;
-
-// ============================================================================
-// Snapshot and Element Classes
-// ============================================================================
-
-/**
- * Element wrapper with LLM-friendly toString
- */
-class SnapshotElement {
-  /**
-   * @param {ElementData} data
-   */
-  constructor(data) {
-    /** @type {number} */
-    this.ref = data.ref;
-    /** @type {string} */
-    this.role = data.role;
-    /** @type {string} */
-    this.name = data.name;
-    /** @type {string|undefined} */
-    this.value = data.value;
-    /** @type {string[]} */
-    this.attrs = data.attrs;
-    /** @type {Element} */
-    this.domElement = data.domElement;
-  }
+// Guard against re-injection (silently skip if already loaded)
+// @ts-ignore - custom property on window
+if (!window.__browserCliInjected) {
+  // @ts-ignore - custom property on window
+  window.__browserCliInjected = true;
 
   /**
-   * LLM-friendly string representation
-   * @returns {string}
+   * Content script for Browser CLI Controller
+   * Optimized API for LLM agents with limited context windows
+   *
+   * @typedef {'css' | 'text' | 'aria-label' | 'placeholder'} SelectorType
+   *
+   * @typedef {object} ConsoleLog
+   * @property {string} type - Log type (log, error, warn, info, debug)
+   * @property {string} message - Log message
+   * @property {string} timestamp - ISO timestamp
+   *
+   * @typedef {object} ElementData
+   * @property {number} ref - Element reference number
+   * @property {string} role - Element role (button, link, input, etc.)
+   * @property {string} name - Accessible name
+   * @property {string} [value] - Current value (for inputs)
+   * @property {string[]} attrs - Attributes like [clickable], [disabled]
+   * @property {Element} domElement - Reference to DOM element
    */
-  toString() {
-    let s = `[${this.ref}] ${this.role}`;
-    if (this.name) {
-      s += ` "${this.name}"`;
+
+  /** @type {ConsoleLog[]} Store console logs */
+  const consoleLogs = [];
+  /** @type {number} */
+  const MAX_CONSOLE_LOGS = 1000;
+
+  /** @type {HTMLDivElement|undefined} Virtual cursor element */
+  let virtualCursor;
+
+  /** @type {HTMLInputElement|HTMLTextAreaElement|undefined} Last focused input element */
+  let lastFocusedInput;
+
+  /** @type {Map<number, Element>} Current ref to element mapping */
+  let currentRefMap = new Map();
+
+  /** @type {Snapshot|undefined} Last snapshot for diffing */
+  let lastSnapshot;
+
+  // ============================================================================
+  // Snapshot and Element Classes
+  // ============================================================================
+
+  /**
+   * Element wrapper with LLM-friendly toString
+   */
+  class SnapshotElement {
+    /**
+     * @param {ElementData} data
+     */
+    constructor(data) {
+      /** @type {number} */
+      this.ref = data.ref;
+      /** @type {string} */
+      this.role = data.role;
+      /** @type {string} */
+      this.name = data.name;
+      /** @type {string|undefined} */
+      this.value = data.value;
+      /** @type {string[]} */
+      this.attrs = data.attrs;
+      /** @type {Element} */
+      this.domElement = data.domElement;
     }
-    if (this.attrs.length > 0) {
-      s += ` [${this.attrs.join(", ")}]`;
-    }
-    if (this.value !== undefined) {
-      s += ` value="${this.value}"`;
-    }
-    return s;
-  }
 
-  /**
-   * JSON representation (without DOM element)
-   * @returns {object}
-   */
-  toJSON() {
-    return {
-      ref: this.ref,
-      role: this.role,
-      name: this.name,
-      value: this.value,
-      attrs: this.attrs,
-    };
-  }
-}
+    /**
+     * LLM-friendly string representation
+     * @returns {string}
+     */
+    toString() {
+      let s = `[${this.ref}] ${this.role}`;
+      if (this.name) {
+        s += ` "${this.name}"`;
+      }
+      if (this.attrs.length > 0) {
+        s += ` [${this.attrs.join(", ")}]`;
+      }
+      if (this.value !== undefined) {
+        s += ` value="${this.value}"`;
+      }
+      return s;
+    }
 
-/**
- * Snapshot class with filtering and LLM-friendly output
- */
-class Snapshot {
-  /**
-   * @param {SnapshotElement[]} elements
-   * @param {string} url
-   * @param {string} title
-   */
-  constructor(elements, url, title) {
-    /** @type {SnapshotElement[]} */
-    this.elements = elements;
-    /** @type {string} */
-    this.url = url;
-    /** @type {string} */
-    this.title = title;
-    /** @type {Map<number, SnapshotElement>} */
-    this._refMap = new Map();
-    for (const el of elements) {
-      this._refMap.set(el.ref, el);
+    /**
+     * JSON representation (without DOM element)
+     * @returns {object}
+     */
+    toJSON() {
+      return {
+        ref: this.ref,
+        role: this.role,
+        name: this.name,
+        value: this.value,
+        attrs: this.attrs,
+      };
     }
   }
 
   /**
-   * Find element by ref
-   * @param {number} ref
-   * @returns {SnapshotElement|undefined}
+   * Snapshot class with filtering and LLM-friendly output
    */
-  find(ref) {
-    return this._refMap.get(ref);
-  }
-
-  /**
-   * Get all buttons
-   * @returns {SnapshotElement[]}
-   */
-  get buttons() {
-    return this.elements.filter((e) => e.role === "button");
-  }
-
-  /**
-   * Get all links
-   * @returns {SnapshotElement[]}
-   */
-  get links() {
-    return this.elements.filter((e) => e.role === "link");
-  }
-
-  /**
-   * Get all inputs
-   * @returns {SnapshotElement[]}
-   */
-  get inputs() {
-    return this.elements.filter(
-      (e) =>
-        ["input", "textarea", "select"].includes(e.role) ||
-        e.role.startsWith("input["),
-    );
-  }
-
-  /**
-   * Get all form elements
-   * @returns {SnapshotElement[]}
-   */
-  get forms() {
-    return this.elements.filter(
-      (e) =>
-        ["input", "textarea", "select", "checkbox", "radio"].includes(e.role) ||
-        e.role.startsWith("input["),
-    );
-  }
-
-  /**
-   * Search by text
-   * @param {string} text
-   * @returns {SnapshotElement[]}
-   */
-  search(text) {
-    const lower = text.toLowerCase();
-    return this.elements.filter(
-      (e) =>
-        e.name?.toLowerCase().includes(lower) ||
-        e.value?.toLowerCase().includes(lower),
-    );
-  }
-
-  /**
-   * Compare with another snapshot and return differences
-   * @param {Snapshot} other - Previous snapshot to compare against
-   * @returns {SnapshotDiff}
-   */
-  diff(other) {
-    return new SnapshotDiff(other, this);
-  }
-
-  /**
-   * LLM-friendly output
-   * @returns {string}
-   */
-  toString() {
-    let out = `Page: ${this.title}\nURL: ${this.url}\n\n`;
-    for (const el of this.elements) {
-      out += el.toString() + "\n";
-    }
-    return out;
-  }
-
-  /**
-   * JSON representation
-   * @returns {object}
-   */
-  toJSON() {
-    return {
-      url: this.url,
-      title: this.title,
-      elements: this.elements.map((e) => e.toJSON()),
-    };
-  }
-}
-
-/**
- * Diff between two snapshots
- */
-class SnapshotDiff {
-  /**
-   * @param {Snapshot} before
-   * @param {Snapshot} after
-   */
-  constructor(before, after) {
-    /** @type {boolean} */
-    this.urlChanged = before.url !== after.url;
-    /** @type {string|undefined} */
-    this.oldUrl = this.urlChanged ? before.url : undefined;
-    /** @type {string|undefined} */
-    this.newUrl = this.urlChanged ? after.url : undefined;
-
-    /** @type {boolean} */
-    this.titleChanged = before.title !== after.title;
-    /** @type {string|undefined} */
-    this.oldTitle = this.titleChanged ? before.title : undefined;
-    /** @type {string|undefined} */
-    this.newTitle = this.titleChanged ? after.title : undefined;
-
-    // Build maps by element signature (role + name) for comparison
-    /** @type {Map<string, SnapshotElement>} */
-    const beforeMap = new Map();
-    for (const el of before.elements) {
-      const key = `${el.role}|${el.name}`;
-      beforeMap.set(key, el);
+  class Snapshot {
+    /**
+     * @param {SnapshotElement[]} elements
+     * @param {string} url
+     * @param {string} title
+     */
+    constructor(elements, url, title) {
+      /** @type {SnapshotElement[]} */
+      this.elements = elements;
+      /** @type {string} */
+      this.url = url;
+      /** @type {string} */
+      this.title = title;
+      /** @type {Map<number, SnapshotElement>} */
+      this._refMap = new Map();
+      for (const el of elements) {
+        this._refMap.set(el.ref, el);
+      }
     }
 
-    /** @type {Map<string, SnapshotElement>} */
-    const afterMap = new Map();
-    for (const el of after.elements) {
-      const key = `${el.role}|${el.name}`;
-      afterMap.set(key, el);
+    /**
+     * Find element by ref
+     * @param {number} ref
+     * @returns {SnapshotElement|undefined}
+     */
+    find(ref) {
+      return this._refMap.get(ref);
     }
 
-    /** @type {SnapshotElement[]} */
-    this.added = [];
-    /** @type {SnapshotElement[]} */
-    this.removed = [];
-    /** @type {Array<{element: SnapshotElement, changes: string[]}>} */
-    this.changed = [];
+    /**
+     * Get all buttons
+     * @returns {SnapshotElement[]}
+     */
+    get buttons() {
+      return this.elements.filter((e) => e.role === "button");
+    }
 
-    // Find added and changed elements
-    for (const [key, el] of afterMap) {
-      const beforeEl = beforeMap.get(key);
-      if (beforeEl) {
-        // Check for changes
-        const changes = [];
-        if (beforeEl.value !== el.value) {
-          changes.push(
-            `value: "${beforeEl.value ?? ""}" → "${el.value ?? ""}"`,
+    /**
+     * Get all links
+     * @returns {SnapshotElement[]}
+     */
+    get links() {
+      return this.elements.filter((e) => e.role === "link");
+    }
+
+    /**
+     * Get all inputs
+     * @returns {SnapshotElement[]}
+     */
+    get inputs() {
+      return this.elements.filter(
+        (e) =>
+          ["input", "textarea", "select"].includes(e.role) ||
+          e.role.startsWith("input["),
+      );
+    }
+
+    /**
+     * Get all form elements
+     * @returns {SnapshotElement[]}
+     */
+    get forms() {
+      return this.elements.filter(
+        (e) =>
+          ["input", "textarea", "select", "checkbox", "radio"].includes(
+            e.role,
+          ) || e.role.startsWith("input["),
+      );
+    }
+
+    /**
+     * Search by text
+     * @param {string} text
+     * @returns {SnapshotElement[]}
+     */
+    search(text) {
+      const lower = text.toLowerCase();
+      return this.elements.filter(
+        (e) =>
+          e.name?.toLowerCase().includes(lower) ||
+          e.value?.toLowerCase().includes(lower),
+      );
+    }
+
+    /**
+     * Compare with another snapshot and return differences
+     * @param {Snapshot} other - Previous snapshot to compare against
+     * @returns {SnapshotDiff}
+     */
+    diff(other) {
+      return new SnapshotDiff(other, this);
+    }
+
+    /**
+     * LLM-friendly output
+     * @returns {string}
+     */
+    toString() {
+      let out = `Page: ${this.title}\nURL: ${this.url}\n\n`;
+      for (const el of this.elements) {
+        out += el.toString() + "\n";
+      }
+      return out;
+    }
+
+    /**
+     * JSON representation
+     * @returns {object}
+     */
+    toJSON() {
+      return {
+        url: this.url,
+        title: this.title,
+        elements: this.elements.map((e) => e.toJSON()),
+      };
+    }
+  }
+
+  /**
+   * Diff between two snapshots
+   */
+  class SnapshotDiff {
+    /**
+     * @param {Snapshot} before
+     * @param {Snapshot} after
+     */
+    constructor(before, after) {
+      /** @type {boolean} */
+      this.urlChanged = before.url !== after.url;
+      /** @type {string|undefined} */
+      this.oldUrl = this.urlChanged ? before.url : undefined;
+      /** @type {string|undefined} */
+      this.newUrl = this.urlChanged ? after.url : undefined;
+
+      /** @type {boolean} */
+      this.titleChanged = before.title !== after.title;
+      /** @type {string|undefined} */
+      this.oldTitle = this.titleChanged ? before.title : undefined;
+      /** @type {string|undefined} */
+      this.newTitle = this.titleChanged ? after.title : undefined;
+
+      // Build maps by element signature (role + name) for comparison
+      /** @type {Map<string, SnapshotElement>} */
+      const beforeMap = new Map();
+      for (const el of before.elements) {
+        const key = `${el.role}|${el.name}`;
+        beforeMap.set(key, el);
+      }
+
+      /** @type {Map<string, SnapshotElement>} */
+      const afterMap = new Map();
+      for (const el of after.elements) {
+        const key = `${el.role}|${el.name}`;
+        afterMap.set(key, el);
+      }
+
+      /** @type {SnapshotElement[]} */
+      this.added = [];
+      /** @type {SnapshotElement[]} */
+      this.removed = [];
+      /** @type {Array<{element: SnapshotElement, changes: string[]}>} */
+      this.changed = [];
+
+      // Find added and changed elements
+      for (const [key, el] of afterMap) {
+        const beforeEl = beforeMap.get(key);
+        if (beforeEl) {
+          // Check for changes
+          const changes = [];
+          if (beforeEl.value !== el.value) {
+            changes.push(
+              `value: "${beforeEl.value ?? ""}" → "${el.value ?? ""}"`,
+            );
+          }
+          const beforeAttrs = beforeEl.attrs.join(",");
+          const afterAttrs = el.attrs.join(",");
+          if (beforeAttrs !== afterAttrs) {
+            changes.push(`attrs: [${beforeAttrs}] → [${afterAttrs}]`);
+          }
+          if (changes.length > 0) {
+            this.changed.push({ element: el, changes });
+          }
+        } else {
+          this.added.push(el);
+        }
+      }
+
+      // Find removed elements
+      for (const [key, el] of beforeMap) {
+        if (!afterMap.has(key)) {
+          this.removed.push(el);
+        }
+      }
+    }
+
+    /**
+     * Check if anything changed
+     * @returns {boolean}
+     */
+    get hasChanges() {
+      return (
+        this.urlChanged ||
+        this.titleChanged ||
+        this.added.length > 0 ||
+        this.removed.length > 0 ||
+        this.changed.length > 0
+      );
+    }
+
+    /**
+     * LLM-friendly output
+     * @returns {string}
+     */
+    toString() {
+      if (!this.hasChanges) {
+        return "No changes";
+      }
+
+      const lines = [];
+
+      if (this.urlChanged) {
+        lines.push(`URL: ${this.oldUrl} → ${this.newUrl}`);
+      }
+      if (this.titleChanged) {
+        lines.push(`Title: "${this.oldTitle}" → "${this.newTitle}"`);
+      }
+
+      if (this.added.length > 0) {
+        lines.push("", `Added (${this.added.length}):`);
+        for (const el of this.added) {
+          lines.push(`  + ${el.toString()}`);
+        }
+      }
+
+      if (this.removed.length > 0) {
+        lines.push("", `Removed (${this.removed.length}):`);
+        for (const el of this.removed) {
+          lines.push(`  - ${el.toString()}`);
+        }
+      }
+
+      if (this.changed.length > 0) {
+        lines.push("", `Changed (${this.changed.length}):`);
+        for (const { element, changes } of this.changed) {
+          lines.push(
+            `  ~ ${element.toString()}`,
+            ...changes.map((c) => `      ${c}`),
           );
         }
-        const beforeAttrs = beforeEl.attrs.join(",");
-        const afterAttrs = el.attrs.join(",");
-        if (beforeAttrs !== afterAttrs) {
-          changes.push(`attrs: [${beforeAttrs}] → [${afterAttrs}]`);
-        }
-        if (changes.length > 0) {
-          this.changed.push({ element: el, changes });
-        }
-      } else {
-        this.added.push(el);
       }
+
+      return lines.join("\n");
     }
 
-    // Find removed elements
-    for (const [key, el] of beforeMap) {
-      if (!afterMap.has(key)) {
-        this.removed.push(el);
-      }
+    /**
+     * JSON representation
+     * @returns {object}
+     */
+    toJSON() {
+      return {
+        urlChanged: this.urlChanged,
+        oldUrl: this.oldUrl,
+        newUrl: this.newUrl,
+        titleChanged: this.titleChanged,
+        oldTitle: this.oldTitle,
+        newTitle: this.newTitle,
+        added: this.added.map((e) => e.toJSON()),
+        removed: this.removed.map((e) => e.toJSON()),
+        changed: this.changed.map(({ element, changes }) => ({
+          element: element.toJSON(),
+          changes,
+        })),
+      };
     }
   }
+
+  // ============================================================================
+  // Virtual Cursor
+  // ============================================================================
 
   /**
-   * Check if anything changed
-   * @returns {boolean}
+   * Create and initialize the virtual cursor
    */
-  get hasChanges() {
-    return (
-      this.urlChanged ||
-      this.titleChanged ||
-      this.added.length > 0 ||
-      this.removed.length > 0 ||
-      this.changed.length > 0
-    );
-  }
-
-  /**
-   * LLM-friendly output
-   * @returns {string}
-   */
-  toString() {
-    if (!this.hasChanges) {
-      return "No changes";
+  function initializeVirtualCursor() {
+    if (virtualCursor) {
+      return;
     }
 
-    const lines = [];
-
-    if (this.urlChanged) {
-      lines.push(`URL: ${this.oldUrl} → ${this.newUrl}`);
-    }
-    if (this.titleChanged) {
-      lines.push(`Title: "${this.oldTitle}" → "${this.newTitle}"`);
-    }
-
-    if (this.added.length > 0) {
-      lines.push("", `Added (${this.added.length}):`);
-      for (const el of this.added) {
-        lines.push(`  + ${el.toString()}`);
-      }
-    }
-
-    if (this.removed.length > 0) {
-      lines.push("", `Removed (${this.removed.length}):`);
-      for (const el of this.removed) {
-        lines.push(`  - ${el.toString()}`);
-      }
-    }
-
-    if (this.changed.length > 0) {
-      lines.push("", `Changed (${this.changed.length}):`);
-      for (const { element, changes } of this.changed) {
-        lines.push(
-          `  ~ ${element.toString()}`,
-          ...changes.map((c) => `      ${c}`),
-        );
-      }
-    }
-
-    return lines.join("\n");
-  }
-
-  /**
-   * JSON representation
-   * @returns {object}
-   */
-  toJSON() {
-    return {
-      urlChanged: this.urlChanged,
-      oldUrl: this.oldUrl,
-      newUrl: this.newUrl,
-      titleChanged: this.titleChanged,
-      oldTitle: this.oldTitle,
-      newTitle: this.newTitle,
-      added: this.added.map((e) => e.toJSON()),
-      removed: this.removed.map((e) => e.toJSON()),
-      changed: this.changed.map(({ element, changes }) => ({
-        element: element.toJSON(),
-        changes,
-      })),
-    };
-  }
-}
-
-// ============================================================================
-// Virtual Cursor
-// ============================================================================
-
-/**
- * Create and initialize the virtual cursor
- */
-function initializeVirtualCursor() {
-  if (virtualCursor) {
-    return;
-  }
-
-  virtualCursor = document.createElement("div");
-  virtualCursor.id = "browser-cli-cursor";
-  virtualCursor.style.cssText = `
+    virtualCursor = document.createElement("div");
+    virtualCursor.id = "browser-cli-cursor";
+    virtualCursor.style.cssText = `
     position: fixed;
     width: 20px;
     height: 20px;
@@ -398,8 +405,8 @@ function initializeVirtualCursor() {
     opacity: 1;
   `;
 
-  const inner = document.createElement("div");
-  inner.style.cssText = `
+    const inner = document.createElement("div");
+    inner.style.cssText = `
     position: absolute;
     top: 50%;
     left: 50%;
@@ -411,8 +418,8 @@ function initializeVirtualCursor() {
     box-shadow: 0 0 10px rgba(255, 107, 107, 0.5);
   `;
 
-  const outer = document.createElement("div");
-  outer.style.cssText = `
+    const outer = document.createElement("div");
+    outer.style.cssText = `
     position: absolute;
     top: 50%;
     left: 50%;
@@ -424,8 +431,8 @@ function initializeVirtualCursor() {
     animation: browser-cli-pulse 1.5s ease-out infinite;
   `;
 
-  const style = document.createElement("style");
-  style.textContent = `
+    const style = document.createElement("style");
+    style.textContent = `
     @keyframes browser-cli-pulse {
       0% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
       100% { transform: translate(-50%, -50%) scale(2); opacity: 0; }
@@ -437,53 +444,53 @@ function initializeVirtualCursor() {
     }
   `;
 
-  virtualCursor.append(inner);
-  virtualCursor.append(outer);
-  document.head.append(style);
-  document.body.append(virtualCursor);
-}
-
-/**
- * Move virtual cursor to element with animation
- * @param {Element} element - Target element
- * @param {boolean} [showClick=false] - Whether to show click animation
- */
-function moveCursorToElement(element, showClick = false) {
-  if (!virtualCursor) {
-    initializeVirtualCursor();
+    virtualCursor.append(inner);
+    virtualCursor.append(outer);
+    document.head.append(style);
+    document.body.append(virtualCursor);
   }
 
-  const rect = element.getBoundingClientRect();
-  const x = rect.left + rect.width / 2;
-  const y = rect.top + rect.height / 2;
+  /**
+   * Move virtual cursor to element with animation
+   * @param {Element} element - Target element
+   * @param {boolean} [showClick=false] - Whether to show click animation
+   */
+  function moveCursorToElement(element, showClick = false) {
+    if (!virtualCursor) {
+      initializeVirtualCursor();
+    }
 
-  if (virtualCursor) {
-    virtualCursor.style.left = `${x}px`;
-    virtualCursor.style.top = `${y}px`;
-    virtualCursor.style.opacity = "1";
+    const rect = element.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
 
-    if (showClick) {
-      const inner = virtualCursor.querySelector("div:first-child");
-      if (inner && inner instanceof HTMLElement) {
-        inner.style.animation = "browser-cli-click 0.3s ease-out";
-        setTimeout(() => {
-          inner.style.animation = "";
-        }, 300);
+    if (virtualCursor) {
+      virtualCursor.style.left = `${x}px`;
+      virtualCursor.style.top = `${y}px`;
+      virtualCursor.style.opacity = "1";
+
+      if (showClick) {
+        const inner = virtualCursor.querySelector("div:first-child");
+        if (inner && inner instanceof HTMLElement) {
+          inner.style.animation = "browser-cli-click 0.3s ease-out";
+          setTimeout(() => {
+            inner.style.animation = "";
+          }, 300);
+        }
       }
     }
   }
-}
 
-// ============================================================================
-// Console Override
-// ============================================================================
+  // ============================================================================
+  // Console Override
+  // ============================================================================
 
-/**
- * Inject console override into page context to capture all logs
- */
-function injectConsoleOverride() {
-  const script = document.createElement("script");
-  script.textContent = `
+  /**
+   * Inject console override into page context to capture all logs
+   */
+  function injectConsoleOverride() {
+    const script = document.createElement("script");
+    script.textContent = `
     (function() {
       const consoleMethods = ['log', 'error', 'warn', 'info', 'debug'];
       consoleMethods.forEach(method => {
@@ -506,1805 +513,1805 @@ function injectConsoleOverride() {
       });
     })();
   `;
-  (document.head || document.documentElement).append(script);
-  script.remove();
-}
-
-window.addEventListener("message", (event) => {
-  if (event.source !== window) {
-    return;
+    (document.head || document.documentElement).append(script);
+    script.remove();
   }
 
-  if (event.data && event.data.type === "browser-cli-console") {
-    consoleLogs.push({
-      type: event.data.method,
-      message: event.data.args.join(" "),
-      timestamp: event.data.timestamp,
-    });
-
-    if (consoleLogs.length > MAX_CONSOLE_LOGS) {
-      consoleLogs.shift();
-    }
-  }
-});
-
-injectConsoleOverride();
-
-/** @type {Array<keyof Console>} */
-const consoleMethods = /** @type {any} */ ([
-  "log",
-  "error",
-  "warn",
-  "info",
-  "debug",
-]);
-for (const method of consoleMethods) {
-  // @ts-ignore
-  const original = console[method];
-  // @ts-ignore
-  console[method] = function (.../** @type {any[]} */ args) {
-    consoleLogs.push({
-      type: method,
-      message: args
-        .map((arg) => {
-          try {
-            return typeof arg === "object" ? JSON.stringify(arg) : String(arg);
-          } catch {
-            return String(arg);
-          }
-        })
-        .join(" "),
-      timestamp: new Date().toISOString(),
-    });
-
-    if (consoleLogs.length > MAX_CONSOLE_LOGS) {
-      consoleLogs.shift();
+  window.addEventListener("message", (event) => {
+    if (event.source !== window) {
+      return;
     }
 
-    original.apply(console, args);
-  };
-}
+    if (event.data && event.data.type === "browser-cli-console") {
+      consoleLogs.push({
+        type: event.data.method,
+        message: event.data.args.join(" "),
+        timestamp: event.data.timestamp,
+      });
 
-// ============================================================================
-// Element Finding Functions
-// ============================================================================
-
-/**
- * Find element by ref number
- * @param {number} ref - Reference number from snapshot
- * @returns {Element} Found element
- */
-function findByRef(ref) {
-  const element = currentRefMap.get(ref);
-  if (element) {
-    // Verify element is still in DOM
-    if (document.contains(element)) {
-      return element;
+      if (consoleLogs.length > MAX_CONSOLE_LOGS) {
+        consoleLogs.shift();
+      }
     }
-    // Element was removed, clear stale ref
-    currentRefMap.delete(ref);
+  });
+
+  injectConsoleOverride();
+
+  /** @type {Array<keyof Console>} */
+  const consoleMethods = /** @type {any} */ ([
+    "log",
+    "error",
+    "warn",
+    "info",
+    "debug",
+  ]);
+  for (const method of consoleMethods) {
+    // @ts-ignore
+    const original = console[method];
+    // @ts-ignore
+    console[method] = function (.../** @type {any[]} */ args) {
+      consoleLogs.push({
+        type: method,
+        message: args
+          .map((arg) => {
+            try {
+              return typeof arg === "object"
+                ? JSON.stringify(arg)
+                : String(arg);
+            } catch {
+              return String(arg);
+            }
+          })
+          .join(" "),
+        timestamp: new Date().toISOString(),
+      });
+
+      if (consoleLogs.length > MAX_CONSOLE_LOGS) {
+        consoleLogs.shift();
+      }
+
+      original.apply(console, args);
+    };
   }
 
-  // Build helpful error message with available refs
-  const available = [];
-  for (const [r, el] of currentRefMap) {
-    if (!document.contains(el)) {
-      continue;
+  // ============================================================================
+  // Element Finding Functions
+  // ============================================================================
+
+  /**
+   * Find element by ref number
+   * @param {number} ref - Reference number from snapshot
+   * @returns {Element} Found element
+   */
+  function findByRef(ref) {
+    const element = currentRefMap.get(ref);
+    if (element) {
+      // Verify element is still in DOM
+      if (document.contains(element)) {
+        return element;
+      }
+      // Element was removed, clear stale ref
+      currentRefMap.delete(ref);
     }
-    const role = getElementRole(el);
-    const name = getAccessibleName(el);
-    available.push(`  [${r}] ${role}${name ? ` "${name}"` : ""}`);
-    if (available.length >= 5) {
-      available.push("  ...");
-      break;
+
+    // Build helpful error message with available refs
+    const available = [];
+    for (const [r, el] of currentRefMap) {
+      if (!document.contains(el)) {
+        continue;
+      }
+      const role = getElementRole(el);
+      const name = getAccessibleName(el);
+      available.push(`  [${r}] ${role}${name ? ` "${name}"` : ""}`);
+      if (available.length >= 5) {
+        available.push("  ...");
+        break;
+      }
+    }
+
+    let msg = `Element [${ref}] not found.`;
+    msg +=
+      available.length > 0
+        ? ` Available:\n${available.join("\n")}`
+        : " No refs available. Call snap() first.";
+    throw new Error(msg);
+  }
+
+  /**
+   * Find element by CSS selector
+   * @param {string} selector - CSS selector
+   * @returns {Element} Found element
+   */
+  function findBySelector(selector) {
+    try {
+      const element = document.querySelector(selector);
+      if (element) {
+        return element;
+      }
+      throw new Error(`No element matches CSS selector: ${selector}`);
+    } catch (error) {
+      if (error instanceof Error && error.name === "SyntaxError") {
+        throw new Error(`Invalid CSS selector: ${selector}`);
+      }
+      throw error;
     }
   }
 
-  let msg = `Element [${ref}] not found.`;
-  msg +=
-    available.length > 0
-      ? ` Available:\n${available.join("\n")}`
-      : " No refs available. Call snap() first.";
-  throw new Error(msg);
-}
+  /**
+   * Find element by text content
+   * @param {string} text - Text to search for
+   * @returns {Element} Found element
+   */
+  function findByText(text) {
+    const xpath = text.includes('"')
+      ? `//*[contains(text(), '${text}')]`
+      : `//*[contains(text(), "${text}")]`;
 
-/**
- * Find element by CSS selector
- * @param {string} selector - CSS selector
- * @returns {Element} Found element
- */
-function findBySelector(selector) {
-  try {
-    const element = document.querySelector(selector);
+    const result = document.evaluate(
+      xpath,
+      document,
+      undefined,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
+    );
+    if (result.singleNodeValue && result.singleNodeValue instanceof Element) {
+      return result.singleNodeValue;
+    }
+    throw new Error(`No element found with text: ${text}`);
+  }
+
+  /**
+   * Find element by aria-label
+   * @param {string} label - ARIA label to search for
+   * @returns {Element} Found element
+   */
+  function findByAriaLabel(label) {
+    const element = document.querySelector(
+      `[aria-label="${CSS.escape(label)}"]`,
+    );
     if (element) {
       return element;
     }
-    throw new Error(`No element matches CSS selector: ${selector}`);
-  } catch (error) {
-    if (error instanceof Error && error.name === "SyntaxError") {
-      throw new Error(`Invalid CSS selector: ${selector}`);
-    }
-    throw error;
-  }
-}
-
-/**
- * Find element by text content
- * @param {string} text - Text to search for
- * @returns {Element} Found element
- */
-function findByText(text) {
-  const xpath = text.includes('"')
-    ? `//*[contains(text(), '${text}')]`
-    : `//*[contains(text(), "${text}")]`;
-
-  const result = document.evaluate(
-    xpath,
-    document,
-    undefined,
-    XPathResult.FIRST_ORDERED_NODE_TYPE,
-  );
-  if (result.singleNodeValue && result.singleNodeValue instanceof Element) {
-    return result.singleNodeValue;
-  }
-  throw new Error(`No element found with text: ${text}`);
-}
-
-/**
- * Find element by aria-label
- * @param {string} label - ARIA label to search for
- * @returns {Element} Found element
- */
-function findByAriaLabel(label) {
-  const element = document.querySelector(`[aria-label="${CSS.escape(label)}"]`);
-  if (element) {
-    return element;
-  }
-  throw new Error(`No element found with aria-label: ${label}`);
-}
-
-/**
- * Find element by placeholder
- * @param {string} placeholder - Placeholder text to search for
- * @returns {Element} Found element
- */
-function findByPlaceholder(placeholder) {
-  const element = document.querySelector(
-    `[placeholder="${CSS.escape(placeholder)}"]`,
-  );
-  if (element) {
-    return element;
-  }
-  throw new Error(`No element found with placeholder: ${placeholder}`);
-}
-
-/**
- * Find element based on selector type or ref
- * @param {string|number} selector - The selector value or ref number
- * @param {SelectorType} [selectorType='css'] - Type of selector
- * @returns {Element} Found element
- */
-function find(selector, selectorType = "css") {
-  // If selector is a number, treat as ref
-  if (typeof selector === "number") {
-    return findByRef(selector);
+    throw new Error(`No element found with aria-label: ${label}`);
   }
 
-  switch (selectorType) {
-    case "css": {
-      return findBySelector(selector);
+  /**
+   * Find element by placeholder
+   * @param {string} placeholder - Placeholder text to search for
+   * @returns {Element} Found element
+   */
+  function findByPlaceholder(placeholder) {
+    const element = document.querySelector(
+      `[placeholder="${CSS.escape(placeholder)}"]`,
+    );
+    if (element) {
+      return element;
     }
-    case "text": {
-      return findByText(selector);
-    }
-    case "aria-label": {
-      return findByAriaLabel(selector);
-    }
-    case "placeholder": {
-      return findByPlaceholder(selector);
-    }
-    default: {
-      throw new Error(`Unknown selector type: ${selectorType}`);
-    }
-  }
-}
-
-// ============================================================================
-// Snapshot Generation
-// ============================================================================
-
-/**
- * Get the role of an element
- * @param {Element} element
- * @returns {string}
- */
-function getElementRole(element) {
-  const explicitRole = element.getAttribute("role");
-  if (explicitRole) {
-    return explicitRole;
+    throw new Error(`No element found with placeholder: ${placeholder}`);
   }
 
-  const tag = element.tagName.toLowerCase();
-
-  // Map common tags to roles
-  const tagRoleMap = {
-    a: "link",
-    button: "button",
-    input: "input",
-    textarea: "textarea",
-    select: "select",
-    img: "img",
-    h1: "heading",
-    h2: "heading",
-    h3: "heading",
-    h4: "heading",
-    h5: "heading",
-    h6: "heading",
-    nav: "navigation",
-    main: "main",
-    header: "banner",
-    footer: "contentinfo",
-    aside: "complementary",
-    form: "form",
-    table: "table",
-    ul: "list",
-    ol: "list",
-    li: "listitem",
-  };
-
-  if (tag === "input") {
-    const type = element.getAttribute("type") || "text";
-    if (type === "checkbox") {
-      return "checkbox";
+  /**
+   * Find element based on selector type or ref
+   * @param {string|number} selector - The selector value or ref number
+   * @param {SelectorType} [selectorType='css'] - Type of selector
+   * @returns {Element} Found element
+   */
+  function find(selector, selectorType = "css") {
+    // If selector is a number, treat as ref
+    if (typeof selector === "number") {
+      return findByRef(selector);
     }
-    if (type === "radio") {
-      return "radio";
-    }
-    if (type === "submit" || type === "button") {
-      return "button";
-    }
-    return `input[${type}]`;
-  }
 
-  return /** @type {Record<string, string>} */ (tagRoleMap)[tag] || tag;
-}
-
-/**
- * Get accessible name of an element
- * @param {Element} element
- * @returns {string}
- */
-function getAccessibleName(element) {
-  // aria-label takes precedence
-  const ariaLabel = element.getAttribute("aria-label");
-  if (ariaLabel) {
-    return ariaLabel;
-  }
-
-  // aria-labelledby
-  const labelledBy = element.getAttribute("aria-labelledby");
-  if (labelledBy) {
-    const labelEl = document.querySelector(`#${CSS.escape(labelledBy)}`);
-    if (labelEl) {
-      return labelEl.textContent?.trim() || "";
+    switch (selectorType) {
+      case "css": {
+        return findBySelector(selector);
+      }
+      case "text": {
+        return findByText(selector);
+      }
+      case "aria-label": {
+        return findByAriaLabel(selector);
+      }
+      case "placeholder": {
+        return findByPlaceholder(selector);
+      }
+      default: {
+        throw new Error(`Unknown selector type: ${selectorType}`);
+      }
     }
   }
 
-  // For inputs, check associated label
-  if (
-    element instanceof HTMLInputElement ||
-    element instanceof HTMLTextAreaElement ||
-    element instanceof HTMLSelectElement
-  ) {
-    // Check for label wrapping the input
-    const parentLabel = element.closest("label");
-    if (parentLabel) {
-      const text = parentLabel.textContent?.trim() || "";
+  // ============================================================================
+  // Snapshot Generation
+  // ============================================================================
+
+  /**
+   * Get the role of an element
+   * @param {Element} element
+   * @returns {string}
+   */
+  function getElementRole(element) {
+    const explicitRole = element.getAttribute("role");
+    if (explicitRole) {
+      return explicitRole;
+    }
+
+    const tag = element.tagName.toLowerCase();
+
+    // Map common tags to roles
+    const tagRoleMap = {
+      a: "link",
+      button: "button",
+      input: "input",
+      textarea: "textarea",
+      select: "select",
+      img: "img",
+      h1: "heading",
+      h2: "heading",
+      h3: "heading",
+      h4: "heading",
+      h5: "heading",
+      h6: "heading",
+      nav: "navigation",
+      main: "main",
+      header: "banner",
+      footer: "contentinfo",
+      aside: "complementary",
+      form: "form",
+      table: "table",
+      ul: "list",
+      ol: "list",
+      li: "listitem",
+    };
+
+    if (tag === "input") {
+      const type = element.getAttribute("type") || "text";
+      if (type === "checkbox") {
+        return "checkbox";
+      }
+      if (type === "radio") {
+        return "radio";
+      }
+      if (type === "submit" || type === "button") {
+        return "button";
+      }
+      return `input[${type}]`;
+    }
+
+    return /** @type {Record<string, string>} */ (tagRoleMap)[tag] || tag;
+  }
+
+  /**
+   * Get accessible name of an element
+   * @param {Element} element
+   * @returns {string}
+   */
+  function getAccessibleName(element) {
+    // aria-label takes precedence
+    const ariaLabel = element.getAttribute("aria-label");
+    if (ariaLabel) {
+      return ariaLabel;
+    }
+
+    // aria-labelledby
+    const labelledBy = element.getAttribute("aria-labelledby");
+    if (labelledBy) {
+      const labelEl = document.querySelector(`#${CSS.escape(labelledBy)}`);
+      if (labelEl) {
+        return labelEl.textContent?.trim() || "";
+      }
+    }
+
+    // For inputs, check associated label
+    if (
+      element instanceof HTMLInputElement ||
+      element instanceof HTMLTextAreaElement ||
+      element instanceof HTMLSelectElement
+    ) {
+      // Check for label wrapping the input
+      const parentLabel = element.closest("label");
+      if (parentLabel) {
+        const text = parentLabel.textContent?.trim() || "";
+        return text;
+      }
+
+      // Check for label with for attribute
+      if (element.id) {
+        const label = document.querySelector(
+          `label[for="${CSS.escape(element.id)}"]`,
+        );
+        if (label) {
+          return label.textContent?.trim() || "";
+        }
+      }
+
+      // Fall back to placeholder
+      const placeholder = element.getAttribute("placeholder");
+      if (placeholder) {
+        return placeholder;
+      }
+    }
+
+    // alt text for images
+    if (element instanceof HTMLImageElement) {
+      return element.alt || "";
+    }
+
+    // title attribute
+    const title = element.getAttribute("title");
+    if (title) {
+      return title;
+    }
+
+    // Text content for buttons, links, etc.
+    const tag = element.tagName.toLowerCase();
+    if (["button", "a", "h1", "h2", "h3", "h4", "h5", "h6"].includes(tag)) {
+      // Get text content excluding script/style elements
+      let text = "";
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) => {
+          const parent = node.parentElement;
+          if (
+            parent &&
+            ["SCRIPT", "STYLE", "NOSCRIPT"].includes(parent.tagName)
+          ) {
+            return NodeFilter.FILTER_REJECT;
+          }
+          return NodeFilter.FILTER_ACCEPT;
+        },
+      });
+      while (walker.nextNode()) {
+        text += walker.currentNode.textContent;
+      }
+      text = text.trim();
+      // Filter out CSS-looking content (starts with . or # followed by { or contains {)
+      if (text && /^\s*[.#]?[\w-]+\s*\{/.test(text)) {
+        return "";
+      }
       return text;
     }
 
-    // Check for label with for attribute
-    if (element.id) {
-      const label = document.querySelector(
-        `label[for="${CSS.escape(element.id)}"]`,
-      );
-      if (label) {
-        return label.textContent?.trim() || "";
+    return "";
+  }
+
+  /**
+   * Get element attributes for display
+   * @param {Element} element
+   * @returns {string[]}
+   */
+  function getElementAttrs(element) {
+    const attrs = [];
+
+    // Disabled state
+    if (
+      element.hasAttribute("disabled") ||
+      element.getAttribute("aria-disabled") === "true"
+    ) {
+      attrs.push("disabled");
+    }
+
+    // Checked state for checkboxes/radios
+    if (
+      element instanceof HTMLInputElement &&
+      (element.type === "checkbox" || element.type === "radio") &&
+      element.checked
+    ) {
+      attrs.push("checked");
+    }
+
+    // Required
+    if (
+      element.hasAttribute("required") ||
+      element.getAttribute("aria-required") === "true"
+    ) {
+      attrs.push("required");
+    }
+
+    // Expanded/collapsed
+    const expanded = element.getAttribute("aria-expanded");
+    if (expanded === "true") {
+      attrs.push("expanded");
+    }
+    if (expanded === "false") {
+      attrs.push("collapsed");
+    }
+
+    // Readonly
+    if (element.hasAttribute("readonly")) {
+      attrs.push("readonly");
+    }
+
+    // Clickable (for non-obvious elements)
+    const tag = element.tagName.toLowerCase();
+    if (
+      !["a", "button", "input", "select", "textarea"].includes(tag) &&
+      (element.getAttribute("onclick") ||
+        element.getAttribute("role") === "button" ||
+        window.getComputedStyle(element).cursor === "pointer")
+    ) {
+      attrs.push("clickable");
+    }
+
+    return attrs;
+  }
+
+  /**
+   * Get element value
+   * @param {Element} element
+   * @returns {string|undefined}
+   */
+  function getElementValue(element) {
+    if (element instanceof HTMLInputElement) {
+      if (element.type === "checkbox" || element.type === "radio") {
+        return; // Use checked attr instead
       }
-    }
-
-    // Fall back to placeholder
-    const placeholder = element.getAttribute("placeholder");
-    if (placeholder) {
-      return placeholder;
-    }
-  }
-
-  // alt text for images
-  if (element instanceof HTMLImageElement) {
-    return element.alt || "";
-  }
-
-  // title attribute
-  const title = element.getAttribute("title");
-  if (title) {
-    return title;
-  }
-
-  // Text content for buttons, links, etc.
-  const tag = element.tagName.toLowerCase();
-  if (["button", "a", "h1", "h2", "h3", "h4", "h5", "h6"].includes(tag)) {
-    // Get text content excluding script/style elements
-    let text = "";
-    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, {
-      acceptNode: (node) => {
-        const parent = node.parentElement;
-        if (
-          parent &&
-          ["SCRIPT", "STYLE", "NOSCRIPT"].includes(parent.tagName)
-        ) {
-          return NodeFilter.FILTER_REJECT;
-        }
-        return NodeFilter.FILTER_ACCEPT;
-      },
-    });
-    while (walker.nextNode()) {
-      text += walker.currentNode.textContent;
-    }
-    text = text.trim();
-    // Filter out CSS-looking content (starts with . or # followed by { or contains {)
-    if (text && /^\s*[.#]?[\w-]+\s*\{/.test(text)) {
-      return "";
-    }
-    return text;
-  }
-
-  return "";
-}
-
-/**
- * Get element attributes for display
- * @param {Element} element
- * @returns {string[]}
- */
-function getElementAttrs(element) {
-  const attrs = [];
-
-  // Disabled state
-  if (
-    element.hasAttribute("disabled") ||
-    element.getAttribute("aria-disabled") === "true"
-  ) {
-    attrs.push("disabled");
-  }
-
-  // Checked state for checkboxes/radios
-  if (
-    element instanceof HTMLInputElement &&
-    (element.type === "checkbox" || element.type === "radio") &&
-    element.checked
-  ) {
-    attrs.push("checked");
-  }
-
-  // Required
-  if (
-    element.hasAttribute("required") ||
-    element.getAttribute("aria-required") === "true"
-  ) {
-    attrs.push("required");
-  }
-
-  // Expanded/collapsed
-  const expanded = element.getAttribute("aria-expanded");
-  if (expanded === "true") {
-    attrs.push("expanded");
-  }
-  if (expanded === "false") {
-    attrs.push("collapsed");
-  }
-
-  // Readonly
-  if (element.hasAttribute("readonly")) {
-    attrs.push("readonly");
-  }
-
-  // Clickable (for non-obvious elements)
-  const tag = element.tagName.toLowerCase();
-  if (
-    !["a", "button", "input", "select", "textarea"].includes(tag) &&
-    (element.getAttribute("onclick") ||
-      element.getAttribute("role") === "button" ||
-      window.getComputedStyle(element).cursor === "pointer")
-  ) {
-    attrs.push("clickable");
-  }
-
-  return attrs;
-}
-
-/**
- * Get element value
- * @param {Element} element
- * @returns {string|undefined}
- */
-function getElementValue(element) {
-  if (element instanceof HTMLInputElement) {
-    if (element.type === "checkbox" || element.type === "radio") {
-      return; // Use checked attr instead
-    }
-    if (element.type === "password") {
-      return element.value ? "••••••" : "";
-    }
-    return element.value;
-  }
-
-  if (element instanceof HTMLTextAreaElement) {
-    return element.value;
-  }
-
-  if (element instanceof HTMLSelectElement) {
-    const selected = element.options[element.selectedIndex];
-    return selected ? selected.text : "";
-  }
-}
-
-/**
- * Check if element should be included in snapshot
- * @param {Element} element
- * @returns {boolean}
- */
-function shouldIncludeElement(element) {
-  // Skip hidden elements
-  const style = window.getComputedStyle(element);
-  if (style.display === "none" || style.visibility === "hidden") {
-    return false;
-  }
-
-  // Skip zero-size elements
-  const rect = element.getBoundingClientRect();
-  if (rect.width === 0 && rect.height === 0) {
-    return false;
-  }
-
-  // Skip script, style, noscript, template
-  const tag = element.tagName.toLowerCase();
-  if (
-    ["script", "style", "noscript", "template", "svg", "path"].includes(tag)
-  ) {
-    return false;
-  }
-
-  // Include interactive elements
-  if (["a", "button", "input", "textarea", "select"].includes(tag)) {
-    return true;
-  }
-
-  // Include elements with explicit roles
-  if (element.hasAttribute("role")) {
-    const role = element.getAttribute("role");
-    if (role && !["presentation", "none"].includes(role)) {
-      return true;
-    }
-  }
-
-  // Include headings
-  if (["h1", "h2", "h3", "h4", "h5", "h6"].includes(tag)) {
-    return true;
-  }
-
-  // Include landmarks
-  if (["nav", "main", "header", "footer", "aside", "form"].includes(tag)) {
-    return true;
-  }
-
-  // Include images with alt text
-  if (tag === "img" && element.getAttribute("alt")) {
-    return true;
-  }
-
-  // Include elements with onclick attribute
-  if (element.getAttribute("onclick")) {
-    return true;
-  }
-
-  // Include elements with aria-label
-  if (element.hasAttribute("aria-label")) {
-    return true;
-  }
-
-  // For cursor:pointer elements, only include if they:
-  // 1. Have a meaningful accessible name (not empty, not just whitespace)
-  // 2. Are not generic wrapper tags (div, span, g, rect, circle, etc.)
-  // 3. Or have tabindex making them keyboard-focusable
-  if (window.getComputedStyle(element).cursor === "pointer") {
-    const genericTags = [
-      "div",
-      "span",
-      "g",
-      "rect",
-      "circle",
-      "path",
-      "svg",
-      "text",
-      "br",
-      "hr",
-      "b",
-      "i",
-      "em",
-      "strong",
-    ];
-    if (genericTags.includes(tag)) {
-      // Only include generic clickable if it has tabindex or meaningful name
-      if (
-        element.hasAttribute("tabindex") &&
-        element.getAttribute("tabindex") !== "-1"
-      ) {
-        return true;
+      if (element.type === "password") {
+        return element.value ? "••••••" : "";
       }
-      // Check for meaningful accessible name
-      const name = getAccessibleName(element);
-      if (name && name.length > 0 && name.length < 200 && !/^\s*$/.test(name)) {
-        return true;
-      }
+      return element.value;
+    }
+
+    if (element instanceof HTMLTextAreaElement) {
+      return element.value;
+    }
+
+    if (element instanceof HTMLSelectElement) {
+      const selected = element.options[element.selectedIndex];
+      return selected ? selected.text : "";
+    }
+  }
+
+  /**
+   * Check if element should be included in snapshot
+   * @param {Element} element
+   * @returns {boolean}
+   */
+  function shouldIncludeElement(element) {
+    // Skip hidden elements
+    const style = window.getComputedStyle(element);
+    if (style.display === "none" || style.visibility === "hidden") {
       return false;
     }
-    return true;
+
+    // Skip zero-size elements
+    const rect = element.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      return false;
+    }
+
+    // Skip script, style, noscript, template
+    const tag = element.tagName.toLowerCase();
+    if (
+      ["script", "style", "noscript", "template", "svg", "path"].includes(tag)
+    ) {
+      return false;
+    }
+
+    // Include interactive elements
+    if (["a", "button", "input", "textarea", "select"].includes(tag)) {
+      return true;
+    }
+
+    // Include elements with explicit roles
+    if (element.hasAttribute("role")) {
+      const role = element.getAttribute("role");
+      if (role && !["presentation", "none"].includes(role)) {
+        return true;
+      }
+    }
+
+    // Include headings
+    if (["h1", "h2", "h3", "h4", "h5", "h6"].includes(tag)) {
+      return true;
+    }
+
+    // Include landmarks
+    if (["nav", "main", "header", "footer", "aside", "form"].includes(tag)) {
+      return true;
+    }
+
+    // Include images with alt text
+    if (tag === "img" && element.getAttribute("alt")) {
+      return true;
+    }
+
+    // Include elements with onclick attribute
+    if (element.getAttribute("onclick")) {
+      return true;
+    }
+
+    // Include elements with aria-label
+    if (element.hasAttribute("aria-label")) {
+      return true;
+    }
+
+    // For cursor:pointer elements, only include if they:
+    // 1. Have a meaningful accessible name (not empty, not just whitespace)
+    // 2. Are not generic wrapper tags (div, span, g, rect, circle, etc.)
+    // 3. Or have tabindex making them keyboard-focusable
+    if (window.getComputedStyle(element).cursor === "pointer") {
+      const genericTags = [
+        "div",
+        "span",
+        "g",
+        "rect",
+        "circle",
+        "path",
+        "svg",
+        "text",
+        "br",
+        "hr",
+        "b",
+        "i",
+        "em",
+        "strong",
+      ];
+      if (genericTags.includes(tag)) {
+        // Only include generic clickable if it has tabindex or meaningful name
+        if (
+          element.hasAttribute("tabindex") &&
+          element.getAttribute("tabindex") !== "-1"
+        ) {
+          return true;
+        }
+        // Check for meaningful accessible name
+        const name = getAccessibleName(element);
+        if (
+          name &&
+          name.length > 0 &&
+          name.length < 200 &&
+          !/^\s*$/.test(name)
+        ) {
+          return true;
+        }
+        return false;
+      }
+      return true;
+    }
+
+    return false;
   }
 
-  return false;
-}
+  /**
+   * @typedef {object} SnapOptions
+   * @property {boolean} [forms] - Only form elements
+   * @property {boolean} [links] - Only links
+   * @property {boolean} [buttons] - Only buttons
+   * @property {string} [text] - Filter by text content
+   * @property {number} [near] - Elements near ref
+   */
 
-/**
- * @typedef {object} SnapOptions
- * @property {boolean} [forms] - Only form elements
- * @property {boolean} [links] - Only links
- * @property {boolean} [buttons] - Only buttons
- * @property {string} [text] - Filter by text content
- * @property {number} [near] - Elements near ref
- */
+  /**
+   * Generate snapshot with optional filtering
+   * @param {SnapOptions} [options]
+   * @returns {Snapshot}
+   */
+  function generateSnapshot(options = {}) {
+    const elements = [];
+    let ref = 1;
 
-/**
- * Generate snapshot with optional filtering
- * @param {SnapOptions} [options]
- * @returns {Snapshot}
- */
-function generateSnapshot(options = {}) {
-  const elements = [];
-  let ref = 1;
+    // Clear old ref map
+    currentRefMap = new Map();
 
-  // Clear old ref map
-  currentRefMap = new Map();
+    // Collect all relevant elements
+    const allElements = document.body.querySelectorAll("*");
 
-  // Collect all relevant elements
-  const allElements = document.body.querySelectorAll("*");
+    for (const element of allElements) {
+      if (!shouldIncludeElement(element)) {
+        continue;
+      }
 
-  for (const element of allElements) {
-    if (!shouldIncludeElement(element)) {
-      continue;
-    }
+      const role = getElementRole(element);
+      const name = getAccessibleName(element);
+      const attrs = getElementAttrs(element);
+      const value = getElementValue(element);
 
-    const role = getElementRole(element);
-    const name = getAccessibleName(element);
-    const attrs = getElementAttrs(element);
-    const value = getElementValue(element);
-
-    // Apply filters
-    if (
-      options.forms &&
-      !["input", "textarea", "select", "checkbox", "radio"].includes(role) &&
-      !role.startsWith("input[")
-    ) {
-      continue;
-    }
-
-    if (options.links && role !== "link") {
-      continue;
-    }
-    if (options.buttons && role !== "button") {
-      continue;
-    }
-
-    if (options.text) {
-      const searchText = options.text.toLowerCase();
+      // Apply filters
       if (
-        !name.toLowerCase().includes(searchText) &&
-        !(value && value.toLowerCase().includes(searchText))
+        options.forms &&
+        !["input", "textarea", "select", "checkbox", "radio"].includes(role) &&
+        !role.startsWith("input[")
       ) {
         continue;
       }
+
+      if (options.links && role !== "link") {
+        continue;
+      }
+      if (options.buttons && role !== "button") {
+        continue;
+      }
+
+      if (options.text) {
+        const searchText = options.text.toLowerCase();
+        if (
+          !name.toLowerCase().includes(searchText) &&
+          !(value && value.toLowerCase().includes(searchText))
+        ) {
+          continue;
+        }
+      }
+
+      const snapshotElement = new SnapshotElement({
+        ref,
+        role,
+        name,
+        value,
+        attrs,
+        domElement: element,
+      });
+
+      elements.push(snapshotElement);
+      currentRefMap.set(ref, element);
+      ref++;
     }
 
-    const snapshotElement = new SnapshotElement({
-      ref,
-      role,
-      name,
-      value,
-      attrs,
-      domElement: element,
+    // Handle "near" filter - find elements near a reference element
+    if (options.near === undefined) {
+      return new Snapshot(elements, window.location.href, document.title);
+    }
+
+    const nearElement = currentRefMap.get(options.near);
+    if (!nearElement) {
+      return new Snapshot(elements, window.location.href, document.title);
+    }
+
+    const nearRect = nearElement.getBoundingClientRect();
+    const threshold = 200; // pixels
+
+    const filtered = elements.filter((el) => {
+      const rect = el.domElement.getBoundingClientRect();
+      const distance = Math.hypot(
+        rect.left - nearRect.left,
+        rect.top - nearRect.top,
+      );
+      return distance < threshold;
     });
 
-    elements.push(snapshotElement);
-    currentRefMap.set(ref, element);
-    ref++;
+    return new Snapshot(filtered, window.location.href, document.title);
   }
 
-  // Handle "near" filter - find elements near a reference element
-  if (options.near === undefined) {
-    return new Snapshot(elements, window.location.href, document.title);
-  }
+  // ============================================================================
+  // JS API - Main Functions
+  // ============================================================================
 
-  const nearElement = currentRefMap.get(options.near);
-  if (!nearElement) {
-    return new Snapshot(elements, window.location.href, document.title);
-  }
+  /**
+   * Click an element
+   * @param {string|number} selector - Element selector or ref number
+   * @param {SelectorType|{double?: boolean}} [selectorTypeOrOptions='css']
+   * @returns {Promise<{clicked: string|number}>}
+   */
+  async function click(selector, selectorTypeOrOptions = "css") {
+    let selectorType = "css";
+    let double = false;
 
-  const nearRect = nearElement.getBoundingClientRect();
-  const threshold = 200; // pixels
+    if (typeof selectorTypeOrOptions === "object") {
+      double = selectorTypeOrOptions.double || false;
+    } else {
+      selectorType = selectorTypeOrOptions;
+    }
 
-  const filtered = elements.filter((el) => {
-    const rect = el.domElement.getBoundingClientRect();
-    const distance = Math.hypot(
-      rect.left - nearRect.left,
-      rect.top - nearRect.top,
+    const element = /** @type {HTMLElement} */ (
+      find(selector, /** @type {SelectorType} */ (selectorType))
     );
-    return distance < threshold;
-  });
+    moveCursorToElement(element, true);
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
-  return new Snapshot(filtered, window.location.href, document.title);
-}
+    if (double) {
+      element.dispatchEvent(
+        new MouseEvent("dblclick", {
+          view: window,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    } else {
+      element.click();
+    }
 
-// ============================================================================
-// JS API - Main Functions
-// ============================================================================
+    if (element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
+      lastFocusedInput = /** @type {HTMLInputElement|HTMLTextAreaElement} */ (
+        element
+      );
+    }
 
-/**
- * Click an element
- * @param {string|number} selector - Element selector or ref number
- * @param {SelectorType|{double?: boolean}} [selectorTypeOrOptions='css']
- * @returns {Promise<{clicked: string|number}>}
- */
-async function click(selector, selectorTypeOrOptions = "css") {
-  let selectorType = "css";
-  let double = false;
-
-  if (typeof selectorTypeOrOptions === "object") {
-    double = selectorTypeOrOptions.double || false;
-  } else {
-    selectorType = selectorTypeOrOptions;
+    return { clicked: selector };
   }
 
-  const element = /** @type {HTMLElement} */ (
-    find(selector, /** @type {SelectorType} */ (selectorType))
-  );
-  moveCursorToElement(element, true);
-  await new Promise((resolve) => setTimeout(resolve, 300));
+  /**
+   * Type text into an element
+   * @param {string|number} selector - Element selector or ref number
+   * @param {string} text - Text to type
+   * @param {SelectorType|{clear?: boolean}} [selectorTypeOrOptions='css']
+   * @returns {Promise<{typed: string, into: string|number}>}
+   */
+  async function type(selector, text, selectorTypeOrOptions = "css") {
+    let selectorType = "css";
+    let clear = false;
 
-  if (double) {
+    if (typeof selectorTypeOrOptions === "object") {
+      clear = selectorTypeOrOptions.clear || false;
+    } else {
+      selectorType = selectorTypeOrOptions;
+    }
+
+    const element = /** @type {HTMLInputElement|HTMLTextAreaElement} */ (
+      find(selector, /** @type {SelectorType} */ (selectorType))
+    );
+
+    if (element.tagName !== "INPUT" && element.tagName !== "TEXTAREA") {
+      throw new Error(
+        `Element is not an input field. Found: <${element.tagName.toLowerCase()}>`,
+      );
+    }
+
+    moveCursorToElement(element);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    element.focus();
+    lastFocusedInput = element;
+
+    if (clear) {
+      element.value = "";
+    }
+
+    element.value = clear ? text : element.value + text;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+
+    return { typed: text, into: selector };
+  }
+
+  /**
+   * Hover over an element
+   * @param {string|number} selector - Element selector or ref number
+   * @param {SelectorType} [selectorType='css'] - Type of selector
+   * @returns {Promise<{hovered: string|number}>}
+   */
+  async function hover(selector, selectorType = "css") {
+    const element = find(selector, selectorType);
+    moveCursorToElement(element);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
     element.dispatchEvent(
-      new MouseEvent("dblclick", {
+      new MouseEvent("mouseenter", {
         view: window,
         bubbles: true,
         cancelable: true,
       }),
     );
-  } else {
-    element.click();
-  }
-
-  if (element.tagName === "INPUT" || element.tagName === "TEXTAREA") {
-    lastFocusedInput = /** @type {HTMLInputElement|HTMLTextAreaElement} */ (
-      element
+    element.dispatchEvent(
+      new MouseEvent("mouseover", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      }),
     );
+
+    return { hovered: selector };
   }
 
-  return { clicked: selector };
-}
+  /**
+   * Drag from one element to another
+   * @param {string|number} startSelector - Start element selector or ref
+   * @param {string|number} endSelector - End element selector or ref
+   * @param {SelectorType} [selectorType='css'] - Type of selector
+   * @returns {Promise<{dragged: string|number, to: string|number}>}
+   */
+  async function drag(startSelector, endSelector, selectorType = "css") {
+    const startElement = find(startSelector, selectorType);
+    const endElement = find(endSelector, selectorType);
 
-/**
- * Type text into an element
- * @param {string|number} selector - Element selector or ref number
- * @param {string} text - Text to type
- * @param {SelectorType|{clear?: boolean}} [selectorTypeOrOptions='css']
- * @returns {Promise<{typed: string, into: string|number}>}
- */
-async function type(selector, text, selectorTypeOrOptions = "css") {
-  let selectorType = "css";
-  let clear = false;
+    const startRect = startElement.getBoundingClientRect();
+    const endRect = endElement.getBoundingClientRect();
+    const startX = startRect.left + startRect.width / 2;
+    const startY = startRect.top + startRect.height / 2;
+    const endX = endRect.left + endRect.width / 2;
+    const endY = endRect.top + endRect.height / 2;
 
-  if (typeof selectorTypeOrOptions === "object") {
-    clear = selectorTypeOrOptions.clear || false;
-  } else {
-    selectorType = selectorTypeOrOptions;
-  }
+    moveCursorToElement(startElement, true);
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
-  const element = /** @type {HTMLInputElement|HTMLTextAreaElement} */ (
-    find(selector, /** @type {SelectorType} */ (selectorType))
-  );
+    const dataTransfer = new DataTransfer();
+    dataTransfer.effectAllowed = "all";
+    dataTransfer.dropEffect = "move";
 
-  if (element.tagName !== "INPUT" && element.tagName !== "TEXTAREA") {
-    throw new Error(
-      `Element is not an input field. Found: <${element.tagName.toLowerCase()}>`,
+    startElement.dispatchEvent(
+      new MouseEvent("mousedown", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+        clientX: startX,
+        clientY: startY,
+      }),
     );
-  }
 
-  moveCursorToElement(element);
-  await new Promise((resolve) => setTimeout(resolve, 300));
-  element.focus();
-  lastFocusedInput = element;
-
-  if (clear) {
-    element.value = "";
-  }
-
-  element.value = clear ? text : element.value + text;
-  element.dispatchEvent(new Event("input", { bubbles: true }));
-  element.dispatchEvent(new Event("change", { bubbles: true }));
-
-  return { typed: text, into: selector };
-}
-
-/**
- * Hover over an element
- * @param {string|number} selector - Element selector or ref number
- * @param {SelectorType} [selectorType='css'] - Type of selector
- * @returns {Promise<{hovered: string|number}>}
- */
-async function hover(selector, selectorType = "css") {
-  const element = find(selector, selectorType);
-  moveCursorToElement(element);
-  await new Promise((resolve) => setTimeout(resolve, 300));
-
-  element.dispatchEvent(
-    new MouseEvent("mouseenter", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-  element.dispatchEvent(
-    new MouseEvent("mouseover", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-    }),
-  );
-
-  return { hovered: selector };
-}
-
-/**
- * Drag from one element to another
- * @param {string|number} startSelector - Start element selector or ref
- * @param {string|number} endSelector - End element selector or ref
- * @param {SelectorType} [selectorType='css'] - Type of selector
- * @returns {Promise<{dragged: string|number, to: string|number}>}
- */
-async function drag(startSelector, endSelector, selectorType = "css") {
-  const startElement = find(startSelector, selectorType);
-  const endElement = find(endSelector, selectorType);
-
-  const startRect = startElement.getBoundingClientRect();
-  const endRect = endElement.getBoundingClientRect();
-  const startX = startRect.left + startRect.width / 2;
-  const startY = startRect.top + startRect.height / 2;
-  const endX = endRect.left + endRect.width / 2;
-  const endY = endRect.top + endRect.height / 2;
-
-  moveCursorToElement(startElement, true);
-  await new Promise((resolve) => setTimeout(resolve, 300));
-
-  const dataTransfer = new DataTransfer();
-  dataTransfer.effectAllowed = "all";
-  dataTransfer.dropEffect = "move";
-
-  startElement.dispatchEvent(
-    new MouseEvent("mousedown", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      clientX: startX,
-      clientY: startY,
-    }),
-  );
-
-  startElement.dispatchEvent(
-    new DragEvent("dragstart", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      clientX: startX,
-      clientY: startY,
-      dataTransfer,
-    }),
-  );
-
-  if (virtualCursor) {
-    virtualCursor.style.transition = "all 0.8s cubic-bezier(0.4, 0, 0.2, 1)";
-    moveCursorToElement(endElement);
-    await new Promise((resolve) => setTimeout(resolve, 800));
-  }
-
-  endElement.dispatchEvent(
-    new DragEvent("dragenter", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      clientX: endX,
-      clientY: endY,
-      dataTransfer,
-    }),
-  );
-
-  endElement.dispatchEvent(
-    new DragEvent("dragover", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      clientX: endX,
-      clientY: endY,
-      dataTransfer,
-    }),
-  );
-
-  await new Promise((resolve) => setTimeout(resolve, 50));
-
-  endElement.dispatchEvent(
-    new DragEvent("drop", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      clientX: endX,
-      clientY: endY,
-      dataTransfer,
-    }),
-  );
-
-  startElement.dispatchEvent(
-    new DragEvent("dragend", {
-      view: window,
-      bubbles: true,
-      cancelable: true,
-      clientX: endX,
-      clientY: endY,
-      dataTransfer,
-    }),
-  );
-
-  if (virtualCursor) {
-    virtualCursor.style.transition = "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)";
-  }
-
-  return { dragged: startSelector, to: endSelector };
-}
-
-/**
- * Select an option in a dropdown
- * @param {string|number} selector - Select element selector or ref
- * @param {string} option - Option value to select
- * @param {SelectorType} [selectorType='css'] - Type of selector
- * @returns {Promise<{selected: string, in: string|number}>}
- */
-async function select(selector, option, selectorType = "css") {
-  const element = /** @type {HTMLSelectElement} */ (
-    find(selector, selectorType)
-  );
-  if (element.tagName !== "SELECT") {
-    throw new Error(
-      `Element is not a select field. Found: <${element.tagName.toLowerCase()}>`,
+    startElement.dispatchEvent(
+      new DragEvent("dragstart", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+        clientX: startX,
+        clientY: startY,
+        dataTransfer,
+      }),
     );
-  }
-  moveCursorToElement(element, true);
-  await new Promise((resolve) => setTimeout(resolve, 300));
-  element.value = option;
-  element.dispatchEvent(new Event("change", { bubbles: true }));
 
-  return { selected: option, in: selector };
-}
-
-/**
- * Press a keyboard key
- * @param {string} keyName - Key to press
- * @returns {Snapshot}
- */
-/** @type {Record<string, {code: string, keyCode: number}>} */
-const SPECIAL_KEYS = {
-  Enter: { code: "Enter", keyCode: 13 },
-  Tab: { code: "Tab", keyCode: 9 },
-  Escape: { code: "Escape", keyCode: 27 },
-  Backspace: { code: "Backspace", keyCode: 8 },
-  Delete: { code: "Delete", keyCode: 46 },
-  ArrowUp: { code: "ArrowUp", keyCode: 38 },
-  ArrowDown: { code: "ArrowDown", keyCode: 40 },
-  ArrowLeft: { code: "ArrowLeft", keyCode: 37 },
-  ArrowRight: { code: "ArrowRight", keyCode: 39 },
-  Home: { code: "Home", keyCode: 36 },
-  End: { code: "End", keyCode: 35 },
-  PageUp: { code: "PageUp", keyCode: 33 },
-  PageDown: { code: "PageDown", keyCode: 34 },
-  " ": { code: "Space", keyCode: 32 },
-  Space: { code: "Space", keyCode: 32 },
-};
-
-const TEXT_INPUT_TYPES = new Set([
-  "text",
-  "search",
-  "email",
-  "password",
-  "tel",
-  "url",
-  "number",
-]);
-
-/**
- * Build keyboard event options for a key
- * @param {string} keyName
- * @returns {{key: string, code: string, keyCode: number, which: number, bubbles: boolean, cancelable: boolean, composed: boolean}}
- */
-function buildKeyEventOptions(keyName) {
-  let code = keyName;
-  let keyCode = 0;
-  let key = keyName;
-
-  if (SPECIAL_KEYS[keyName]) {
-    code = SPECIAL_KEYS[keyName].code;
-    keyCode = SPECIAL_KEYS[keyName].keyCode;
-    key = keyName === "Space" ? " " : keyName;
-  } else if (keyName.length === 1) {
-    keyCode = keyName.codePointAt(0) || 0;
-    if (keyName >= "a" && keyName <= "z") {
-      code = `Key${keyName.toUpperCase()}`;
-      keyCode = keyName.toUpperCase().codePointAt(0) || 0;
-    } else if (keyName >= "A" && keyName <= "Z") {
-      code = `Key${keyName}`;
-    } else if (keyName >= "0" && keyName <= "9") {
-      code = `Digit${keyName}`;
+    if (virtualCursor) {
+      virtualCursor.style.transition = "all 0.8s cubic-bezier(0.4, 0, 0.2, 1)";
+      moveCursorToElement(endElement);
+      await new Promise((resolve) => setTimeout(resolve, 800));
     }
-  } else {
-    code = keyName.charAt(0).toUpperCase() + keyName.slice(1);
-  }
 
-  return {
-    key,
-    code,
-    keyCode,
-    which: keyCode,
-    bubbles: true,
-    cancelable: true,
-    composed: true,
-  };
-}
+    endElement.dispatchEvent(
+      new DragEvent("dragenter", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+        clientX: endX,
+        clientY: endY,
+        dataTransfer,
+      }),
+    );
 
-/**
- * Check if element is a text-editable input
- * @param {Element} element
- * @returns {boolean}
- */
-function isTextInput(element) {
-  if (element.tagName === "TEXTAREA") {
-    return true;
-  }
-  if (element.tagName === "INPUT") {
-    const type =
-      /** @type {HTMLInputElement} */ (element).type?.toLowerCase() || "text";
-    return TEXT_INPUT_TYPES.has(type);
-  }
-  return false;
-}
+    endElement.dispatchEvent(
+      new DragEvent("dragover", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+        clientX: endX,
+        clientY: endY,
+        dataTransfer,
+      }),
+    );
 
-/**
- * Insert text at cursor position in input/textarea
- * @param {HTMLInputElement|HTMLTextAreaElement} element
- * @param {string} text
- */
-function insertTextAtCursor(element, text) {
-  const start = element.selectionStart || 0;
-  const end = element.selectionEnd || 0;
-  element.value =
-    element.value.slice(0, start) + text + element.value.slice(end);
-  element.selectionStart = element.selectionEnd = start + text.length;
-  element.dispatchEvent(
-    new Event("input", { bubbles: true, cancelable: true }),
-  );
-}
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
-/**
- * Try to submit the form containing an input
- * @param {HTMLInputElement} input
- * @returns {boolean} True if form was submitted
- */
-function trySubmitForm(input) {
-  const form = input.form;
-  if (!form) {
-    return false;
-  }
+    endElement.dispatchEvent(
+      new DragEvent("drop", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+        clientX: endX,
+        clientY: endY,
+        dataTransfer,
+      }),
+    );
 
-  // Try requestSubmit first (triggers submit event handlers)
-  if (typeof form.requestSubmit === "function") {
-    try {
-      form.requestSubmit();
-      return true;
-    } catch {
-      // requestSubmit can throw if form is invalid, fall through
+    startElement.dispatchEvent(
+      new DragEvent("dragend", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+        clientX: endX,
+        clientY: endY,
+        dataTransfer,
+      }),
+    );
+
+    if (virtualCursor) {
+      virtualCursor.style.transition = "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)";
     }
+
+    return { dragged: startSelector, to: endSelector };
   }
 
-  // Fallback: find submit button and click it
-  const submitButton = form.querySelector(
-    'button[type="submit"], input[type="submit"], button:not([type])',
-  );
-  if (submitButton) {
-    /** @type {HTMLButtonElement|HTMLInputElement} */ (submitButton).click();
-    return true;
-  }
-
-  // Last resort: dispatch submit event
-  form.dispatchEvent(
-    new SubmitEvent("submit", { bubbles: true, cancelable: true }),
-  );
-  return true;
-}
-
-/**
- * Handle Tab key navigation
- * @param {Element} activeElement
- */
-function handleTabKey(activeElement) {
-  const focusableElements = /** @type {HTMLElement[]} */ ([
-    ...document.querySelectorAll(
-      'a[href], button, input, textarea, select, [tabindex]:not([tabindex="-1"])',
-    ),
-  ]).filter(
-    (el) =>
-      !(/** @type {HTMLButtonElement|HTMLInputElement} */ (el).disabled) &&
-      el.offsetParent !== null,
-  );
-
-  const currentIndex = focusableElements.indexOf(
-    /** @type {HTMLElement} */ (activeElement),
-  );
-  if (currentIndex !== -1 && currentIndex < focusableElements.length - 1) {
-    focusableElements[currentIndex + 1].focus();
-  }
-
-  // Track newly focused input
-  setTimeout(() => {
-    const newActive = document.activeElement;
-    if (
-      newActive &&
-      (newActive.tagName === "INPUT" || newActive.tagName === "TEXTAREA")
-    ) {
-      lastFocusedInput = /** @type {HTMLInputElement|HTMLTextAreaElement} */ (
-        newActive
+  /**
+   * Select an option in a dropdown
+   * @param {string|number} selector - Select element selector or ref
+   * @param {string} option - Option value to select
+   * @param {SelectorType} [selectorType='css'] - Type of selector
+   * @returns {Promise<{selected: string, in: string|number}>}
+   */
+  async function select(selector, option, selectorType = "css") {
+    const element = /** @type {HTMLSelectElement} */ (
+      find(selector, selectorType)
+    );
+    if (element.tagName !== "SELECT") {
+      throw new Error(
+        `Element is not a select field. Found: <${element.tagName.toLowerCase()}>`,
       );
     }
-  }, 50);
-}
+    moveCursorToElement(element, true);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    element.value = option;
+    element.dispatchEvent(new Event("change", { bubbles: true }));
 
-/**
- * Handle character input in contentEditable
- * @param {Element} element
- * @param {string} char
- */
-function insertCharInContentEditable(element, char) {
-  const selection = window.getSelection();
-  if (!selection || selection.rangeCount === 0) {
-    return;
+    return { selected: option, in: selector };
   }
 
-  const range = selection.getRangeAt(0);
-  range.deleteContents();
-  const textNode = document.createTextNode(char);
-  range.insertNode(textNode);
-  range.setStartAfter(textNode);
-  range.setEndAfter(textNode);
-  selection.removeAllRanges();
-  selection.addRange(range);
-  element.dispatchEvent(
-    new Event("input", { bubbles: true, cancelable: true }),
-  );
-}
-
-/**
- * Simulate a key press
- * @param {string} keyName - Key to press (e.g., "Enter", "Tab", "a", "A")
- * @returns {{key: string}}
- */
-function key(keyName) {
-  // Get active element, restoring last focused input if needed
-  let activeElement = document.activeElement || document.body;
-  if (activeElement === document.body && lastFocusedInput) {
-    activeElement = lastFocusedInput;
-    lastFocusedInput.focus();
-  }
-
-  const eventOptions = buildKeyEventOptions(keyName);
-
-  // Dispatch keydown
-  const keydownPrevented = !activeElement.dispatchEvent(
-    new KeyboardEvent("keydown", eventOptions),
-  );
-
-  // Handle special keys
-  if (!keydownPrevented) {
-    if (keyName === "Enter") {
-      if (activeElement.tagName === "INPUT" && isTextInput(activeElement)) {
-        trySubmitForm(/** @type {HTMLInputElement} */ (activeElement));
-      } else if (activeElement.tagName === "TEXTAREA") {
-        insertTextAtCursor(
-          /** @type {HTMLTextAreaElement} */ (activeElement),
-          "\n",
-        );
-      }
-    } else if (keyName === "Tab") {
-      handleTabKey(activeElement);
-    } else if (keyName.length === 1) {
-      // Printable character
-      if (isTextInput(activeElement)) {
-        insertTextAtCursor(
-          /** @type {HTMLInputElement|HTMLTextAreaElement} */ (activeElement),
-          keyName,
-        );
-        activeElement.dispatchEvent(
-          new Event("change", { bubbles: true, cancelable: true }),
-        );
-      } else if (
-        /** @type {HTMLElement} */ (activeElement).contentEditable === "true"
-      ) {
-        insertCharInContentEditable(activeElement, keyName);
-      }
-    }
-  }
-
-  // Dispatch keypress for printable characters
-  if (keyName.length === 1) {
-    activeElement.dispatchEvent(new KeyboardEvent("keypress", eventOptions));
-  }
-
-  // Dispatch keyup
-  activeElement.dispatchEvent(new KeyboardEvent("keyup", eventOptions));
-
-  return { key: keyName };
-}
-
-/**
- * Get snapshot of the page
- * Returns full snapshot on first call, diff on subsequent calls (to save tokens)
- * @param {SnapOptions & {full?: boolean}} [options] - Filter options, use {full: true} for full snapshot
- * @returns {Snapshot|SnapshotDiff}
- */
-function snap(options) {
-  const snapshot = generateSnapshot(options);
-
-  // If full snapshot explicitly requested or options are set (filtering), return full
-  if (
-    options?.full ||
-    (options && Object.keys(options).some((k) => k !== "full"))
-  ) {
-    if (!options || !Object.keys(options).some((k) => k !== "full")) {
-      lastSnapshot = snapshot;
-    }
-    return snapshot;
-  }
-
-  // First call or no previous snapshot - return full snapshot
-  if (!lastSnapshot) {
-    lastSnapshot = snapshot;
-    return snapshot;
-  }
-
-  // Return diff to save tokens
-  const result = snapshot.diff(lastSnapshot);
-  lastSnapshot = snapshot;
-  return result;
-}
-
-/**
- * Get console logs
- * @returns {{logs: ConsoleLog[]}}
- */
-function logs() {
-  return { logs: [...consoleLogs] };
-}
-
-/**
- * Wait for DOM to stabilize (no mutations for a period)
- * @param {number} [stableMs=300] - How long DOM must be stable
- * @param {number} [timeout=10000] - Maximum wait time
- * @returns {Promise<{waited: string}>}
- */
-function waitForIdle(stableMs = 300, timeout = 10_000) {
-  return new Promise((resolve, reject) => {
-    let lastMutationTime = Date.now();
-    let resolved = false;
-    const startTime = Date.now();
-
-    const observer = new MutationObserver(() => {
-      lastMutationTime = Date.now();
-    });
-
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      characterData: true,
-    });
-
-    const checkStable = () => {
-      if (resolved) {
-        return;
-      }
-
-      const now = Date.now();
-      if (now - startTime > timeout) {
-        resolved = true;
-        observer.disconnect();
-        reject(new Error("Timeout waiting for page to stabilize"));
-        return;
-      }
-
-      if (now - lastMutationTime >= stableMs) {
-        resolved = true;
-        observer.disconnect();
-        resolve({ waited: "idle" });
-        return;
-      }
-
-      setTimeout(checkStable, 50);
-    };
-
-    // Start checking after initial delay
-    setTimeout(checkStable, 50);
-  });
-}
-
-/**
- * Wait for condition or timeout
- * @param {number|string} condition - ms to wait, "idle", "text", or "gone"
- * @param {string|number} [value] - Text to wait for, or stableMs for idle
- * @param {number} [timeout=10000] - Maximum wait time in ms
- * @returns {Promise<{waited: number|string}>}
- */
-async function wait(condition, value, timeout = 10_000) {
-  if (typeof condition === "number") {
-    // Simple delay
-    await new Promise((resolve) => setTimeout(resolve, condition));
-    return { waited: condition };
-  }
-
-  if (condition === "idle") {
-    // Wait for DOM to stabilize
-    const stableMs = typeof value === "number" ? value : 300;
-    return waitForIdle(stableMs, timeout);
-  }
-
-  if (condition === "text" && typeof value === "string") {
-    // Wait for text to appear
-    const startTime = Date.now();
-    while (Date.now() - startTime < timeout) {
-      if (document.body.textContent?.includes(value)) {
-        return { waited: `text:${value}` };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    throw new Error(`Timeout waiting for text: "${value}"`);
-  }
-
-  if (condition === "gone" && typeof value === "string") {
-    // Wait for text to disappear
-    const startTime = Date.now();
-    while (Date.now() - startTime < timeout) {
-      if (!document.body.textContent?.includes(value)) {
-        return { waited: `gone:${value}` };
-      }
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    throw new Error(`Timeout waiting for text to disappear: "${value}"`);
-  }
-
-  throw new Error(`Invalid wait condition: ${condition}`);
-}
-
-// ============================================================================
-// Browser-level functions (delegate to background script)
-// ============================================================================
-
-/** @type {number} */
-let bgMessageCounter = 0;
-
-/**
- * Send a command to the background script and wait for response
- * @param {string} command
- * @param {object} [params={}]
- * @returns {Promise<any>}
- */
-function sendToBackground(command, params = {}) {
-  return new Promise((resolve, reject) => {
-    const messageId = `content_${++bgMessageCounter}`;
-
-    /**
-     * @param {any} response
-     */
-    function handleResponse(response) {
-      if (response && response.bgMessageId === messageId) {
-        browser.runtime.onMessage.removeListener(handleResponse);
-        if (response.error) {
-          reject(new Error(response.error));
-        } else {
-          resolve(response.result);
-        }
-      }
-    }
-
-    browser.runtime.onMessage.addListener(handleResponse);
-    browser.runtime.sendMessage({ command, params, bgMessageId: messageId });
-
-    // Timeout after 30 seconds
-    setTimeout(() => {
-      browser.runtime.onMessage.removeListener(handleResponse);
-      reject(new Error("Background script timeout"));
-    }, 30_000);
-  });
-}
-
-/**
- * Take a screenshot
- * @param {string} [path] - Output file path
- * @returns {Promise<string>} Path to saved screenshot
- */
-async function shot(path) {
-  const result = await sendToBackground("screenshot", { output_path: path });
-  return result.screenshot_path || result.screenshot;
-}
-
-/**
- * Navigate the current tab to a URL
- * Delegates to background script so navigation completes properly
- * @param {string} url - URL to navigate to
- * @returns {Promise<{url: string}>}
- */
-async function go(url) {
-  return sendToBackground("go", { url });
-}
-
-/**
- * Create a new tab
- * @param {string} [url] - URL to open
- * @returns {Promise<{tabId: string, url: string}>} Tab info
- */
-async function tab(url) {
-  const result = await sendToBackground("new-tab", { url });
-  return { tabId: result.tabId, url: result.url };
-}
-
-/**
- * List all managed tabs
- * @returns {Promise<Array<{id: string, url: string, title: string, active: boolean}>>}
- */
-async function tabs() {
-  const result = await sendToBackground("list-tabs");
-  return result.tabs;
-}
-
-/**
- * Download a file
- * @param {string} url - URL to download
- * @param {string} [filename] - Filename (relative to downloads folder)
- * @returns {Promise<{downloaded: string, path: string}>}
- */
-async function download(url, filename) {
-  return sendToBackground("download", { url, filename });
-}
-
-// ============================================================================
-// Message handling for background script commands
-// ============================================================================
-// Reader Mode (Mozilla Readability)
-// ============================================================================
-
-/**
- * @typedef {object} ReadOptions
- * @property {number} [maxLength] - Maximum length of text content (default: no limit)
- * @property {boolean} [includeMetadata] - Include title, byline, etc. (default: true)
- */
-
-/**
- * @typedef {object} ReadResult
- * @property {string} title - Article title
- * @property {string} [byline] - Author information
- * @property {string} [siteName] - Name of the site
- * @property {string} [excerpt] - Short excerpt/description
- * @property {string} [publishedTime] - Publication time
- * @property {string} content - Plain text content of the article
- * @property {number} length - Length of content in characters
- */
-
-/**
- * Collect all documents including iframes that may contain content
- * @returns {Document[]}
- */
-function collectDocuments() {
-  /** @type {Document[]} */
-  const docs = [document];
-  for (const f of document.querySelectorAll("iframe,frame")) {
-    try {
-      const frame = /** @type {HTMLIFrameElement | HTMLFrameElement} */ (f);
-      const v =
-        frame.contentDocument?.documentElement?.textContent?.length ?? 0;
-      if (v > 100 && frame.contentDocument) {
-        docs.push(frame.contentDocument);
-      }
-    } catch {
-      // Cross-origin iframe, skip
-    }
-  }
-  // Sort by content length (longest first)
-  docs.sort((a, b) => {
-    const aLen = a.documentElement?.textContent?.length ?? 0;
-    const bLen = b.documentElement?.textContent?.length ?? 0;
-    return bLen - aLen;
-  });
-  return docs;
-}
-
-/**
- * Fix SVG elements that may cause issues with Readability
- * @param {Document} doc
- */
-function fixSVGElements(doc) {
-  for (const svg of doc.querySelectorAll("svg")) {
-    if (!svg.hasAttribute("width") || !svg.hasAttribute("height")) {
-      try {
-        const style = window.getComputedStyle(svg);
-        if (!svg.hasAttribute("width")) {
-          svg.setAttribute("width", style.width);
-        }
-        if (!svg.hasAttribute("height")) {
-          svg.setAttribute("height", style.height);
-        }
-      } catch {
-        // Skip if getComputedStyle fails
-      }
-    }
-  }
-}
-
-/**
- * Find elements that are hidden via computed styles
- * Must be called on live document before cloning to access computed styles
- * @param {Document} doc - The document to analyze
- * @returns {Set<Element>} Set of elements that are hidden
- */
-function findHiddenElements(doc) {
-  const hidden = new Set();
-
-  for (const el of doc.body.querySelectorAll("*")) {
-    try {
-      const style = window.getComputedStyle(el);
-      if (style.display === "none" || style.visibility === "hidden") {
-        hidden.add(el);
-      }
-    } catch {
-      // Skip elements that can't be styled
-    }
-  }
-
-  return hidden;
-}
-
-/**
- * Get DOM path to element as array of child indices
- * @param {Element} el
- * @param {Document} doc
- * @returns {number[]}
- */
-function getElementPath(el, doc) {
-  const path = [];
-  let current = el;
-  while (current && current !== doc.body) {
-    const parent = current.parentElement;
-    if (!parent) {
-      break;
-    }
-    const index = [...parent.children].indexOf(current);
-    path.unshift(index);
-    current = parent;
-  }
-  return path;
-}
-
-/**
- * Get element by DOM path
- * @param {number[]} path
- * @param {Document} doc
- * @returns {Element|null}
- */
-function getElementByPath(path, doc) {
-  /** @type {Element|null} */
-  let current = doc.body;
-  for (const index of path) {
-    if (!current || !current.children[index]) {
-      // eslint-disable-next-line unicorn/no-null
-      return null;
-    }
-    current = current.children[index];
-  }
-  return current;
-}
-
-/**
- * Remove hidden elements from cloned document
- * @param {Document} clonedDoc - The cloned document to clean
- * @param {Set<Element>} hiddenElements - Elements from original doc that were hidden
- * @param {Document} originalDoc - The original document for path matching
- */
-function removeHiddenFromClone(clonedDoc, hiddenElements, originalDoc) {
-  for (const el of hiddenElements) {
-    const path = getElementPath(el, originalDoc);
-    const clonedEl = getElementByPath(path, clonedDoc);
-    if (clonedEl) {
-      clonedEl.remove();
-    }
-  }
-}
-
-/**
- * Extract readable article content from the page using Mozilla Readability
- * Optimized for LLM consumption - returns plain text to minimize tokens
- * @param {ReadOptions} [options] - Options for extraction
- * @returns {ReadResult|null} Article content or null if not extractable
- */
-function read(options = {}) {
-  // Check if Readability is available (injected before content.js)
-  if (typeof Readability === "undefined") {
-    throw new TypeError(
-      "Readability not available. This should not happen - please report a bug.",
-    );
-  }
-
-  const { maxLength, includeMetadata = true } = options;
-
-  // Fix SVG elements before cloning
-  fixSVGElements(document);
-
-  // Collect documents from main page and iframes
-  const docs = collectDocuments();
-
-  /** @type {ReturnType<Readability['parse']>} */
-  // eslint-disable-next-line unicorn/no-null -- Readability.parse() returns null
-  let article = null;
-
-  // Try each document until we find readable content
-  for (const d of docs) {
-    // Find hidden elements before cloning (need computed styles from live doc)
-    const hiddenElements = findHiddenElements(d);
-
-    // Clone the document to avoid modifying the actual page
-    const documentClone = /** @type {Document} */ (d.cloneNode(true));
-
-    // Remove hidden elements from clone
-    removeHiddenFromClone(documentClone, hiddenElements, d);
-
-    // Create Readability instance - use default charThreshold (500)
-    // which makes Readability retry with different strategies if initial
-    // extraction is too short
-    const reader = new Readability(documentClone);
-
-    article = reader.parse();
-    if (article && article.textContent && article.textContent.length > 50) {
-      break;
-    }
-  }
-
-  if (!article) {
-    // eslint-disable-next-line unicorn/no-null -- null indicates "no article found" (matches Readability API)
-    return null;
-  }
-
-  // Get plain text content
-  let textContent = article.textContent || "";
-
-  // Normalize whitespace: collapse multiple newlines/spaces
-  textContent = textContent
-    .replaceAll(/\n{3,}/g, "\n\n") // Max 2 consecutive newlines
-    .replaceAll(/[ \t]+/g, " ") // Collapse horizontal whitespace
-    .replaceAll(/\n +/g, "\n") // Remove leading spaces on lines
-    .replaceAll(/ +\n/g, "\n") // Remove trailing spaces on lines
-    .trim();
-
-  // Apply max length if specified
-  if (maxLength && textContent.length > maxLength) {
-    // Try to cut at a sentence or paragraph boundary
-    let cutPoint = textContent.lastIndexOf("\n\n", maxLength);
-    if (cutPoint < maxLength * 0.5) {
-      cutPoint = textContent.lastIndexOf(". ", maxLength);
-      if (cutPoint > 0) {
-        cutPoint += 1;
-      } // Include the period
-    }
-    if (cutPoint < maxLength * 0.5) {
-      cutPoint = maxLength;
-    }
-    textContent = textContent.slice(0, cutPoint).trim() + "\n\n[truncated]";
-  }
-
-  /** @type {ReadResult} */
-  const result = {
-    title: article.title || document.title,
-    content: textContent,
-    length: textContent.length,
+  /**
+   * Press a keyboard key
+   * @param {string} keyName - Key to press
+   * @returns {Snapshot}
+   */
+  /** @type {Record<string, {code: string, keyCode: number}>} */
+  const SPECIAL_KEYS = {
+    Enter: { code: "Enter", keyCode: 13 },
+    Tab: { code: "Tab", keyCode: 9 },
+    Escape: { code: "Escape", keyCode: 27 },
+    Backspace: { code: "Backspace", keyCode: 8 },
+    Delete: { code: "Delete", keyCode: 46 },
+    ArrowUp: { code: "ArrowUp", keyCode: 38 },
+    ArrowDown: { code: "ArrowDown", keyCode: 40 },
+    ArrowLeft: { code: "ArrowLeft", keyCode: 37 },
+    ArrowRight: { code: "ArrowRight", keyCode: 39 },
+    Home: { code: "Home", keyCode: 36 },
+    End: { code: "End", keyCode: 35 },
+    PageUp: { code: "PageUp", keyCode: 33 },
+    PageDown: { code: "PageDown", keyCode: 34 },
+    " ": { code: "Space", keyCode: 32 },
+    Space: { code: "Space", keyCode: 32 },
   };
 
-  // Include metadata if requested
-  if (includeMetadata) {
-    if (article.byline) {
-      result.byline = article.byline;
-    }
-    if (article.siteName) {
-      result.siteName = article.siteName;
-    }
-    if (article.excerpt) {
-      result.excerpt = article.excerpt;
-    }
-    if (article.publishedTime) {
-      result.publishedTime = article.publishedTime;
-    }
-  }
+  const TEXT_INPUT_TYPES = new Set([
+    "text",
+    "search",
+    "email",
+    "password",
+    "tel",
+    "url",
+    "number",
+  ]);
 
-  return result;
-}
+  /**
+   * Build keyboard event options for a key
+   * @param {string} keyName
+   * @returns {{key: string, code: string, keyCode: number, which: number, bubbles: boolean, cancelable: boolean, composed: boolean}}
+   */
+  function buildKeyEventOptions(keyName) {
+    let code = keyName;
+    let keyCode = 0;
+    let key = keyName;
 
-// ============================================================================
-
-/**
- * Serialize result for transport
- * @param {any} value
- * @returns {any}
- */
-function serializeResult(value) {
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  // Handle Snapshot and SnapshotElement
-  if (value instanceof Snapshot || value instanceof SnapshotElement) {
-    return value.toJSON();
-  }
-
-  // Handle arrays
-  if (Array.isArray(value)) {
-    return value.map((v) => serializeResult(v));
-  }
-
-  // Handle objects with toJSON
-  if (typeof value === "object" && typeof value.toJSON === "function") {
-    return value.toJSON();
-  }
-
-  // Try structuredClone for other objects
-  try {
-    return structuredClone(value);
-  } catch {
-    return String(value);
-  }
-}
-
-/**
- * Handle exec command - execute JavaScript with API available
- * @param {string} code - JavaScript code to execute
- * @returns {Promise<{result: any}>}
- */
-async function handleExec(code) {
-  // Create async function to allow await in code
-  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-
-  // Wrap code to auto-return the last expression if no explicit return
-  let wrappedCode = code.trim();
-  if (!wrappedCode.includes("return ") && !wrappedCode.includes("return;")) {
-    // Find the last statement and return it
-    const lines = wrappedCode.split("\n");
-    const lastLine = lines.pop()?.trim() || "";
-    if (lastLine && !lastLine.endsWith(";")) {
-      // Last line is an expression - return it
-      wrappedCode = [...lines, `return (${lastLine})`].join("\n");
-    } else if (lastLine) {
-      // Last line ends with semicolon - try to return it anyway
-      const expr = lastLine.slice(0, -1).trim();
-      if (
-        expr &&
-        !expr.startsWith("const ") &&
-        !expr.startsWith("let ") &&
-        !expr.startsWith("var ")
-      ) {
-        wrappedCode = [...lines, `return (${expr})`].join("\n");
+    if (SPECIAL_KEYS[keyName]) {
+      code = SPECIAL_KEYS[keyName].code;
+      keyCode = SPECIAL_KEYS[keyName].keyCode;
+      key = keyName === "Space" ? " " : keyName;
+    } else if (keyName.length === 1) {
+      keyCode = keyName.codePointAt(0) || 0;
+      if (keyName >= "a" && keyName <= "z") {
+        code = `Key${keyName.toUpperCase()}`;
+        keyCode = keyName.toUpperCase().codePointAt(0) || 0;
+      } else if (keyName >= "A" && keyName <= "Z") {
+        code = `Key${keyName}`;
+      } else if (keyName >= "0" && keyName <= "9") {
+        code = `Digit${keyName}`;
       }
+    } else {
+      code = keyName.charAt(0).toUpperCase() + keyName.slice(1);
     }
+
+    return {
+      key,
+      code,
+      keyCode,
+      which: keyCode,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    };
   }
 
-  // Make API functions available in the execution context
-  const fn = new AsyncFunction(
-    // Content script functions
-    "click",
-    "type",
-    "hover",
-    "drag",
-    "select",
-    "key",
-    "snap",
-    "logs",
-    "find",
-    "wait",
-    "read",
-    "go",
-    // Background script functions
-    "shot",
-    "tab",
-    "tabs",
-    "download",
-    wrappedCode,
-  );
-
-  const result = await fn(
-    // Content script functions
-    click,
-    type,
-    hover,
-    drag,
-    select,
-    key,
-    snap,
-    logs,
-    find,
-    wait,
-    read,
-    go,
-    // Background script functions
-    shot,
-    tab,
-    tabs,
-    download,
-  );
-
-  return { result: serializeResult(result) };
-}
-
-browser.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
-  const { command, params, messageId } = message;
-
-  // Skip if this is a response to a background script request
-  if (message.bgMessageId) {
+  /**
+   * Check if element is a text-editable input
+   * @param {Element} element
+   * @returns {boolean}
+   */
+  function isTextInput(element) {
+    if (element.tagName === "TEXTAREA") {
+      return true;
+    }
+    if (element.tagName === "INPUT") {
+      const type =
+        /** @type {HTMLInputElement} */ (element).type?.toLowerCase() || "text";
+      return TEXT_INPUT_TYPES.has(type);
+    }
     return false;
   }
 
-  if (!virtualCursor && command !== "exec") {
-    initializeVirtualCursor();
+  /**
+   * Insert text at cursor position in input/textarea
+   * @param {HTMLInputElement|HTMLTextAreaElement} element
+   * @param {string} text
+   */
+  function insertTextAtCursor(element, text) {
+    const start = element.selectionStart || 0;
+    const end = element.selectionEnd || 0;
+    element.value =
+      element.value.slice(0, start) + text + element.value.slice(end);
+    element.selectionStart = element.selectionEnd = start + text.length;
+    element.dispatchEvent(
+      new Event("input", { bubbles: true, cancelable: true }),
+    );
   }
 
-  /** */
-  async function executeCommand() {
-    try {
-      let result;
+  /**
+   * Try to submit the form containing an input
+   * @param {HTMLInputElement} input
+   * @returns {boolean} True if form was submitted
+   */
+  function trySubmitForm(input) {
+    const form = input.form;
+    if (!form) {
+      return false;
+    }
 
-      switch (command) {
-        case "exec": {
-          result = await handleExec(params.code);
-          break;
+    // Try requestSubmit first (triggers submit event handlers)
+    if (typeof form.requestSubmit === "function") {
+      try {
+        form.requestSubmit();
+        return true;
+      } catch {
+        // requestSubmit can throw if form is invalid, fall through
+      }
+    }
+
+    // Fallback: find submit button and click it
+    const submitButton = form.querySelector(
+      'button[type="submit"], input[type="submit"], button:not([type])',
+    );
+    if (submitButton) {
+      /** @type {HTMLButtonElement|HTMLInputElement} */ (submitButton).click();
+      return true;
+    }
+
+    // Last resort: dispatch submit event
+    form.dispatchEvent(
+      new SubmitEvent("submit", { bubbles: true, cancelable: true }),
+    );
+    return true;
+  }
+
+  /**
+   * Handle Tab key navigation
+   * @param {Element} activeElement
+   */
+  function handleTabKey(activeElement) {
+    const focusableElements = /** @type {HTMLElement[]} */ ([
+      ...document.querySelectorAll(
+        'a[href], button, input, textarea, select, [tabindex]:not([tabindex="-1"])',
+      ),
+    ]).filter(
+      (el) =>
+        !(/** @type {HTMLButtonElement|HTMLInputElement} */ (el).disabled) &&
+        el.offsetParent !== null,
+    );
+
+    const currentIndex = focusableElements.indexOf(
+      /** @type {HTMLElement} */ (activeElement),
+    );
+    if (currentIndex !== -1 && currentIndex < focusableElements.length - 1) {
+      focusableElements[currentIndex + 1].focus();
+    }
+
+    // Track newly focused input
+    setTimeout(() => {
+      const newActive = document.activeElement;
+      if (
+        newActive &&
+        (newActive.tagName === "INPUT" || newActive.tagName === "TEXTAREA")
+      ) {
+        lastFocusedInput = /** @type {HTMLInputElement|HTMLTextAreaElement} */ (
+          newActive
+        );
+      }
+    }, 50);
+  }
+
+  /**
+   * Handle character input in contentEditable
+   * @param {Element} element
+   * @param {string} char
+   */
+  function insertCharInContentEditable(element, char) {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) {
+      return;
+    }
+
+    const range = selection.getRangeAt(0);
+    range.deleteContents();
+    const textNode = document.createTextNode(char);
+    range.insertNode(textNode);
+    range.setStartAfter(textNode);
+    range.setEndAfter(textNode);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    element.dispatchEvent(
+      new Event("input", { bubbles: true, cancelable: true }),
+    );
+  }
+
+  /**
+   * Simulate a key press
+   * @param {string} keyName - Key to press (e.g., "Enter", "Tab", "a", "A")
+   * @returns {{key: string}}
+   */
+  function key(keyName) {
+    // Get active element, restoring last focused input if needed
+    let activeElement = document.activeElement || document.body;
+    if (activeElement === document.body && lastFocusedInput) {
+      activeElement = lastFocusedInput;
+      lastFocusedInput.focus();
+    }
+
+    const eventOptions = buildKeyEventOptions(keyName);
+
+    // Dispatch keydown
+    const keydownPrevented = !activeElement.dispatchEvent(
+      new KeyboardEvent("keydown", eventOptions),
+    );
+
+    // Handle special keys
+    if (!keydownPrevented) {
+      if (keyName === "Enter") {
+        if (activeElement.tagName === "INPUT" && isTextInput(activeElement)) {
+          trySubmitForm(/** @type {HTMLInputElement} */ (activeElement));
+        } else if (activeElement.tagName === "TEXTAREA") {
+          insertTextAtCursor(
+            /** @type {HTMLTextAreaElement} */ (activeElement),
+            "\n",
+          );
         }
-        default: {
-          throw new Error(`Unknown command: ${command}`);
+      } else if (keyName === "Tab") {
+        handleTabKey(activeElement);
+      } else if (keyName.length === 1) {
+        // Printable character
+        if (isTextInput(activeElement)) {
+          insertTextAtCursor(
+            /** @type {HTMLInputElement|HTMLTextAreaElement} */ (activeElement),
+            keyName,
+          );
+          activeElement.dispatchEvent(
+            new Event("change", { bubbles: true, cancelable: true }),
+          );
+        } else if (
+          /** @type {HTMLElement} */ (activeElement).contentEditable === "true"
+        ) {
+          insertCharInContentEditable(activeElement, keyName);
+        }
+      }
+    }
+
+    // Dispatch keypress for printable characters
+    if (keyName.length === 1) {
+      activeElement.dispatchEvent(new KeyboardEvent("keypress", eventOptions));
+    }
+
+    // Dispatch keyup
+    activeElement.dispatchEvent(new KeyboardEvent("keyup", eventOptions));
+
+    return { key: keyName };
+  }
+
+  /**
+   * Get snapshot of the page
+   * Returns full snapshot on first call, diff on subsequent calls (to save tokens)
+   * @param {SnapOptions & {full?: boolean}} [options] - Filter options, use {full: true} for full snapshot
+   * @returns {Snapshot|SnapshotDiff}
+   */
+  function snap(options) {
+    const snapshot = generateSnapshot(options);
+
+    // If full snapshot explicitly requested or options are set (filtering), return full
+    if (
+      options?.full ||
+      (options && Object.keys(options).some((k) => k !== "full"))
+    ) {
+      if (!options || !Object.keys(options).some((k) => k !== "full")) {
+        lastSnapshot = snapshot;
+      }
+      return snapshot;
+    }
+
+    // First call or no previous snapshot - return full snapshot
+    if (!lastSnapshot) {
+      lastSnapshot = snapshot;
+      return snapshot;
+    }
+
+    // Return diff to save tokens
+    const result = snapshot.diff(lastSnapshot);
+    lastSnapshot = snapshot;
+    return result;
+  }
+
+  /**
+   * Get console logs
+   * @returns {{logs: ConsoleLog[]}}
+   */
+  function logs() {
+    return { logs: [...consoleLogs] };
+  }
+
+  /**
+   * Wait for DOM to stabilize (no mutations for a period)
+   * @param {number} [stableMs=300] - How long DOM must be stable
+   * @param {number} [timeout=10000] - Maximum wait time
+   * @returns {Promise<{waited: string}>}
+   */
+  function waitForIdle(stableMs = 300, timeout = 10_000) {
+    return new Promise((resolve, reject) => {
+      let lastMutationTime = Date.now();
+      let resolved = false;
+      const startTime = Date.now();
+
+      const observer = new MutationObserver(() => {
+        lastMutationTime = Date.now();
+      });
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      });
+
+      const checkStable = () => {
+        if (resolved) {
+          return;
+        }
+
+        const now = Date.now();
+        if (now - startTime > timeout) {
+          resolved = true;
+          observer.disconnect();
+          reject(new Error("Timeout waiting for page to stabilize"));
+          return;
+        }
+
+        if (now - lastMutationTime >= stableMs) {
+          resolved = true;
+          observer.disconnect();
+          resolve({ waited: "idle" });
+          return;
+        }
+
+        setTimeout(checkStable, 50);
+      };
+
+      // Start checking after initial delay
+      setTimeout(checkStable, 50);
+    });
+  }
+
+  /**
+   * Wait for condition or timeout
+   * @param {number|string} condition - ms to wait, "idle", "text", or "gone"
+   * @param {string|number} [value] - Text to wait for, or stableMs for idle
+   * @param {number} [timeout=10000] - Maximum wait time in ms
+   * @returns {Promise<{waited: number|string}>}
+   */
+  async function wait(condition, value, timeout = 10_000) {
+    if (typeof condition === "number") {
+      // Simple delay
+      await new Promise((resolve) => setTimeout(resolve, condition));
+      return { waited: condition };
+    }
+
+    if (condition === "idle") {
+      // Wait for DOM to stabilize
+      const stableMs = typeof value === "number" ? value : 300;
+      return waitForIdle(stableMs, timeout);
+    }
+
+    if (condition === "text" && typeof value === "string") {
+      // Wait for text to appear
+      const startTime = Date.now();
+      while (Date.now() - startTime < timeout) {
+        if (document.body.textContent?.includes(value)) {
+          return { waited: `text:${value}` };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      throw new Error(`Timeout waiting for text: "${value}"`);
+    }
+
+    if (condition === "gone" && typeof value === "string") {
+      // Wait for text to disappear
+      const startTime = Date.now();
+      while (Date.now() - startTime < timeout) {
+        if (!document.body.textContent?.includes(value)) {
+          return { waited: `gone:${value}` };
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      throw new Error(`Timeout waiting for text to disappear: "${value}"`);
+    }
+
+    throw new Error(`Invalid wait condition: ${condition}`);
+  }
+
+  // ============================================================================
+  // Browser-level functions (delegate to background script)
+  // ============================================================================
+
+  /** @type {number} */
+  let bgMessageCounter = 0;
+
+  /**
+   * Send a command to the background script and wait for response
+   * @param {string} command
+   * @param {object} [params={}]
+   * @returns {Promise<any>}
+   */
+  function sendToBackground(command, params = {}) {
+    return new Promise((resolve, reject) => {
+      const messageId = `content_${++bgMessageCounter}`;
+
+      /**
+       * @param {any} response
+       */
+      function handleResponse(response) {
+        if (response && response.bgMessageId === messageId) {
+          browser.runtime.onMessage.removeListener(handleResponse);
+          if (response.error) {
+            reject(new Error(response.error));
+          } else {
+            resolve(response.result);
+          }
         }
       }
 
-      browser.runtime.sendMessage({ messageId, result, success: true });
-    } catch (error) {
-      browser.runtime.sendMessage({
-        messageId,
-        error: error instanceof Error ? error.message : String(error),
-        success: false,
-      });
+      browser.runtime.onMessage.addListener(handleResponse);
+      browser.runtime.sendMessage({ command, params, bgMessageId: messageId });
+
+      // Timeout after 30 seconds
+      setTimeout(() => {
+        browser.runtime.onMessage.removeListener(handleResponse);
+        reject(new Error("Background script timeout"));
+      }, 30_000);
+    });
+  }
+
+  /**
+   * Take a screenshot
+   * @param {string} [path] - Output file path
+   * @returns {Promise<string>} Path to saved screenshot
+   */
+  async function shot(path) {
+    const result = await sendToBackground("screenshot", { output_path: path });
+    return result.screenshot_path || result.screenshot;
+  }
+
+  /**
+   * Create a new tab
+   * @param {string} [url] - URL to open
+   * @returns {Promise<{tabId: string, url: string}>} Tab info
+   */
+  async function tab(url) {
+    const result = await sendToBackground("new-tab", { url });
+    return { tabId: result.tabId, url: result.url };
+  }
+
+  /**
+   * List all managed tabs
+   * @returns {Promise<Array<{id: string, url: string, title: string, active: boolean}>>}
+   */
+  async function tabs() {
+    const result = await sendToBackground("list-tabs");
+    return result.tabs;
+  }
+
+  /**
+   * Download a file
+   * @param {string} url - URL to download
+   * @param {string} [filename] - Filename (relative to downloads folder)
+   * @returns {Promise<{downloaded: string, path: string}>}
+   */
+  async function download(url, filename) {
+    return sendToBackground("download", { url, filename });
+  }
+
+  // ============================================================================
+  // Message handling for background script commands
+  // ============================================================================
+  // Reader Mode (Mozilla Readability)
+  // ============================================================================
+
+  /**
+   * @typedef {object} ReadOptions
+   * @property {number} [maxLength] - Maximum length of text content (default: no limit)
+   * @property {boolean} [includeMetadata] - Include title, byline, etc. (default: true)
+   */
+
+  /**
+   * @typedef {object} ReadResult
+   * @property {string} title - Article title
+   * @property {string} [byline] - Author information
+   * @property {string} [siteName] - Name of the site
+   * @property {string} [excerpt] - Short excerpt/description
+   * @property {string} [publishedTime] - Publication time
+   * @property {string} content - Plain text content of the article
+   * @property {number} length - Length of content in characters
+   */
+
+  /**
+   * Collect all documents including iframes that may contain content
+   * @returns {Document[]}
+   */
+  function collectDocuments() {
+    /** @type {Document[]} */
+    const docs = [document];
+    for (const f of document.querySelectorAll("iframe,frame")) {
+      try {
+        const frame = /** @type {HTMLIFrameElement | HTMLFrameElement} */ (f);
+        const v =
+          frame.contentDocument?.documentElement?.textContent?.length ?? 0;
+        if (v > 100 && frame.contentDocument) {
+          docs.push(frame.contentDocument);
+        }
+      } catch {
+        // Cross-origin iframe, skip
+      }
+    }
+    // Sort by content length (longest first)
+    docs.sort((a, b) => {
+      const aLen = a.documentElement?.textContent?.length ?? 0;
+      const bLen = b.documentElement?.textContent?.length ?? 0;
+      return bLen - aLen;
+    });
+    return docs;
+  }
+
+  /**
+   * Fix SVG elements that may cause issues with Readability
+   * @param {Document} doc
+   */
+  function fixSVGElements(doc) {
+    for (const svg of doc.querySelectorAll("svg")) {
+      if (!svg.hasAttribute("width") || !svg.hasAttribute("height")) {
+        try {
+          const style = window.getComputedStyle(svg);
+          if (!svg.hasAttribute("width")) {
+            svg.setAttribute("width", style.width);
+          }
+          if (!svg.hasAttribute("height")) {
+            svg.setAttribute("height", style.height);
+          }
+        } catch {
+          // Skip if getComputedStyle fails
+        }
+      }
     }
   }
 
-  executeCommand();
-  return true;
-});
+  /**
+   * Find elements that are hidden via computed styles
+   * Must be called on live document before cloning to access computed styles
+   * @param {Document} doc - The document to analyze
+   * @returns {Set<Element>} Set of elements that are hidden
+   */
+  function findHiddenElements(doc) {
+    const hidden = new Set();
+
+    for (const el of doc.body.querySelectorAll("*")) {
+      try {
+        const style = window.getComputedStyle(el);
+        if (style.display === "none" || style.visibility === "hidden") {
+          hidden.add(el);
+        }
+      } catch {
+        // Skip elements that can't be styled
+      }
+    }
+
+    return hidden;
+  }
+
+  /**
+   * Get DOM path to element as array of child indices
+   * @param {Element} el
+   * @param {Document} doc
+   * @returns {number[]}
+   */
+  function getElementPath(el, doc) {
+    const path = [];
+    let current = el;
+    while (current && current !== doc.body) {
+      const parent = current.parentElement;
+      if (!parent) {
+        break;
+      }
+      const index = [...parent.children].indexOf(current);
+      path.unshift(index);
+      current = parent;
+    }
+    return path;
+  }
+
+  /**
+   * Get element by DOM path
+   * @param {number[]} path
+   * @param {Document} doc
+   * @returns {Element|null}
+   */
+  function getElementByPath(path, doc) {
+    /** @type {Element|null} */
+    let current = doc.body;
+    for (const index of path) {
+      if (!current || !current.children[index]) {
+        // eslint-disable-next-line unicorn/no-null
+        return null;
+      }
+      current = current.children[index];
+    }
+    return current;
+  }
+
+  /**
+   * Remove hidden elements from cloned document
+   * @param {Document} clonedDoc - The cloned document to clean
+   * @param {Set<Element>} hiddenElements - Elements from original doc that were hidden
+   * @param {Document} originalDoc - The original document for path matching
+   */
+  function removeHiddenFromClone(clonedDoc, hiddenElements, originalDoc) {
+    for (const el of hiddenElements) {
+      const path = getElementPath(el, originalDoc);
+      const clonedEl = getElementByPath(path, clonedDoc);
+      if (clonedEl) {
+        clonedEl.remove();
+      }
+    }
+  }
+
+  /**
+   * Extract readable article content from the page using Mozilla Readability
+   * Optimized for LLM consumption - returns plain text to minimize tokens
+   * @param {ReadOptions} [options] - Options for extraction
+   * @returns {ReadResult|null} Article content or null if not extractable
+   */
+  function read(options = {}) {
+    // Check if Readability is available (injected before content.js)
+    if (typeof Readability === "undefined") {
+      throw new TypeError(
+        "Readability not available. This should not happen - please report a bug.",
+      );
+    }
+
+    const { maxLength, includeMetadata = true } = options;
+
+    // Fix SVG elements before cloning
+    fixSVGElements(document);
+
+    // Collect documents from main page and iframes
+    const docs = collectDocuments();
+
+    /** @type {ReturnType<Readability['parse']>} */
+    // eslint-disable-next-line unicorn/no-null -- Readability.parse() returns null
+    let article = null;
+
+    // Try each document until we find readable content
+    for (const d of docs) {
+      // Find hidden elements before cloning (need computed styles from live doc)
+      const hiddenElements = findHiddenElements(d);
+
+      // Clone the document to avoid modifying the actual page
+      const documentClone = /** @type {Document} */ (d.cloneNode(true));
+
+      // Remove hidden elements from clone
+      removeHiddenFromClone(documentClone, hiddenElements, d);
+
+      // Create Readability instance - use default charThreshold (500)
+      // which makes Readability retry with different strategies if initial
+      // extraction is too short
+      const reader = new Readability(documentClone);
+
+      article = reader.parse();
+      if (article && article.textContent && article.textContent.length > 50) {
+        break;
+      }
+    }
+
+    if (!article) {
+      // eslint-disable-next-line unicorn/no-null -- null indicates "no article found" (matches Readability API)
+      return null;
+    }
+
+    // Get plain text content
+    let textContent = article.textContent || "";
+
+    // Normalize whitespace: collapse multiple newlines/spaces
+    textContent = textContent
+      .replaceAll(/\n{3,}/g, "\n\n") // Max 2 consecutive newlines
+      .replaceAll(/[ \t]+/g, " ") // Collapse horizontal whitespace
+      .replaceAll(/\n +/g, "\n") // Remove leading spaces on lines
+      .replaceAll(/ +\n/g, "\n") // Remove trailing spaces on lines
+      .trim();
+
+    // Apply max length if specified
+    if (maxLength && textContent.length > maxLength) {
+      // Try to cut at a sentence or paragraph boundary
+      let cutPoint = textContent.lastIndexOf("\n\n", maxLength);
+      if (cutPoint < maxLength * 0.5) {
+        cutPoint = textContent.lastIndexOf(". ", maxLength);
+        if (cutPoint > 0) {
+          cutPoint += 1;
+        } // Include the period
+      }
+      if (cutPoint < maxLength * 0.5) {
+        cutPoint = maxLength;
+      }
+      textContent = textContent.slice(0, cutPoint).trim() + "\n\n[truncated]";
+    }
+
+    /** @type {ReadResult} */
+    const result = {
+      title: article.title || document.title,
+      content: textContent,
+      length: textContent.length,
+    };
+
+    // Include metadata if requested
+    if (includeMetadata) {
+      if (article.byline) {
+        result.byline = article.byline;
+      }
+      if (article.siteName) {
+        result.siteName = article.siteName;
+      }
+      if (article.excerpt) {
+        result.excerpt = article.excerpt;
+      }
+      if (article.publishedTime) {
+        result.publishedTime = article.publishedTime;
+      }
+    }
+
+    return result;
+  }
+
+  // ============================================================================
+
+  /**
+   * Serialize result for transport
+   * @param {any} value
+   * @returns {any}
+   */
+  function serializeResult(value) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+
+    // Handle Snapshot and SnapshotElement
+    if (value instanceof Snapshot || value instanceof SnapshotElement) {
+      return value.toJSON();
+    }
+
+    // Handle arrays
+    if (Array.isArray(value)) {
+      return value.map((v) => serializeResult(v));
+    }
+
+    // Handle objects with toJSON
+    if (typeof value === "object" && typeof value.toJSON === "function") {
+      return value.toJSON();
+    }
+
+    // Try structuredClone for other objects
+    try {
+      return structuredClone(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  /**
+   * Handle exec command - execute JavaScript with API available
+   * @param {string} code - JavaScript code to execute
+   * @returns {Promise<{result: any}>}
+   */
+  async function handleExec(code) {
+    // Create async function to allow await in code
+    const AsyncFunction = Object.getPrototypeOf(
+      async function () {},
+    ).constructor;
+
+    // Wrap code to auto-return the last expression if no explicit return
+    let wrappedCode = code.trim();
+    if (!wrappedCode.includes("return ") && !wrappedCode.includes("return;")) {
+      // Find the last statement and return it
+      const lines = wrappedCode.split("\n");
+      const lastLine = lines.pop()?.trim() || "";
+      if (lastLine && !lastLine.endsWith(";")) {
+        // Last line is an expression - return it
+        wrappedCode = [...lines, `return (${lastLine})`].join("\n");
+      } else if (lastLine) {
+        // Last line ends with semicolon - try to return it anyway
+        const expr = lastLine.slice(0, -1).trim();
+        if (
+          expr &&
+          !expr.startsWith("const ") &&
+          !expr.startsWith("let ") &&
+          !expr.startsWith("var ")
+        ) {
+          wrappedCode = [...lines, `return (${expr})`].join("\n");
+        }
+      }
+    }
+
+    // Make API functions available in the execution context
+    const fn = new AsyncFunction(
+      // Content script functions
+      "click",
+      "type",
+      "hover",
+      "drag",
+      "select",
+      "key",
+      "snap",
+      "logs",
+      "find",
+      "wait",
+      "read",
+      // Background script functions
+      "shot",
+      "tab",
+      "tabs",
+      "download",
+      wrappedCode,
+    );
+
+    const result = await fn(
+      // Content script functions
+      click,
+      type,
+      hover,
+      drag,
+      select,
+      key,
+      snap,
+      logs,
+      find,
+      wait,
+      read,
+      // Background script functions
+      shot,
+      tab,
+      tabs,
+      download,
+    );
+
+    return { result: serializeResult(result) };
+  }
+
+  browser.runtime.onMessage.addListener((message, _sender, _sendResponse) => {
+    const { command, params, messageId } = message;
+
+    // Skip if this is a response to a background script request
+    if (message.bgMessageId) {
+      return false;
+    }
+
+    if (!virtualCursor && command !== "exec") {
+      initializeVirtualCursor();
+    }
+
+    /** */
+    async function executeCommand() {
+      try {
+        let result;
+
+        switch (command) {
+          case "exec": {
+            result = await handleExec(params.code);
+            break;
+          }
+          default: {
+            throw new Error(`Unknown command: ${command}`);
+          }
+        }
+
+        browser.runtime.sendMessage({ messageId, result, success: true });
+      } catch (error) {
+        browser.runtime.sendMessage({
+          messageId,
+          error: error instanceof Error ? error.message : String(error),
+          success: false,
+        });
+      }
+    }
+
+    executeCommand();
+    return true;
+  });
+} // End of re-injection guard

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -1990,13 +1990,13 @@ function read(options = {}) {
     // Clone the document to avoid modifying the actual page
     const documentClone = d.cloneNode(true);
 
-    // Create Readability instance with options optimized for text extraction
-    const reader = new Readability(/** @type {Document} */ (documentClone), {
-      charThreshold: 100, // Lower threshold to capture more content
-    });
+    // Create Readability instance - use default charThreshold (500)
+    // which makes Readability retry with different strategies if initial
+    // extraction is too short
+    const reader = new Readability(/** @type {Document} */ (documentClone));
 
     article = reader.parse();
-    if (article && article.textContent && article.textContent.length > 100) {
+    if (article && article.textContent && article.textContent.length > 50) {
       break;
     }
   }

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -1858,6 +1858,16 @@ async function shot(path) {
 }
 
 /**
+ * Navigate the current tab to a URL
+ * Delegates to background script so navigation completes properly
+ * @param {string} url - URL to navigate to
+ * @returns {Promise<{url: string}>}
+ */
+async function go(url) {
+  return sendToBackground("go", { url });
+}
+
+/**
  * Create a new tab
  * @param {string} [url] - URL to open
  * @returns {Promise<{tabId: string, url: string}>} Tab info
@@ -2225,6 +2235,7 @@ async function handleExec(code) {
     "find",
     "wait",
     "read",
+    "go",
     // Background script functions
     "shot",
     "tab",
@@ -2246,6 +2257,7 @@ async function handleExec(code) {
     find,
     wait,
     read,
+    go,
     // Background script functions
     shot,
     tab,

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -69,9 +69,15 @@ class SnapshotElement {
    */
   toString() {
     let s = `[${this.ref}] ${this.role}`;
-    if (this.name) s += ` "${this.name}"`;
-    if (this.attrs.length > 0) s += ` [${this.attrs.join(", ")}]`;
-    if (this.value !== undefined) s += ` value="${this.value}"`;
+    if (this.name) {
+      s += ` "${this.name}"`;
+    }
+    if (this.attrs.length > 0) {
+      s += ` [${this.attrs.join(", ")}]`;
+    }
+    if (this.value !== undefined) {
+      s += ` value="${this.value}"`;
+    }
     return s;
   }
 
@@ -376,7 +382,9 @@ class SnapshotDiff {
  * Create and initialize the virtual cursor
  */
 function initializeVirtualCursor() {
-  if (virtualCursor) return;
+  if (virtualCursor) {
+    return;
+  }
 
   virtualCursor = document.createElement("div");
   virtualCursor.id = "browser-cli-cursor";
@@ -503,7 +511,9 @@ function injectConsoleOverride() {
 }
 
 window.addEventListener("message", (event) => {
-  if (event.source !== window) return;
+  if (event.source !== window) {
+    return;
+  }
 
   if (event.data && event.data.type === "browser-cli-console") {
     consoleLogs.push({
@@ -606,7 +616,9 @@ function findByRef(ref) {
 function findBySelector(selector) {
   try {
     const element = document.querySelector(selector);
-    if (element) return element;
+    if (element) {
+      return element;
+    }
     throw new Error(`No element matches CSS selector: ${selector}`);
   } catch (error) {
     if (error instanceof Error && error.name === "SyntaxError") {
@@ -645,7 +657,9 @@ function findByText(text) {
  */
 function findByAriaLabel(label) {
   const element = document.querySelector(`[aria-label="${CSS.escape(label)}"]`);
-  if (element) return element;
+  if (element) {
+    return element;
+  }
   throw new Error(`No element found with aria-label: ${label}`);
 }
 
@@ -658,7 +672,9 @@ function findByPlaceholder(placeholder) {
   const element = document.querySelector(
     `[placeholder="${CSS.escape(placeholder)}"]`,
   );
-  if (element) return element;
+  if (element) {
+    return element;
+  }
   throw new Error(`No element found with placeholder: ${placeholder}`);
 }
 
@@ -704,7 +720,9 @@ function find(selector, selectorType = "css") {
  */
 function getElementRole(element) {
   const explicitRole = element.getAttribute("role");
-  if (explicitRole) return explicitRole;
+  if (explicitRole) {
+    return explicitRole;
+  }
 
   const tag = element.tagName.toLowerCase();
 
@@ -736,9 +754,15 @@ function getElementRole(element) {
 
   if (tag === "input") {
     const type = element.getAttribute("type") || "text";
-    if (type === "checkbox") return "checkbox";
-    if (type === "radio") return "radio";
-    if (type === "submit" || type === "button") return "button";
+    if (type === "checkbox") {
+      return "checkbox";
+    }
+    if (type === "radio") {
+      return "radio";
+    }
+    if (type === "submit" || type === "button") {
+      return "button";
+    }
     return `input[${type}]`;
   }
 
@@ -753,13 +777,17 @@ function getElementRole(element) {
 function getAccessibleName(element) {
   // aria-label takes precedence
   const ariaLabel = element.getAttribute("aria-label");
-  if (ariaLabel) return ariaLabel;
+  if (ariaLabel) {
+    return ariaLabel;
+  }
 
   // aria-labelledby
   const labelledBy = element.getAttribute("aria-labelledby");
   if (labelledBy) {
     const labelEl = document.querySelector(`#${CSS.escape(labelledBy)}`);
-    if (labelEl) return labelEl.textContent?.trim() || "";
+    if (labelEl) {
+      return labelEl.textContent?.trim() || "";
+    }
   }
 
   // For inputs, check associated label
@@ -780,12 +808,16 @@ function getAccessibleName(element) {
       const label = document.querySelector(
         `label[for="${CSS.escape(element.id)}"]`,
       );
-      if (label) return label.textContent?.trim() || "";
+      if (label) {
+        return label.textContent?.trim() || "";
+      }
     }
 
     // Fall back to placeholder
     const placeholder = element.getAttribute("placeholder");
-    if (placeholder) return placeholder;
+    if (placeholder) {
+      return placeholder;
+    }
   }
 
   // alt text for images
@@ -795,7 +827,9 @@ function getAccessibleName(element) {
 
   // title attribute
   const title = element.getAttribute("title");
-  if (title) return title;
+  if (title) {
+    return title;
+  }
 
   // Text content for buttons, links, etc.
   const tag = element.tagName.toLowerCase();
@@ -863,8 +897,12 @@ function getElementAttrs(element) {
 
   // Expanded/collapsed
   const expanded = element.getAttribute("aria-expanded");
-  if (expanded === "true") attrs.push("expanded");
-  if (expanded === "false") attrs.push("collapsed");
+  if (expanded === "true") {
+    attrs.push("expanded");
+  }
+  if (expanded === "false") {
+    attrs.push("collapsed");
+  }
 
   // Readonly
   if (element.hasAttribute("readonly")) {
@@ -945,7 +983,9 @@ function shouldIncludeElement(element) {
   // Include elements with explicit roles
   if (element.hasAttribute("role")) {
     const role = element.getAttribute("role");
-    if (role && !["presentation", "none"].includes(role)) return true;
+    if (role && !["presentation", "none"].includes(role)) {
+      return true;
+    }
   }
 
   // Include headings
@@ -1040,7 +1080,9 @@ function generateSnapshot(options = {}) {
   const allElements = document.body.querySelectorAll("*");
 
   for (const element of allElements) {
-    if (!shouldIncludeElement(element)) continue;
+    if (!shouldIncludeElement(element)) {
+      continue;
+    }
 
     const role = getElementRole(element);
     const name = getAccessibleName(element);
@@ -1056,8 +1098,12 @@ function generateSnapshot(options = {}) {
       continue;
     }
 
-    if (options.links && role !== "link") continue;
-    if (options.buttons && role !== "button") continue;
+    if (options.links && role !== "link") {
+      continue;
+    }
+    if (options.buttons && role !== "button") {
+      continue;
+    }
 
     if (options.text) {
       const searchText = options.text.toLowerCase();
@@ -1843,6 +1889,177 @@ async function download(url, filename) {
 // ============================================================================
 // Message handling for background script commands
 // ============================================================================
+// Reader Mode (Mozilla Readability)
+// ============================================================================
+
+/**
+ * @typedef {object} ReadOptions
+ * @property {number} [maxLength] - Maximum length of text content (default: no limit)
+ * @property {boolean} [includeMetadata] - Include title, byline, etc. (default: true)
+ */
+
+/**
+ * @typedef {object} ReadResult
+ * @property {string} title - Article title
+ * @property {string} [byline] - Author information
+ * @property {string} [siteName] - Name of the site
+ * @property {string} [excerpt] - Short excerpt/description
+ * @property {string} [publishedTime] - Publication time
+ * @property {string} content - Plain text content of the article
+ * @property {number} length - Length of content in characters
+ */
+
+/**
+ * Collect all documents including iframes that may contain content
+ * @returns {Document[]}
+ */
+function collectDocuments() {
+  /** @type {Document[]} */
+  const docs = [document];
+  for (const f of document.querySelectorAll("iframe,frame")) {
+    try {
+      const frame = /** @type {HTMLIFrameElement | HTMLFrameElement} */ (f);
+      const v =
+        frame.contentDocument?.documentElement?.textContent?.length ?? 0;
+      if (v > 100 && frame.contentDocument) {
+        docs.push(frame.contentDocument);
+      }
+    } catch {
+      // Cross-origin iframe, skip
+    }
+  }
+  // Sort by content length (longest first)
+  docs.sort((a, b) => {
+    const aLen = a.documentElement?.textContent?.length ?? 0;
+    const bLen = b.documentElement?.textContent?.length ?? 0;
+    return bLen - aLen;
+  });
+  return docs;
+}
+
+/**
+ * Fix SVG elements that may cause issues with Readability
+ * @param {Document} doc
+ */
+function fixSVGElements(doc) {
+  for (const svg of doc.querySelectorAll("svg")) {
+    if (!svg.hasAttribute("width") || !svg.hasAttribute("height")) {
+      try {
+        const style = window.getComputedStyle(svg);
+        if (!svg.hasAttribute("width")) {
+          svg.setAttribute("width", style.width);
+        }
+        if (!svg.hasAttribute("height")) {
+          svg.setAttribute("height", style.height);
+        }
+      } catch {
+        // Skip if getComputedStyle fails
+      }
+    }
+  }
+}
+
+/**
+ * Extract readable article content from the page using Mozilla Readability
+ * Optimized for LLM consumption - returns plain text to minimize tokens
+ * @param {ReadOptions} [options] - Options for extraction
+ * @returns {ReadResult|null} Article content or null if not extractable
+ */
+function read(options = {}) {
+  // Check if Readability is available (injected before content.js)
+  if (typeof Readability === "undefined") {
+    throw new TypeError(
+      "Readability not available. This should not happen - please report a bug.",
+    );
+  }
+
+  const { maxLength, includeMetadata = true } = options;
+
+  // Fix SVG elements before cloning
+  fixSVGElements(document);
+
+  // Collect documents from main page and iframes
+  const docs = collectDocuments();
+
+  /** @type {ReturnType<Readability['parse']>} */
+  // eslint-disable-next-line unicorn/no-null -- Readability.parse() returns null
+  let article = null;
+
+  // Try each document until we find readable content
+  for (const d of docs) {
+    // Clone the document to avoid modifying the actual page
+    const documentClone = d.cloneNode(true);
+
+    // Create Readability instance with options optimized for text extraction
+    const reader = new Readability(/** @type {Document} */ (documentClone), {
+      charThreshold: 100, // Lower threshold to capture more content
+    });
+
+    article = reader.parse();
+    if (article && article.textContent && article.textContent.length > 100) {
+      break;
+    }
+  }
+
+  if (!article) {
+    // eslint-disable-next-line unicorn/no-null -- null indicates "no article found" (matches Readability API)
+    return null;
+  }
+
+  // Get plain text content
+  let textContent = article.textContent || "";
+
+  // Normalize whitespace: collapse multiple newlines/spaces
+  textContent = textContent
+    .replaceAll(/\n{3,}/g, "\n\n") // Max 2 consecutive newlines
+    .replaceAll(/[ \t]+/g, " ") // Collapse horizontal whitespace
+    .replaceAll(/\n +/g, "\n") // Remove leading spaces on lines
+    .replaceAll(/ +\n/g, "\n") // Remove trailing spaces on lines
+    .trim();
+
+  // Apply max length if specified
+  if (maxLength && textContent.length > maxLength) {
+    // Try to cut at a sentence or paragraph boundary
+    let cutPoint = textContent.lastIndexOf("\n\n", maxLength);
+    if (cutPoint < maxLength * 0.5) {
+      cutPoint = textContent.lastIndexOf(". ", maxLength);
+      if (cutPoint > 0) {
+        cutPoint += 1;
+      } // Include the period
+    }
+    if (cutPoint < maxLength * 0.5) {
+      cutPoint = maxLength;
+    }
+    textContent = textContent.slice(0, cutPoint).trim() + "\n\n[truncated]";
+  }
+
+  /** @type {ReadResult} */
+  const result = {
+    title: article.title || document.title,
+    content: textContent,
+    length: textContent.length,
+  };
+
+  // Include metadata if requested
+  if (includeMetadata) {
+    if (article.byline) {
+      result.byline = article.byline;
+    }
+    if (article.siteName) {
+      result.siteName = article.siteName;
+    }
+    if (article.excerpt) {
+      result.excerpt = article.excerpt;
+    }
+    if (article.publishedTime) {
+      result.publishedTime = article.publishedTime;
+    }
+  }
+
+  return result;
+}
+
+// ============================================================================
 
 /**
  * Serialize result for transport
@@ -1922,6 +2139,7 @@ async function handleExec(code) {
     "logs",
     "find",
     "wait",
+    "read",
     // Background script functions
     "shot",
     "tab",
@@ -1942,6 +2160,7 @@ async function handleExec(code) {
     logs,
     find,
     wait,
+    read,
     // Background script functions
     shot,
     tab,

--- a/browser-cli/extension/eslint.config.js
+++ b/browser-cli/extension/eslint.config.js
@@ -3,6 +3,10 @@ import jsdoc from "eslint-plugin-jsdoc";
 import unicorn from "eslint-plugin-unicorn";
 
 export default [
+  {
+    // Ignore vendored files - must be first and standalone
+    ignores: ["Readability.js"],
+  },
   js.configs.recommended,
   unicorn.configs.recommended,
   {
@@ -48,6 +52,7 @@ export default [
         NodeFilter: "readonly",
         SubmitEvent: "readonly",
         MutationObserver: "readonly",
+        Readability: "readonly",
       },
     },
     plugins: {

--- a/browser-cli/extension/global.d.ts
+++ b/browser-cli/extension/global.d.ts
@@ -1,1 +1,32 @@
 /// <reference types="firefox-webext-browser" />
+
+// Mozilla Readability library (injected before content.js)
+declare class Readability {
+  constructor(
+    doc: Document,
+    options?: {
+      debug?: boolean;
+      maxElemsToParse?: number;
+      nbTopCandidates?: number;
+      charThreshold?: number;
+      classesToPreserve?: string[];
+      keepClasses?: boolean;
+      disableJSONLD?: boolean;
+      serializer?: (el: Element) => string;
+      allowedVideoRegex?: RegExp;
+      linkDensityModifier?: number;
+    },
+  );
+  parse(): {
+    title: string;
+    content: string;
+    textContent: string;
+    length: number;
+    excerpt: string;
+    byline: string | null;
+    dir: string | null;
+    siteName: string | null;
+    lang: string | null;
+    publishedTime: string | null;
+  } | null;
+}

--- a/browser-cli/extension/jsconfig.json
+++ b/browser-cli/extension/jsconfig.json
@@ -15,5 +15,5 @@
     "types": ["firefox-webext-browser"]
   },
   "include": ["*.js", "*.d.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "Readability.js"]
 }

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.28",
+  "version": "1.0.30",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.34",
+  "version": "1.0.36",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.32",
+  "version": "1.0.34",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.25",
+  "version": "1.0.28",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/package.json
+++ b/browser-cli/extension/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "typecheck": "tsc --project ./jsconfig.json --noEmit",
-    "lint": "eslint *.js",
-    "lint:fix": "eslint *.js --fix",
+    "lint": "eslint --no-warn-ignored *.js",
+    "lint:fix": "eslint --no-warn-ignored *.js --fix",
     "start": "web-ext run",
     "build": "web-ext build"
   },

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -110,15 +110,23 @@ await download(url, "invoice.pdf")  // Downloads to ~/Downloads/invoice.pdf
 EOF
 ```
 
-## Screenshots & Tabs
+## Navigation & Tabs
+
+```bash
+browser-cli <<'EOF'
+await go("https://example.com")   // Navigate current tab (use for scripts)
+await tab()                       // New tab
+await tab("https://example.com")  // New tab with URL (switches context)
+await tabs()                      // List all tabs
+EOF
+```
+
+## Screenshots
 
 ```bash
 browser-cli <<'EOF'
 await shot()                      // Screenshot, returns data URL
 await shot("/tmp/page.png")       // Screenshot to file
-await tab()                       // New tab
-await tab("https://example.com")  // New tab with URL
-await tabs()                      // List all tabs
 EOF
 ```
 

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -78,18 +78,18 @@ EOF
 
 Output:
 
-```json
-{
-  "title": "Article Title",
-  "byline": "John Doe",
-  "siteName": "Example News",
-  "excerpt": "Brief description...",
-  "content": "Full article text...",
-  "length": 12345
-}
+```
+Article Title
+=============
+By: John Doe
+Source: Example News
+
+----------------------------------------
+
+Full article text...
 ```
 
-Returns `null` if page content is not suitable for reader mode.
+Returns empty output if page content is not suitable for reader mode.
 
 ## Waiting
 

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -67,12 +67,12 @@ Extract readable article content using Mozilla Readability. Returns plain text
 optimized for LLM consumption.
 
 ```bash
-browser-cli <<'EOF'
-await tab("https://example.com/article")
-read()                            // Extract article as plain text
-read({maxLength: 5000})           // Limit content length
-read({includeMetadata: false})    // Skip title/byline/etc
-EOF
+# Navigate and read article in one go
+browser-cli TABID --go "https://example.com/article" && browser-cli TABID <<< 'read()'
+
+# Options
+read({maxLength: 5000})        // Limit content length
+read({includeMetadata: false}) // Skip title/byline/etc
 ```
 
 Output:
@@ -113,12 +113,19 @@ EOF
 ## Navigation & Tabs
 
 ```bash
+# Navigate current tab to URL (waits for load)
+browser-cli TABID --go "https://example.com"
+
+# Then run commands on the loaded page
+browser-cli TABID <<< "read()"
+
+# Open new tab (note: switches execution context)
 browser-cli <<'EOF'
-await go("https://example.com")   // Navigate current tab (use for scripts)
-await tab()                       // New tab
-await tab("https://example.com")  // New tab with URL (switches context)
-await tabs()                      // List all tabs
+await tab("https://example.com")
 EOF
+
+# List all tabs
+browser-cli <<< "await tabs()"
 ```
 
 ## Screenshots

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -62,6 +62,35 @@ logs()                    // Get console logs
 EOF
 ```
 
+## Reader Mode (Article Extraction)
+
+Extract readable article content using Mozilla Readability. Returns plain text
+optimized for LLM consumption.
+
+```bash
+browser-cli <<'EOF'
+await tab("https://example.com/article")
+read()                            // Extract article as plain text
+read({maxLength: 5000})           // Limit content length
+read({includeMetadata: false})    // Skip title/byline/etc
+EOF
+```
+
+Output:
+
+```json
+{
+  "title": "Article Title",
+  "byline": "John Doe",
+  "siteName": "Example News",
+  "excerpt": "Brief description...",
+  "content": "Full article text...",
+  "length": 12345
+}
+```
+
+Returns `null` if page content is not suitable for reader mode.
+
 ## Waiting
 
 ```bash

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -57,7 +57,6 @@ snap({forms: true})       // Only form elements
 snap({links: true})       // Only links
 snap({buttons: true})     // Only buttons
 snap({text: "login"})     // Elements containing "login"
-diff()                    // Show changes since last snap
 logs()                    // Get console logs
 EOF
 ```


### PR DESCRIPTION
## Reader Mode (Article Extraction)

Extract readable article content using Mozilla Readability. Returns plain text
optimized for LLM consumption.

```bash
browser-cli <<'EOF'
await tab("https://example.com/article")
read()                            // Extract article as plain text
read({maxLength: 5000})           // Limit content length
read({includeMetadata: false})    // Skip title/byline/etc
EOF
```

Output:

```
Article Title
=============
By: John Doe
Source: Example News

----------------------------------------

Full article text...
```

Returns empty output if page content is not suitable for reader mode.