### PR TITLE
kagi-search: show summary by default, make links opt-in

### DIFF
--- a/kagi-search/kagi_search.py
+++ b/kagi-search/kagi_search.py
@@ -467,7 +467,10 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Search Kagi using session token")
     parser.add_argument("query", nargs="?", help="Search query")
     parser.add_argument(
-        "-n", "--num-results", type=int, default=10, help="Number of results (default: 10)"
+        "-n", "--num-results", type=int, default=3, help="Number of link results (default: 3)"
+    )
+    parser.add_argument(
+        "-l", "--links", action="store_true", help="Show search result links (hidden by default)"
     )
     parser.add_argument("-t", "--token", help="Session token (overrides config)")
     parser.add_argument("-c", "--config", help="Config file path")
@@ -500,7 +503,7 @@ def main() -> None:
 
     # Perform search
     try:
-        results = client.search(args.query, limit=args.num_results)
+        results = client.search(args.query, limit=args.num_results) if args.links else []
         quick_answer = client.get_quick_answer(args.query)
     except Exception as e:
         error_msg = colorize(f"Search failed: {e}", color="red", bold=True)
@@ -545,28 +548,35 @@ def main() -> None:
                     if ref_title and ref_url:
                         ref_link = hyperlink(ref_url, colorize(ref_title, color="blue"))
                         print(f"  {ref_num} {ref_link}")
+                        url_text = colorize(ref_url, color="green", dim=True)
+                        url_with_link = hyperlink(ref_url, url_text)
+                        print(f"      {url_with_link}")
 
             print(colorize("─" * 80, color="cyan", dim=True))
-            print()  # Extra newline before search results
-        for i, result in enumerate(results, 1):
-            # Result number in yellow/bold
-            number = colorize(f"{i}.", color="yellow", bold=True)
-            # Title in blue/bold with hyperlink
-            title = colorize(result.title, color="blue", bold=True)
-            title_with_link = hyperlink(result.url, title)
-            print(f"\n{number} {title_with_link}")
 
-            # URL in green with hyperlink
-            url_text = colorize(result.url, color="green")
-            url_with_link = hyperlink(result.url, url_text)
-            print(f"   {url_with_link}")
+        # Display search result links only when --links is passed
+        if results:
+            if quick_answer:
+                print()  # Extra newline after Quick Answer
+            for i, result in enumerate(results, 1):
+                # Result number in yellow/bold
+                number = colorize(f"{i}.", color="yellow", bold=True)
+                # Title in blue/bold with hyperlink
+                title = colorize(result.title, color="blue", bold=True)
+                title_with_link = hyperlink(result.url, title)
+                print(f"\n{number} {title_with_link}")
 
-            # Snippet in default color but dim
-            if result.snippet:
-                snippet = colorize(result.snippet, dim=True)
-                print(f"   {snippet}")
+                # URL in green with hyperlink
+                url_text = colorize(result.url, color="green")
+                url_with_link = hyperlink(result.url, url_text)
+                print(f"   {url_with_link}")
 
-    if not results and not args.json:
+                # Snippet in default color but dim
+                if result.snippet:
+                    snippet = colorize(result.snippet, dim=True)
+                    print(f"   {snippet}")
+
+    if not quick_answer and not results and not args.json:
         error_msg = colorize("No results found", color="red")
         print(error_msg, file=sys.stderr)
 

--- a/skills/kagi-search/SKILL.md
+++ b/skills/kagi-search/SKILL.md
@@ -6,30 +6,17 @@ description: Search the web using Kagi. Use for web searches with Quick Answer A
 # Usage
 
 ```bash
-# Basic search (includes Quick Answer)
+# Basic search (shows Quick Answer summary only)
 kagi-search "what is the capital of France"
+
+# Include search result links (default: 3 links)
+kagi-search -l "search query"
+
+# Include more links
+kagi-search -l -n 10 "search query"
 
 # JSON output for parsing
 kagi-search -j "search query" | jq '.results[0].url'
-
-# Extract Quick Answer
-kagi-search -j "search query" | jq '.quick_answer.markdown'
-
-# Limit number of results
-kagi-search -n 5 "search query"
-
-# With explicit token
-kagi-search -t "TOKEN" "search query"
-
-# Enable debug logging
-kagi-search -d "search query"
 ```
-
-# Output Format
-
-Results include:
-
-- Quick Answer (AI-generated summary with references)
-- Search results with title, URL, and snippet
 
 See [README.md](../../kagi-search/README.md) for setup and configuration.


### PR DESCRIPTION
Most searches only need the Quick Answer summary, not a list of links. Fetching search results adds latency and clutter for the common case.

Show only the Quick Answer by default and require -l/--links to also display search result links. Lower the default link count to 3 since the full list is rarely needed.

Also show reference URLs below their titles so they are visible in terminals without OSC 8 hyperlink support.