### PR TITLE
home-manager: fix double path in skill symlinks

### DIFF
--- a/home-manager.nix
+++ b/home-manager.nix
@@ -62,9 +62,9 @@ in
     # Symlink only the selected skill directories.
     home.file = lib.listToAttrs (
       map (name: {
-        inherit name;
+        name = ".claude/skills/${name}";
         value.source = "${cfg.skillsSrc}/skills/${name}";
-      }) (map (name: ".claude/skills/${name}") cfg.skills)
+      }) cfg.skills
     );
   };
 }


### PR DESCRIPTION
The listToAttrs mapped over the already-prefixed home.file key (".claude/skills/<name>") but then used it again in the source path, producing broken symlinks like skills/.claude/skills/kagi-search.