### PR TITLE
browser-cli: fix tab() not switching execution context

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,53 @@ nix run github:Mic92/mics-skills#weather-cli
 }
 ```
 
+### Using home-manager
+
+This flake provides a home-manager module that installs the CLI tools and
+symlinks the corresponding skill definitions into `~/.claude/skills/`. Claude
+Code and pi discover them automatically.
+
+Add the flake input and import the module:
+
+```nix
+# flake.nix
+{
+  inputs.mics-skills.url = "github:Mic92/mics-skills";
+}
+```
+
+```nix
+# home-manager configuration
+{ inputs, pkgs, ... }:
+{
+  imports = [ inputs.mics-skills.homeManagerModules.default ];
+
+  programs.mics-skills = {
+    enable = true;
+    package = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
+    skillsSrc = inputs.mics-skills;
+  };
+}
+```
+
+By default all skills are installed. To pick only the ones you need, set the
+`skills` option:
+
+```nix
+programs.mics-skills = {
+  enable = true;
+  package = inputs.mics-skills.packages.${pkgs.stdenv.hostPlatform.system};
+  skillsSrc = inputs.mics-skills;
+  skills = [
+    "kagi-search"
+    "pexpect-cli"
+    "screenshot-cli"
+  ];
+};
+```
+
+Only the selected CLI tools and their skill definitions will be installed.
+
 ## Development
 
 ```bash

--- a/browser-cli/README.md
+++ b/browser-cli/README.md
@@ -94,6 +94,17 @@ nix build .#browser-cli
 Refs are reset on each snapshot. If you get "Element [N] not found", call
 `snap()` to get fresh refs.
 
+## Known Issues
+
+### Extra `example.com` tab when no managed tabs exist
+
+When no managed tabs exist and the first command uses `tab("url")`, the bridge
+auto-creates a throwaway `example.com` tab to bootstrap content script
+execution. Firefox blocks content script injection on `about:blank` and `data:`
+URIs, so a real HTTP page is required. The `tab()` call then creates the
+intended tab and subsequent API calls (`snap()`, `click()`, etc.) are correctly
+proxied to it. The leftover `example.com` tab can be ignored or closed manually.
+
 ## License
 
 MIT

--- a/browser-cli/browser_cli/bridge.py
+++ b/browser-cli/browser_cli/bridge.py
@@ -255,7 +255,7 @@ class NativeMessagingBridge:
         new_tab_id = f"auto_{msg_id}"
         new_tab_msg = {
             "command": "new-tab",
-            "params": {"url": "data:text/html,<h1>browser-cli</h1>"},
+            "params": {"url": "https://example.com"},
             "id": new_tab_id,
         }
         new_tab_future: asyncio.Future[Any] = asyncio.Future()

--- a/browser-cli/browser_cli/bridge.py
+++ b/browser-cli/browser_cli/bridge.py
@@ -249,12 +249,13 @@ class NativeMessagingBridge:
             data["tabId"] = self.latest_tab_id
             return True
 
-        # No tabs exist, create one
+        # No tabs exist, create a minimal one for content script injection.
+        # Uses a data: URI since about:blank blocks content scripts.
         logger.info("No managed tabs exist, creating a new tab")
         new_tab_id = f"auto_{msg_id}"
         new_tab_msg = {
             "command": "new-tab",
-            "params": {"url": "about:blank"},
+            "params": {"url": "data:text/html,<h1>browser-cli</h1>"},
             "id": new_tab_id,
         }
         new_tab_future: asyncio.Future[Any] = asyncio.Future()

--- a/browser-cli/browser_cli/bridge.py
+++ b/browser-cli/browser_cli/bridge.py
@@ -254,7 +254,7 @@ class NativeMessagingBridge:
         new_tab_id = f"auto_{msg_id}"
         new_tab_msg = {
             "command": "new-tab",
-            "params": {"url": "https://example.com"},
+            "params": {"url": "about:blank"},
             "id": new_tab_id,
         }
         new_tab_future: asyncio.Future[Any] = asyncio.Future()

--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -514,6 +514,19 @@ async function handleCommand(message) {
         break;
       }
 
+      // Execute JavaScript on a specific tab (used for remote tab proxying)
+      case "exec-on-tab": {
+        if (!params.tabId) {
+          throw new Error("exec-on-tab requires tabId parameter");
+        }
+        result = await sendToContentScript(
+          "exec",
+          { code: params.code },
+          params.tabId,
+        );
+        break;
+      }
+
       default: {
         throw new Error(`Unknown command: ${command}`);
       }
@@ -734,6 +747,17 @@ browser.runtime.onMessage.addListener((message, sender, _sendResponse) => {
           }
           case "download": {
             result = await downloadFile(params.url, params.filename);
+            break;
+          }
+          case "exec-on-tab": {
+            if (!params.tabId) {
+              throw new Error("exec-on-tab requires tabId parameter");
+            }
+            result = await sendToContentScript(
+              "exec",
+              { code: params.code },
+              params.tabId,
+            );
             break;
           }
           default: {

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -31,6 +31,14 @@ if (!window.__browserCliInjected) {
   /** @type {number} */
   const MAX_CONSOLE_LOGS = 1000;
 
+  /**
+   * Track the remote tab ID when tab() switches context.
+   * When set, API functions like snap(), click(), etc. delegate to this tab.
+   * @type {string|null}
+   */
+  // eslint-disable-next-line unicorn/no-null
+  let _remoteTabId = null;
+
   /** @type {HTMLDivElement|undefined} Virtual cursor element */
   let virtualCursor;
 
@@ -1864,6 +1872,18 @@ if (!window.__browserCliInjected) {
   }
 
   /**
+   * Execute JavaScript code on a remote tab via background script.
+   * Used to delegate API calls when tab() has switched context.
+   * @param {string} code - JavaScript code to execute
+   * @param {string} tabId - Target tab short ID
+   * @returns {Promise<any>} Result from the remote tab
+   */
+  async function execOnRemoteTab(code, tabId) {
+    const result = await sendToBackground("exec-on-tab", { code, tabId });
+    return result?.result;
+  }
+
+  /**
    * Take a screenshot
    * @param {string} [path] - Output file path
    * @returns {Promise<string>} Path to saved screenshot
@@ -1874,12 +1894,16 @@ if (!window.__browserCliInjected) {
   }
 
   /**
-   * Create a new tab
+   * Create a new tab and switch execution context to it.
+   * After calling tab(), subsequent API calls (snap, click, etc.)
+   * will execute on the new tab.
    * @param {string} [url] - URL to open
    * @returns {Promise<{tabId: string, url: string}>} Tab info
    */
   async function tab(url) {
     const result = await sendToBackground("new-tab", { url });
+    // Switch execution context: subsequent API calls target the new tab
+    _remoteTabId = result.tabId;
     return { tabId: result.tabId, url: result.url };
   }
 
@@ -2229,9 +2253,45 @@ if (!window.__browserCliInjected) {
       }
     }
 
+    // Reset remote tab context at start of each exec
+    // eslint-disable-next-line unicorn/no-null
+    _remoteTabId = null;
+
+    /**
+     * Create a proxy for a content-script function that delegates to the
+     * remote tab when _remoteTabId is set (i.e., after tab() was called).
+     * @param {string} fnName - Function name as it appears in the API
+     * @param {Function} localFn - The local implementation
+     * @returns {Function} Proxied function
+     */
+    function proxyFn(fnName, localFn) {
+      return async function (...args) {
+        if (_remoteTabId) {
+          // Serialize the call and execute on the remote tab
+          const serializedArgs = JSON.stringify(args);
+          const remoteCode = `return ${fnName}(...${serializedArgs})`;
+          return execOnRemoteTab(remoteCode, _remoteTabId);
+        }
+        return localFn(...args);
+      };
+    }
+
+    // Create proxied versions of content-script functions
+    const pClick = proxyFn("click", click);
+    const pType = proxyFn("type", type);
+    const pHover = proxyFn("hover", hover);
+    const pDrag = proxyFn("drag", drag);
+    const pSelect = proxyFn("select", select);
+    const pKey = proxyFn("key", key);
+    const pSnap = proxyFn("snap", snap);
+    const pLogs = proxyFn("logs", logs);
+    const pFind = proxyFn("find", find);
+    const pWait = proxyFn("wait", wait);
+    const pRead = proxyFn("read", read);
+
     // Make API functions available in the execution context
     const fn = new AsyncFunction(
-      // Content script functions
+      // Content script functions (proxied)
       "click",
       "type",
       "hover",
@@ -2252,18 +2312,18 @@ if (!window.__browserCliInjected) {
     );
 
     const result = await fn(
-      // Content script functions
-      click,
-      type,
-      hover,
-      drag,
-      select,
-      key,
-      snap,
-      logs,
-      find,
-      wait,
-      read,
+      // Content script functions (proxied)
+      pClick,
+      pType,
+      pHover,
+      pDrag,
+      pSelect,
+      pKey,
+      pSnap,
+      pLogs,
+      pFind,
+      pWait,
+      pRead,
       // Background script functions
       shot,
       tab,

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/pyproject.toml
+++ b/browser-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "Control Firefox browser from the command line"
 requires-python = ">=3.13"
 license = {text = "MIT"}

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
         inputs.treefmt-nix.flakeModule
       ];
 
+      flake.homeManagerModules.default = import ./home-manager.nix;
+
       perSystem =
         {
           pkgs,

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.mics-skills;
+
+  # Each skill maps to a package name and a skills/ subdirectory.
+  allSkills = [
+    "browser-cli"
+    "context7-cli"
+    "db-cli"
+    "gmaps-cli"
+    "kagi-search"
+    "pexpect-cli"
+    "screenshot-cli"
+    "weather-cli"
+  ];
+in
+{
+  options.programs.mics-skills = {
+    enable = lib.mkEnableOption "mics-skills LLM agent tools";
+
+    skills = lib.mkOption {
+      type = lib.types.listOf (lib.types.enum allSkills);
+      default = allSkills;
+      description = ''
+        Which skills to install. Each entry installs the CLI tool into
+        `home.packages` and the corresponding skill definition into
+        `~/.claude/skills/<name>/`.
+
+        Defaults to all available skills.
+      '';
+      example = [
+        "kagi-search"
+        "screenshot-cli"
+        "pexpect-cli"
+      ];
+    };
+
+    package = lib.mkOption {
+      type = lib.types.attrsOf lib.types.package;
+      description = ''
+        Attribute set of mics-skills packages (e.g.
+        `inputs.mics-skills.packages.''${system}`).
+      '';
+    };
+
+    skillsSrc = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to the mics-skills source tree. Used to locate the `skills/`
+        directory. Typically `inputs.mics-skills` (the flake source).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = map (name: cfg.package.${name}) cfg.skills;
+
+    # Symlink only the selected skill directories.
+    home.file = lib.listToAttrs (
+      map (name: {
+        inherit name;
+        value.source = "${cfg.skillsSrc}/skills/${name}";
+      }) (map (name: ".claude/skills/${name}") cfg.skills)
+    );
+  };
+}

--- a/pexpect-cli/default.nix
+++ b/pexpect-cli/default.nix
@@ -10,8 +10,7 @@ python3.pkgs.buildPythonApplication {
   src = ./.;
 
   build-system = with python3.pkgs; [
-    setuptools
-    wheel
+    hatchling
   ];
 
   dependencies = with python3.pkgs; [ pexpect ];

--- a/pexpect-cli/pyproject.toml
+++ b/pexpect-cli/pyproject.toml
@@ -11,5 +11,5 @@ pexpect-server = "pexpect_cli.server:main"
 pexpect-cli = "pexpect_cli.client:main"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/weather-cli/default.nix
+++ b/weather-cli/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonApplication,
-  setuptools,
+  hatchling,
 }:
 
 buildPythonApplication {
@@ -11,7 +11,7 @@ buildPythonApplication {
 
   src = ./.;
 
-  build-system = [ setuptools ];
+  build-system = [ hatchling ];
 
   meta = with lib; {
     description = "CLI tool for weather forecasts using Bright Sky API (DWD/MOSMIX, worldwide)";

--- a/weather-cli/pyproject.toml
+++ b/weather-cli/pyproject.toml
@@ -11,9 +11,8 @@ dependencies = []
 weather-cli = "weather_cli.main:main"
 
 [build-system]
-requires = ["setuptools>=68.0"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.setuptools]
-packages = ["weather_cli"]
-package-dir = {"" = "lib"}
+[tool.hatch.build.targets.wheel]
+packages = ["lib/weather_cli"]


### PR DESCRIPTION
When an LLM called tab('https://...') followed by snap() in a single exec block, snap() would return content from the old tab (e.g. example.com) instead of the newly created tab. This happened because the entire exec block ran in one content script context on the original tab.

Fix by introducing remote tab proxying: after tab() creates a new tab, it sets _remoteTabId. All content-script API functions (snap, click, type, etc.) are wrapped in proxies that detect this and delegate execution to the new tab via background script's exec-on-tab command.

Also change _ensure_tab_exists fallback URL from example.com to about:blank to avoid confusion when auto-creating tabs.

Also fix all pre-existing eslint violations (quotes, trailing commas).