### PR TITLE
db-cli: add --deutschlandticket flag

### DIFF
--- a/db-cli/bin/db-cli.mjs
+++ b/db-cli/bin/db-cli.mjs
@@ -17,6 +17,7 @@ Options:
   -d, --departure <time>   Departure time (ISO format or relative like "in 2 hours")
   -a, --arrival <time>     Arrival time (ISO format or relative like "by 18:00")
   -r, --results <number>   Number of results to show (default: 3)
+  -t, --deutschlandticket  Only show Deutschlandticket-compatible transport (no ICE/IC/EC)
   -h, --help              Show this help message
 
 Examples:
@@ -24,6 +25,7 @@ Examples:
   db-cli --departure "2024-12-25T14:00" Berlin München
   db-cli -d "in 30 minutes" "Hamburg Hbf" "Frankfurt Hbf"
   db-cli --arrival "18:00" Köln Stuttgart
+  db-cli -t "Berlin Hbf" "München Hbf"
 `;
 
 function parseCommandLineArgs() {
@@ -40,6 +42,10 @@ function parseCommandLineArgs() {
       type: "string",
       short: "r",
       default: "3",
+    },
+    deutschlandticket: {
+      type: "boolean",
+      short: "t",
     },
     help: {
       type: "boolean",
@@ -74,6 +80,7 @@ async function main() {
       departure: values.departure,
       arrival: values.arrival,
       results: parseInt(values.results, 10),
+      deutschlandticket: values.deutschlandticket,
     });
   } catch (error) {
     console.error(`Error: ${error.message}`);

--- a/db-cli/lib/bahn-url-builder.mjs
+++ b/db-cli/lib/bahn-url-builder.mjs
@@ -25,27 +25,36 @@ function buildTimeParams(departure, arrival) {
   return [`hd=${isoDate}`, arrival ? "hza=A" : "hza=D"];
 }
 
-function buildAdditionalParams() {
+function buildAdditionalParams(deutschlandticket) {
+  const transportTypes = deutschlandticket
+    ? "vm=02,03,04,05,06,07,08,09" // Deutschlandticket: no ICE (00), no IC/EC (01)
+    : "vm=00,01,02,03,04,05,06,07,08,09"; // all transport types
   return [
     "hz=%5B%5D", // empty array
     "ar=false", // no arrival
     "s=true", // search
     "d=false", // no direct connections only
-    "vm=00,01,02,03,04,05,06,07,08,09", // all transport types
+    transportTypes,
     "fm=false", // no first minute
     "bp=false", // no best price
-    "dlt=false", // no Deutschland ticket
-    "dltv=false", // no Deutschland ticket variant
+    `dlt=${deutschlandticket ? "true" : "false"}`,
+    `dltv=${deutschlandticket ? "true" : "false"}`,
   ];
 }
 
-export default function generateBahnDeUrl(from, to, departure, arrival) {
+export default function generateBahnDeUrl(
+  from,
+  to,
+  departure,
+  arrival,
+  { deutschlandticket = false } = {},
+) {
   const baseUrl = "https://www.bahn.de/buchung/fahrplan/suche";
   const hashParams = [
     ...buildBasicParams(from, to),
     ...buildStationParams(from, to),
     ...buildTimeParams(departure, arrival),
-    ...buildAdditionalParams(),
+    ...buildAdditionalParams(deutschlandticket),
   ];
   return `${baseUrl}#${hashParams.join("&")}`;
 }

--- a/db-cli/lib/index.mjs
+++ b/db-cli/lib/index.mjs
@@ -6,7 +6,14 @@ import { displayResults } from "./journey-display.mjs";
 import { handleStationSearch } from "./station-search.mjs";
 
 export async function searchJourneys(options) {
-  const { from, to, departure, arrival, results = 3 } = options;
+  const {
+    from,
+    to,
+    departure,
+    arrival,
+    results = 3,
+    deutschlandticket,
+  } = options;
 
   const client = createClient(dbProfile, "db-cli/1.0.0");
 
@@ -23,6 +30,22 @@ export async function searchJourneys(options) {
     stopovers: true,
     tickets: true,
   };
+
+  if (deutschlandticket) {
+    journeyOptions.products = {
+      nationalExpress: false, // no ICE
+      national: false, // no IC/EC
+      regionalExpress: true,
+      regional: true,
+      suburban: true,
+      bus: true,
+      ferry: true,
+      subway: true,
+      tram: true,
+      taxi: false,
+    };
+    console.log("Filtering for Deutschlandticket-compatible transport only");
+  }
 
   if (departure) {
     journeyOptions.departure = parseTime(departure);
@@ -55,6 +78,7 @@ export async function searchJourneys(options) {
     toLocation,
     journeyOptions.departure,
     journeyOptions.arrival,
+    { deutschlandticket },
   );
 
   // Display results


### PR DESCRIPTION
Adds a -t/--deutschlandticket option that excludes ICE and IC/EC from search results, showing only Deutschlandticket-compatible transport (regional trains, S-Bahn, U-Bahn, bus, tram, ferry). The filter is applied both to the API query and the generated bahn.de URL.