### PR TITLE
calendar-cli: replace khal with direct vdirsyncer store access

### DIFF
--- a/calendar-cli/README.md
+++ b/calendar-cli/README.md
@@ -1,0 +1,56 @@
+# calendar-cli
+
+CLI tool for managing local vdirsyncer calendars.
+
+Reads and writes `.ics` files directly in the vdirsyncer filesystem store
+(`~/.local/share/calendars/`) using the `icalendar` Python library. No khal
+dependency required.
+
+Also supports sending meeting invitations, importing calendar invites from
+email, and replying to invitations with RSVP responses (via msmtp).
+
+## Subcommands
+
+| Command     | Description                                            |
+| ----------- | ------------------------------------------------------ |
+| `calendars` | List available calendars                               |
+| `list`      | List events (date range, calendar filter)              |
+| `show`      | Show a single event by UID                             |
+| `search`    | Search events by text (summary, location, description) |
+| `new`       | Create a new local event                               |
+| `edit`      | Edit an existing event                                 |
+| `delete`    | Delete an event by UID                                 |
+| `invite`    | Create and send a meeting invitation via email         |
+| `import`    | Import invites, process RSVP replies & cancellations   |
+| `reply`     | RSVP to a calendar invitation                          |
+
+## Requirements
+
+- Python 3.13+
+- vdirsyncer (for calendar sync)
+- msmtp (optional, for sending invitations and replies)
+
+## Configuration
+
+Organizer email/name for `invite` can be set in
+`~/.config/vcal/config.toml`:
+
+```toml
+[user]
+email = "user@example.com"
+name = "User Name"
+```
+
+## Integration with aerc
+
+Add to your aerc `binds.conf`:
+
+```ini
+ii = :pipe -m calendar-cli import<Enter>
+ia = :pipe -m calendar-cli reply accept<Enter>
+id = :pipe -m calendar-cli reply decline<Enter>
+it = :pipe -m calendar-cli reply tentative<Enter>
+```
+
+Use `ii` for **all** incoming calendar emails: new invites,
+attendee responses, and cancellations are detected automatically.

--- a/calendar-cli/calendar_cli/__init__.py
+++ b/calendar-cli/calendar_cli/__init__.py
@@ -1,0 +1,3 @@
+"""CLI tool for managing local vdirsyncer calendars."""
+
+__version__ = "1.0.0"

--- a/calendar-cli/calendar_cli/config.py
+++ b/calendar-cli/calendar_cli/config.py
@@ -1,0 +1,139 @@
+"""Configuration utilities for vcal."""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .errors import ConfigError
+
+
+def ensure_type[T](value: Any, expected_type: type[T], field_name: str) -> T:  # noqa: ANN401
+    """Ensure a value is of the expected type.
+
+    Args:
+        value: The value to check
+        expected_type: The expected type (e.g., str, int, bool)
+        field_name: Name of the field for error messages
+
+    Returns:
+        The value if it matches the type
+
+    Raises:
+        ConfigError: If type doesn't match
+
+    """
+    if not isinstance(value, expected_type):
+        msg = f"'{field_name}' must be {expected_type.__name__}, got {type(value).__name__}"
+        raise ConfigError(msg)
+    return value
+
+
+@dataclass
+class UserConfig:
+    """User configuration."""
+
+    email: str
+    name: str | None = None
+
+
+@dataclass
+class VcalConfig:
+    """Complete vcal configuration."""
+
+    user: UserConfig | None = None
+
+
+def validate_config_data(data: dict[str, Any]) -> VcalConfig:
+    """Validate and convert raw config data to VcalConfig.
+
+    Raises:
+        ConfigError: If configuration is invalid
+
+    """
+    config = VcalConfig()
+
+    if "user" in data:
+        user_data = ensure_type(data["user"], dict, "user")
+
+        # Email is required in user section
+        if "email" not in user_data:
+            msg = "'email' is required in [user] section"
+            raise ConfigError(msg)
+
+        email = ensure_type(user_data["email"], str, "user.email")
+        parts = email.split("@")
+        if len(parts) != 2 or not parts[0] or not parts[1] or "." not in parts[1]:
+            msg = f"Invalid email address: {email}"
+            raise ConfigError(msg)
+
+        # Name is optional
+        name = None
+        if "name" in user_data:
+            name = ensure_type(user_data["name"], str, "user.name")
+
+        config.user = UserConfig(email=email, name=name)
+
+    return config
+
+
+def load_config() -> VcalConfig:
+    """Load configuration from ~/.config/vcal/config.toml.
+
+    Example config file:
+    [user]
+    email = "user@example.com"
+    name = "User Name"  # Optional
+
+    Returns:
+        VcalConfig with loaded settings
+
+    Raises:
+        ConfigError: If config file exists but is invalid
+
+    """
+    config_file = Path.home() / ".config" / "vcal" / "config.toml"
+    if not config_file.exists():
+        return VcalConfig()
+
+    try:
+        with config_file.open("rb") as f:
+            data = tomllib.load(f)
+    except OSError as e:
+        msg = f"Failed to read config file: {e}"
+        raise ConfigError(msg) from e
+    except tomllib.TOMLDecodeError as e:
+        msg = f"Invalid TOML in config file: {e}"
+        raise ConfigError(msg) from e
+
+    return validate_config_data(data)
+
+
+def load_config_or_exit() -> VcalConfig:
+    """Load config, exit with error message if invalid.
+
+    This is a convenience function for CLI usage.
+    """
+    try:
+        return load_config()
+    except ConfigError as e:
+        print(f"Error in ~/.config/vcal/config.toml: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def resolve_user_name(user_email: str) -> str:
+    """Get user display name from config, falling back to the email local part.
+
+    Loads ~/.config/vcal/config.toml and returns [user].name if set.
+    Otherwise derives a title-cased name from the part before '@'.
+    """
+    try:
+        config = load_config()
+        if config.user and config.user.name:
+            return config.user.name
+    except ConfigError:
+        pass
+    return user_email.split("@", maxsplit=1)[0].replace(".", " ").title()

--- a/calendar-cli/calendar_cli/create.py
+++ b/calendar-cli/calendar_cli/create.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Generate ICS calendar invites and send them via msmtp.
+
+Supports attendees with names/emails and meeting links.
+"""
+
+from __future__ import annotations
+
+import argparse
+import email.utils
+import os
+import pwd
+import re
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from icalendar import Alarm, Calendar, Event, vCalAddress, vText
+
+from .config import load_config_or_exit
+from .email_invite import EmailConfig, build_invite_email, send_invite_email
+from .errors import InvalidInputError
+from .store import atomic_write
+from .timeutil import parse_datetime
+from .util import add_vtimezones, new_calendar, parse_rrule_string
+
+
+@dataclass
+class MeetingConfig:
+    """Configuration for a meeting invitation."""
+
+    summary: str
+    start: datetime
+    end: datetime
+    organizer_name: str
+    organizer_email: str
+    attendees: list[tuple[str, str]]
+    location: str | None = None
+    meeting_link: str | None = None
+    description: str | None = None
+    reminder_minutes: int = 15
+    tz: str = "UTC"
+    recurrence: dict[str, object] | None = None
+
+
+@dataclass
+class CreateConfig:
+    """Configuration for create command."""
+
+    meeting: MeetingConfig
+    output_ics: str | None = None
+    output_email: str | None = None
+    dry_run: bool = False
+    calendar_dir: str = "~/.local/share/calendars/personal"
+    no_local_save: bool = False
+
+
+def validate_email(email: str) -> None:
+    """Validate email has proper format with username@domain.tld."""
+    if "@" not in email:
+        msg = f"Invalid email address (missing @): {email}"
+        raise InvalidInputError(msg)
+
+    # Split and validate parts
+    parts = email.split("@")
+    expected_parts = 2
+    if len(parts) != expected_parts or not parts[0] or not parts[1]:
+        msg = f"Invalid email address format: {email}"
+        raise InvalidInputError(msg)
+
+    # Basic domain validation - must have at least one dot
+    if "." not in parts[1]:
+        msg = f"Invalid email domain (missing dot): {email}"
+        raise InvalidInputError(msg)
+
+
+def parse_attendees(attendees_str: str) -> list[tuple[str, str]]:
+    """Parse attendee string format: 'Name <email>' or just 'email'."""
+    attendees: list[tuple[str, str]] = []
+    # Handle empty string
+    if not attendees_str.strip():
+        return attendees
+
+    for attendee_str in attendees_str.split(","):
+        attendee = attendee_str.strip()
+        if not attendee:  # Skip empty items from split
+            continue
+
+        # Use email.utils.parseaddr to parse the email
+        parsed_name, parsed_email = email.utils.parseaddr(attendee)
+
+        # parseaddr returns ('', '') for completely invalid input
+        if not parsed_email:
+            msg = f"Invalid email address: {attendee}"
+            raise InvalidInputError(msg)
+
+        # Validate email format
+        validate_email(parsed_email)
+
+        attendees.append((parsed_name, parsed_email))
+
+    return attendees
+
+
+def _build_invite_description(config: MeetingConfig) -> str | None:
+    """Build event description with optional meeting link."""
+    parts = []
+    if config.description:
+        parts.append(config.description)
+    if config.meeting_link:
+        parts.append(f"\nJoin meeting: {config.meeting_link}")
+    return "\n".join(parts) if parts else None
+
+
+def _build_invite_event(config: MeetingConfig) -> Event:
+    """Build the VEVENT component for a calendar invite."""
+    now = datetime.now(UTC)
+    event = Event()
+
+    event.add("summary", config.summary)
+    event.add("dtstart", config.start)
+    event.add("dtend", config.end)
+    event.add("dtstamp", now)
+    event.add("created", now)
+    event.add("uid", f"{uuid.uuid4()}@calendar-invite-generator")
+    event.add("sequence", 0)
+    event.add("status", "CONFIRMED")
+    event.add("transp", "OPAQUE")
+
+    if config.location:
+        event.add("location", config.location)
+
+    desc = _build_invite_description(config)
+    if desc:
+        event.add("description", desc)
+
+    # Organizer
+    organizer = vCalAddress(f"mailto:{config.organizer_email}")
+    organizer.params["cn"] = vText(config.organizer_name)
+    event.add("organizer", organizer)
+
+    # Organizer as attendee (so it appears in their calendar)
+    org_attendee = vCalAddress(f"mailto:{config.organizer_email}")
+    org_attendee.params["cn"] = vText(config.organizer_name)
+    org_attendee.params["partstat"] = vText("ACCEPTED")
+    org_attendee.params["role"] = vText("REQ-PARTICIPANT")
+    event.add("attendee", org_attendee)
+
+    # Invited attendees
+    for name, email_addr in config.attendees:
+        attendee = vCalAddress(f"mailto:{email_addr}")
+        if name:
+            attendee.params["cn"] = vText(name)
+        attendee.params["partstat"] = vText("NEEDS-ACTION")
+        attendee.params["rsvp"] = vText("TRUE")
+        attendee.params["role"] = vText("REQ-PARTICIPANT")
+        event.add("attendee", attendee)
+
+    # Reminder alarm
+    alarm = Alarm()
+    alarm.add("action", "DISPLAY")
+    alarm.add("description", f"Reminder: {config.summary}")
+    alarm.add("trigger", timedelta(minutes=-config.reminder_minutes))
+    event.add_component(alarm)
+
+    if config.recurrence:
+        event.add("rrule", config.recurrence)
+
+    return event
+
+
+def create_calendar_invite(config: MeetingConfig) -> Calendar:
+    """Create an ICS calendar invite."""
+    cal = new_calendar(method="REQUEST")
+    add_vtimezones(cal, config.start, config.end)
+    cal.add_component(_build_invite_event(config))
+    return cal
+
+
+def get_organizer_info(args: argparse.Namespace) -> tuple[str, str]:
+    """Get organizer name and email from args or system."""
+    # Load config once (will exit on error)
+    config = load_config_or_exit()
+
+    # Try to get name from args, then config, then system
+    organizer_name = args.organizer_name
+    if not organizer_name and config.user:
+        organizer_name = config.user.name
+
+    if not organizer_name:
+        try:
+            # Try to get the real name from passwd entry
+            pw_entry = pwd.getpwuid(os.getuid())
+            organizer_name = pw_entry.pw_gecos.split(",")[0]
+            # Fallback to username if gecos is empty
+            if not organizer_name:
+                organizer_name = pw_entry.pw_name
+        except (KeyError, OSError):
+            # Last resort fallback
+            organizer_name = "Meeting Organizer"
+
+    # Try to get email from args, then config
+    organizer_email = args.organizer_email
+    if not organizer_email and config.user:
+        organizer_email = config.user.email
+
+    return organizer_name, organizer_email
+
+
+def parse_meeting_time(
+    args: argparse.Namespace,
+    tz: ZoneInfo,
+) -> tuple[datetime, datetime]:
+    """Parse start time and calculate end time."""
+    if args.start:
+        start = parse_datetime(args.start, str(tz))
+    else:
+        # Default to next hour
+        now = datetime.now(tz)
+        start = now.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+
+    end = start + timedelta(minutes=args.duration)
+    return start, end
+
+
+def parse_recurrence_options(
+    args: argparse.Namespace,
+    tz: ZoneInfo,
+) -> dict[str, Any] | None:
+    """Parse recurrence options from command line arguments."""
+    if args.rrule:
+        return parse_rrule_string(args.rrule)
+
+    if not args.repeat:
+        return None
+
+    # Build recurrence rule from simple options
+    rrule: dict[str, Any] = {}
+
+    # Set frequency
+    freq_map = {
+        "daily": "DAILY",
+        "weekly": "WEEKLY",
+        "biweekly": "WEEKLY",
+        "monthly": "MONTHLY",
+        "yearly": "YEARLY",
+    }
+    rrule["FREQ"] = freq_map[args.repeat]
+
+    # Handle biweekly
+    if args.repeat == "biweekly":
+        rrule["INTERVAL"] = 2
+
+    # Handle weekdays for weekly recurrence
+    if args.repeat in ["weekly", "biweekly"] and args.weekdays:
+        # Split comma-separated weekdays into a list
+        rrule["BYDAY"] = [day.strip().upper() for day in args.weekdays.split(",")]
+
+    # Handle count or until
+    if args.count:
+        rrule["COUNT"] = args.count
+    elif args.until:
+        try:
+            until_date = datetime.strptime(args.until, "%Y-%m-%d")  # noqa: DTZ007
+            # Convert to UTC for iCalendar - use datetime object directly
+            until_dt = until_date.replace(hour=23, minute=59, second=59).replace(
+                tzinfo=tz
+            )
+            rrule["UNTIL"] = until_dt.astimezone(UTC)
+        except ValueError:
+            msg = "Invalid until date format. Use YYYY-MM-DD"
+            raise InvalidInputError(msg) from None
+
+    return rrule
+
+
+def save_ics_file(cal: Calendar, output: str | None, start: datetime) -> None:
+    """Save ICS file if requested."""
+    if output:
+        output_file = output
+    else:
+        # Generate filename from summary and date
+        event = cal.walk("vevent")[0]
+        summary = str(event.get("summary", "meeting"))
+        safe_summary = re.sub(r"[^\w\s-]", "", summary).strip().replace(" ", "-")
+        date_str = start.strftime("%Y%m%d")
+        output_file = f"{safe_summary}-{date_str}.ics"
+
+    output_path = Path(output_file)
+    try:
+        with output_path.open("wb") as f:
+            f.write(cal.to_ical())
+    except OSError as e:
+        msg = f"Failed to write {output_path}: {e}"
+        raise InvalidInputError(msg) from e
+
+
+def save_to_local_calendar(cal: Calendar, calendar_dir: str) -> None:
+    """Save event to local calendar directory (atomically)."""
+    cal_dir = Path(calendar_dir).expanduser()
+    if cal_dir.is_dir():
+        # Generate unique filename using UID
+        event_uid = cal.walk("vevent")[0]["UID"]
+        calendar_file = cal_dir / f"{event_uid}.ics"
+        try:
+            atomic_write(calendar_file, cal.to_ical())
+        except OSError as e:
+            print(
+                f"Warning: failed to save to local calendar: {e}",
+                file=sys.stderr,
+            )
+
+
+def format_recurrence_description(recurrence: dict[str, object]) -> str:
+    """Format recurrence rule into human-readable description."""
+    recur_desc = []
+    freq = str(recurrence.get("FREQ", "")).lower()
+    if freq:
+        interval = recurrence.get("INTERVAL", 1)
+        biweekly_interval = 2
+        if interval == biweekly_interval and freq == "weekly":
+            recur_desc.append("Repeats: biweekly")
+        else:
+            recur_desc.append(f"Repeats: {freq}")
+
+    if "BYDAY" in recurrence:
+        days = recurrence["BYDAY"]
+        if isinstance(days, list):
+            recur_desc.append(f"on {','.join(days)}")
+        else:
+            recur_desc.append(f"on {days}")
+
+    if "COUNT" in recurrence:
+        recur_desc.append(f"for {recurrence['COUNT']} occurrences")
+    elif "UNTIL" in recurrence:
+        until = recurrence["UNTIL"]
+        if isinstance(until, datetime):
+            recur_desc.append(f"until {until.strftime('%Y-%m-%d')}")
+
+    return " ".join(recur_desc)
+
+
+def print_meeting_details(config: MeetingConfig) -> None:
+    """Print meeting details summary."""
+    # Show recurrence info
+    if config.recurrence:
+        recur_desc = format_recurrence_description(config.recurrence)
+        if recur_desc:
+            print(f"Recurrence: {recur_desc}")
+
+    print("\nAttendees:")
+    for name, email_addr in config.attendees:
+        if name:
+            print(f"  - {name} <{email_addr}>")
+        else:
+            print(f"  - {email_addr}")
+
+    if config.meeting_link:
+        print(f"\nMeeting link: {config.meeting_link}")
+
+
+def run(config: CreateConfig) -> int:
+    """Run the invite command with the given configuration."""
+    cal = create_calendar_invite(config.meeting)
+
+    # Save .ics file if requested
+    if config.output_ics:
+        save_ics_file(cal, config.output_ics, config.meeting.start)
+
+    # Save to local calendar if not disabled
+    if not config.no_local_save:
+        save_to_local_calendar(cal, config.calendar_dir)
+
+    # Build the email
+    email_config = EmailConfig(
+        cal=cal,
+        config=config.meeting,
+        dry_run=config.dry_run,
+    )
+    msg = build_invite_email(email_config)
+
+    # Export email to file or stdout
+    if config.output_email:
+        if config.output_email == "-":
+            sys.stdout.write(msg.as_string())
+        else:
+            try:
+                Path(config.output_email).write_text(msg.as_string())
+            except OSError as e:
+                err_msg = f"Failed to write {config.output_email}: {e}"
+                raise InvalidInputError(err_msg) from e
+        return 0
+
+    # Print meeting details (only when sending, not exporting)
+    print_meeting_details(config.meeting)
+
+    # Send via msmtp
+    if not config.dry_run:
+        send_invite_email(msg)
+
+    return 0
+
+
+def _handle_args(args: argparse.Namespace) -> int:
+    # Parse timezone
+    try:
+        tz = ZoneInfo(args.timezone)
+    except ZoneInfoNotFoundError:
+        msg = f"Unknown timezone: {args.timezone}"
+        raise InvalidInputError(msg) from None
+
+    # Parse time and attendees
+    start, end = parse_meeting_time(args, tz)
+    attendees = parse_attendees(args.attendees)
+
+    if not attendees:
+        msg = "No valid attendees specified"
+        raise InvalidInputError(msg)
+
+    # Get organizer info
+    organizer_name, organizer_email = get_organizer_info(args)
+
+    # Validate organizer email
+    if not organizer_email:
+        msg = (
+            "Organizer email is required. "
+            "Use --organizer-email or create ~/.config/vcal/config.toml with:\n"
+            "[user]\n"
+            'email = "your@email.com"'
+        )
+        raise InvalidInputError(msg)
+
+    validate_email(organizer_email)
+
+    # Parse recurrence options
+    recurrence = parse_recurrence_options(args, tz)
+
+    # Create meeting config
+    meeting = MeetingConfig(
+        summary=args.summary,
+        start=start,
+        end=end,
+        organizer_name=organizer_name,
+        organizer_email=organizer_email,
+        attendees=attendees,
+        location=args.location,
+        meeting_link=args.meeting_link,
+        description=args.description,
+        reminder_minutes=args.reminder,
+        tz=args.timezone,
+        recurrence=recurrence,
+    )
+
+    # Create full config
+    config = CreateConfig(
+        meeting=meeting,
+        output_ics=args.output_ics,
+        output_email=args.output_email,
+        dry_run=args.dry_run,
+        calendar_dir=args.calendar_dir or "~/.local/share/calendars/personal",
+        no_local_save=args.no_local_save,
+    )
+
+    return run(config)
+
+
+def register_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the invite subcommand."""
+    parser = subparsers.add_parser(
+        "invite",
+        help="Create and send calendar invitations via email",
+        description="Generate and send ICS calendar invites via email",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Simple meeting
+  calendar-cli invite -s "Team Meeting" -d 60 -a "john@example.com,Jane Doe <jane@example.com>"
+
+  # Meeting with Zoom link
+  calendar-cli invite -s "Project Review" -d 90 -a "team@example.com" \\
+    -l "https://zoom.us/j/123456789" --meeting-link "https://zoom.us/j/123456789"
+
+  # Specific time and timezone
+  calendar-cli invite -s "Client Call" --start "2024-01-15 14:00" -d 30 \\
+    -a "Client Name <client@company.com>" --timezone "America/New_York"
+
+  # Weekly recurring meeting for 10 weeks
+  calendar-cli invite -s "Weekly Standup" -d 30 -a "team@example.com" \\
+    --repeat weekly --count 10
+
+  # Export email to file instead of sending
+  calendar-cli invite -s "Meeting" -a "test@example.com" \\
+    --timezone UTC --output-email invite.eml
+
+  # Save just the .ics file
+  calendar-cli invite -s "Meeting" -a "test@example.com" \\
+    --timezone UTC --output-ics meeting.ics --output-email /dev/null
+        """,
+    )
+
+    # Add all arguments from create_argument_parser
+    parser.add_argument("-s", "--summary", required=True, help="Meeting title/summary")
+    parser.add_argument(
+        "--start",
+        help="Start time (YYYY-MM-DD HH:MM), defaults to next hour",
+    )
+    parser.add_argument(
+        "-d",
+        "--duration",
+        type=int,
+        default=60,
+        help="Duration in minutes (default: 60)",
+    )
+    parser.add_argument(
+        "-a",
+        "--attendees",
+        required=True,
+        help='Comma-separated attendees: "Name <email>" or just "email"',
+    )
+    parser.add_argument("--organizer-name", help="Your name (defaults to system user)")
+    parser.add_argument(
+        "--organizer-email",
+        help="Your email (can also be set in ~/.config/vcal/config.toml)",
+    )
+    parser.add_argument("-l", "--location", help="Meeting location")
+    parser.add_argument("--meeting-link", help="Meeting URL (Zoom, Teams, etc.)")
+    parser.add_argument("--description", help="Additional meeting description")
+    parser.add_argument(
+        "--reminder",
+        type=int,
+        default=15,
+        help="Reminder minutes before (default: 15)",
+    )
+    parser.add_argument(
+        "--timezone",
+        required=True,
+        help="Olson timezone, e.g. Europe/Berlin, America/New_York",
+    )
+    parser.add_argument(
+        "--output-ics",
+        help="Save .ics file to path",
+    )
+    parser.add_argument(
+        "--output-email",
+        help="Write full email (.eml) to path instead of sending ('-' for stdout)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be sent without sending",
+    )
+
+    parser.add_argument(
+        "--no-local-save",
+        action="store_true",
+        help="Do not save to local calendar",
+    )
+
+    # Recurrence options
+    recurrence_group = parser.add_argument_group("recurrence options")
+    recurrence_group.add_argument(
+        "--repeat",
+        choices=["daily", "weekly", "biweekly", "monthly", "yearly"],
+        help="Simple recurrence pattern",
+    )
+    recurrence_group.add_argument(
+        "--count",
+        type=int,
+        help="Number of occurrences (e.g., --repeat weekly --count 10)",
+    )
+    recurrence_group.add_argument(
+        "--until",
+        help="End date for recurrence (YYYY-MM-DD)",
+    )
+    recurrence_group.add_argument(
+        "--weekdays",
+        help="Comma-separated weekdays for weekly recurrence (e.g., MO,WE,FR)",
+    )
+    recurrence_group.add_argument(
+        "--rrule",
+        help="Custom iCalendar RRULE string (e.g., 'FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10')",
+    )
+
+    parser.set_defaults(func=_handle_args)

--- a/calendar-cli/calendar_cli/email_invite.py
+++ b/calendar-cli/calendar_cli/email_invite.py
@@ -1,0 +1,122 @@
+"""Build and send calendar invite emails via msmtp."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from email import encoders
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import TYPE_CHECKING
+
+from .errors import SendError
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from icalendar import Calendar
+
+    from .create import MeetingConfig
+
+
+def _format_time_with_tz(dt: datetime) -> str:
+    """Format a time as ``HH:MM AM/PM TZ``, with a safe timezone suffix.
+
+    ``strftime("%Z")`` returns an empty string for naive datetimes, which
+    would leave a stray trailing space.  This helper uses the tzname when
+    available and falls back to the numeric UTC offset (``%z``) or omits
+    the suffix entirely for naive datetimes.
+    """
+    time_part = dt.strftime("%I:%M %p")
+    if dt.tzinfo is not None:
+        tz_label = dt.tzname() or dt.strftime("%z")
+        if tz_label:
+            return f"{time_part} {tz_label}"
+    return time_part
+
+
+@dataclass
+class EmailConfig:
+    """Configuration for sending email."""
+
+    cal: Calendar
+    config: MeetingConfig
+    dry_run: bool = False
+
+
+def _sanitize_header(value: str) -> str:
+    """Strip CR/LF and other control characters that could cause header injection."""
+    return value.translate(str.maketrans("", "", "\r\n\x00"))
+
+
+def build_invite_email(email_config: EmailConfig) -> MIMEMultipart:
+    """Build the MIME email message for a calendar invite."""
+    summary = _sanitize_header(email_config.config.summary)
+    org_name = _sanitize_header(email_config.config.organizer_name)
+    org_email = _sanitize_header(email_config.config.organizer_email)
+
+    msg = MIMEMultipart("mixed")
+    msg["Subject"] = f"Invitation: {summary}"
+    msg["From"] = f"{org_name} <{org_email}>"
+
+    # Build recipient list
+    to_list = []
+    for name, email_addr in email_config.config.attendees:
+        clean_addr = _sanitize_header(email_addr)
+        if name:
+            to_list.append(f"{_sanitize_header(name)} <{clean_addr}>")
+        else:
+            to_list.append(clean_addr)
+
+    msg["To"] = ", ".join(to_list)
+
+    # Create email body
+    start_time = _format_time_with_tz(email_config.config.start)
+    end_time = _format_time_with_tz(email_config.config.end)
+    body_text = f"""You have been invited to: {email_config.config.summary}
+
+When: {email_config.config.start.strftime("%A, %B %d, %Y")}
+Time: {start_time} - {end_time}"""
+
+    if email_config.config.meeting_link:
+        body_text += f"\n\nJoin meeting: {email_config.config.meeting_link}"
+
+    body_text += "\n\nPlease see the attached calendar invitation for details."
+
+    # Add text part
+    msg.attach(MIMEText(body_text, "plain"))
+
+    # Add calendar part
+    cal_part = MIMEBase("text", "calendar")
+    cal_part.set_payload(email_config.cal.to_ical())
+    cal_part.add_header("Content-Disposition", 'attachment; filename="invite.ics"')
+    cal_part.replace_header(
+        "Content-Type",
+        'text/calendar; charset="UTF-8"; method=REQUEST',
+    )
+    encoders.encode_base64(cal_part)
+    msg.attach(cal_part)
+
+    return msg
+
+
+def send_invite_email(msg: MIMEMultipart) -> None:
+    """Send a MIME email message via msmtp.
+
+    Raises ``SendError`` on failure.
+    """
+    try:
+        result = subprocess.run(
+            ["msmtp", "-t"],
+            input=msg.as_string(),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:
+        err_msg = f"Failed to run msmtp: {e}"
+        raise SendError(err_msg) from e
+    if result.returncode != 0:
+        err_msg = f"msmtp failed: {result.stderr.strip()}"
+        raise SendError(err_msg)

--- a/calendar-cli/calendar_cli/errors.py
+++ b/calendar-cli/calendar_cli/errors.py
@@ -1,0 +1,36 @@
+"""Error hierarchy for calendar-cli.
+
+All user-facing errors inherit from ``CalendarCliError`` so the top-level
+CLI can catch them in one place and print a clean message without a
+traceback.
+"""
+
+from __future__ import annotations
+
+
+class CalendarCliError(Exception):
+    """Base for all calendar-cli errors that should produce a clean message."""
+
+
+class ConfigError(CalendarCliError):
+    """Invalid or missing configuration."""
+
+
+class EventNotFoundError(CalendarCliError):
+    """Referenced event UID does not exist."""
+
+
+class CalendarNotFoundError(CalendarCliError):
+    """Referenced calendar directory does not exist."""
+
+
+class InvalidInputError(CalendarCliError):
+    """User-provided input is invalid (bad date, email, regex, etc.)."""
+
+
+class ParseError(CalendarCliError):
+    """Failed to parse calendar/email data."""
+
+
+class SendError(CalendarCliError):
+    """Failed to send email via msmtp."""

--- a/calendar-cli/calendar_cli/import_invite.py
+++ b/calendar-cli/calendar_cli/import_invite.py
@@ -1,0 +1,430 @@
+"""Import calendar invites from email or .ics files."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from icalendar import Calendar, Event
+
+from .store import atomic_write, generate_uid, uid_to_filename
+from .timeutil import normalize_windows_tzid
+from .util import (
+    extract_calendar_parts_from_email,
+    get_attendee_list,
+    new_calendar,
+    strip_mailto,
+)
+
+
+@dataclass
+class ImportConfig:
+    """Configuration for import command."""
+
+    file_path: str | None = None
+    calendar: str = "personal"
+    calendars_dir: str = "~/.local/share/calendars"
+
+
+# Re-export for backward compatibility (used by tests)
+extract_calendar_from_email = extract_calendar_parts_from_email
+
+
+def _collect_tzids(events: list[Event]) -> set[str]:
+    """Return TZID strings referenced by date properties in events."""
+    tzids: set[str] = set()
+    for event in events:
+        for prop in ("DTSTART", "DTEND", "DUE", "RECURRENCE-ID"):
+            val = event.get(prop)
+            if val is not None and hasattr(val, "params"):
+                tzid = val.params.get("TZID")
+                if tzid:
+                    tzids.add(str(tzid))
+    return tzids
+
+
+def _build_per_uid_calendar(
+    events: list[Event],
+    timezones: dict[str, object],
+) -> bytes:
+    """Build a VCALENDAR containing all events for one UID plus their timezones."""
+    out_cal = new_calendar()
+
+    for tzid in sorted(_collect_tzids(events)):
+        if tzid in timezones:
+            out_cal.add_component(timezones[tzid])
+
+    for event in events:
+        out_cal.add_component(event)
+
+    result: bytes = out_cal.to_ical()
+    return result
+
+
+def _find_existing_ics(uid: str, calendars_dir: str) -> Path | None:
+    """Find the .ics file for a UID across all calendars.
+
+    First checks the expected filename (fast path), then falls back
+    to parsing each .ics file with icalendar to extract the UID
+    (handles line-folded UIDs and filename mismatches).
+    """
+    base = Path(calendars_dir).expanduser()
+    if not base.is_dir():
+        return None
+    for cal_subdir in base.iterdir():
+        if not cal_subdir.is_dir():
+            continue
+        # Check direct children and one level deeper
+        for ics_dir in [cal_subdir, *[d for d in cal_subdir.iterdir() if d.is_dir()]]:
+            candidate = ics_dir / f"{uid_to_filename(uid)}.ics"
+            if candidate.exists():
+                return candidate
+            # Fallback: parse each file to extract UID properly
+            for ics_file in ics_dir.glob("*.ics"):
+                try:
+                    cal = Calendar.from_ical(ics_file.read_bytes())
+                    for component in cal.walk():
+                        if (
+                            component.name == "VEVENT"
+                            and str(component.get("uid", "")) == uid
+                        ):
+                            return ics_file
+                except (ValueError, OSError):
+                    continue
+    return None
+
+
+def _handle_cancel(
+    events_by_uid: dict[str, list[Event]],
+    calendars_dir: str,
+) -> int:
+    """Handle METHOD:CANCEL — delete or mark matching events as CANCELLED.
+
+    Returns the number of events processed.
+    """
+    count = 0
+    for uid in events_by_uid:
+        existing = _find_existing_ics(uid, calendars_dir)
+        if existing is not None:
+            try:
+                existing.unlink()
+            except OSError as e:
+                print(f"Warning: failed to delete {existing}: {e}", file=sys.stderr)
+                continue
+            print(f"Cancelled event: {uid}")
+            count += 1
+        else:
+            print(f"Warning: cancel for unknown event {uid}", file=sys.stderr)
+    return count
+
+
+def _extract_reply_statuses(
+    reply_events: list[Event],
+) -> list[tuple[str, str]]:
+    """Extract (email, new_partstat) pairs from REPLY VEVENTs."""
+    result: list[tuple[str, str]] = []
+    for reply_ev in reply_events:
+        for reply_att in get_attendee_list(reply_ev):
+            email_addr = strip_mailto(str(reply_att)).lower()
+            status = str(reply_att.params.get("PARTSTAT", "NEEDS-ACTION"))
+            result.append((email_addr, status))
+    return result
+
+
+def _apply_partstat_updates(
+    cal: Calendar,
+    updates: list[tuple[str, str]],
+    uid: str,
+) -> int:
+    """Apply PARTSTAT updates to attendees in a parsed calendar. Returns count."""
+    count = 0
+    for component in cal.walk():
+        if component.name != "VEVENT":
+            continue
+        for att in get_attendee_list(component):
+            att_email = strip_mailto(str(att)).lower()
+            for reply_email, new_status in updates:
+                if att_email == reply_email:
+                    att.params["PARTSTAT"] = new_status
+                    print(f"Updated {reply_email} → {new_status} for {uid}")
+                    count += 1
+    return count
+
+
+def _handle_reply(
+    events_by_uid: dict[str, list[Event]],
+    calendars_dir: str,
+) -> int:
+    """Handle METHOD:REPLY — update PARTSTAT for the replying attendee.
+
+    Returns the number of events processed.
+    """
+    count = 0
+    for uid, reply_events in events_by_uid.items():
+        existing = _find_existing_ics(uid, calendars_dir)
+        if existing is None:
+            print(f"Warning: reply for unknown event {uid}", file=sys.stderr)
+            continue
+
+        try:
+            cal = Calendar.from_ical(existing.read_bytes())
+        except (ValueError, OSError):
+            continue
+
+        updates = _extract_reply_statuses(reply_events)
+        count += _apply_partstat_updates(cal, updates, uid)
+        atomic_write(existing, cal.to_ical())
+
+    return count
+
+
+def _collect_components(
+    cal: Calendar,
+) -> tuple[dict[str, object], dict[str, list[Event]]]:
+    """Collect VTIMEZONEs and group VEVENTs by UID from a parsed calendar."""
+    timezones: dict[str, object] = {}
+    events_by_uid: dict[str, list[Event]] = {}
+    for component in cal.walk():
+        if component.name == "VTIMEZONE":
+            raw_tzid = component.get("TZID")
+            if not raw_tzid:
+                continue
+            raw_tzid = str(raw_tzid)
+            timezones[raw_tzid] = component
+            timezones[normalize_windows_tzid(raw_tzid)] = component
+        elif component.name == "VEVENT":
+            uid = str(component.get("uid", ""))
+            if not uid:
+                uid = generate_uid()
+                component.add("uid", uid)
+            events_by_uid.setdefault(uid, []).append(component)
+    return timezones, events_by_uid
+
+
+def _ensure_calendar_dir(calendars_dir: str, calendar_name: str) -> Path | None:
+    """Create the calendar directory, returning the path or None on failure."""
+    cal_dir = Path(calendars_dir).expanduser() / calendar_name
+    try:
+        cal_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        print(
+            f"Error: failed to create calendar directory {cal_dir}: {e}",
+            file=sys.stderr,
+        )
+        return None
+    return cal_dir
+
+
+def import_to_local(
+    calendar_data: bytes,
+    calendar_name: str,
+    calendars_dir: str = "~/.local/share/calendars",
+) -> bool:
+    """Import calendar data by writing .ics files to the local store.
+
+    Inspects the METHOD property (RFC 6047) to handle different iTIP
+    message types:
+
+    - REQUEST / PUBLISH / missing: save events to the local store
+    - CANCEL: delete the matching local event
+    - REPLY: update attendee PARTSTAT in the existing local event
+
+    Groups VEVENTs by UID (so recurring events with RECURRENCE-ID stay
+    together), includes referenced VTIMEZONEs, and writes one .ics file
+    per UID — matching khal/vdirsyncer conventions.
+
+    Sanitization applied during import:
+    - Windows timezone names converted to Olson (Outlook compatibility)
+    - Events without UID get a generated one (sha256 of content)
+    - Filenames with unsafe chars get SHA-1 hashed
+    - Writes are atomic (tempfile + rename)
+    """
+    try:
+        cal = Calendar.from_ical(calendar_data)
+    except (ValueError, TypeError) as e:
+        print(f"Error parsing calendar data: {e}", file=sys.stderr)
+        return False
+
+    # Check METHOD for iTIP dispatch (RFC 6047)
+    method = str(cal.get("method", "")).upper()
+
+    timezones, events_by_uid = _collect_components(cal)
+    if not events_by_uid:
+        return False
+
+    if method == "CANCEL":
+        return _handle_cancel(events_by_uid, calendars_dir) > 0
+
+    if method == "REPLY":
+        return _handle_reply(events_by_uid, calendars_dir) > 0
+
+    # REQUEST, PUBLISH, or no method — save to local store
+    cal_dir = _ensure_calendar_dir(calendars_dir, calendar_name)
+    if cal_dir is None:
+        return False
+
+    for uid, events in events_by_uid.items():
+        filepath = cal_dir / f"{uid_to_filename(uid)}.ics"
+        atomic_write(filepath, _build_per_uid_calendar(events, timezones))
+
+    return True
+
+
+def sync_calendar() -> None:
+    """Sync calendar with server using vdirsyncer."""
+    try:
+        result = subprocess.run(
+            ["vdirsyncer", "sync"], check=False, capture_output=True
+        )
+    except FileNotFoundError:
+        print("Warning: vdirsyncer not found, skipping sync", file=sys.stderr)
+        return
+    if result.returncode != 0:
+        stderr = result.stderr.decode(errors="replace").strip()
+        print(f"Warning: vdirsyncer sync failed: {stderr}", file=sys.stderr)
+
+
+def process_input(file_path: str | None) -> list[bytes]:
+    """Process input and extract calendar data from a file or stdin."""
+    calendars: list[bytes] = []
+
+    if file_path:
+        path = Path(file_path)
+        if not path.exists():
+            print(f"Error: File '{file_path}' not found", file=sys.stderr)
+            return []
+
+        try:
+            content = path.read_bytes()
+        except OSError as e:
+            print(f"Error: failed to read '{file_path}': {e}", file=sys.stderr)
+            return []
+
+        if path.suffix.lower() == ".ics":
+            if b"BEGIN:VCALENDAR" in content:
+                calendars.append(content)
+        else:
+            calendars.extend(extract_calendar_parts_from_email(content))
+    else:
+        content = sys.stdin.buffer.read()
+        email_calendars = extract_calendar_parts_from_email(content)
+        if email_calendars:
+            calendars.extend(email_calendars)
+        elif b"BEGIN:VCALENDAR" in content and not content.startswith(b"Content-Type:"):
+            calendars.append(content)
+
+    return calendars
+
+
+def _calendar_has_rsvp(cal_data: bytes) -> bool:
+    """Check if calendar data contains RSVP requests by parsing the iCalendar structure."""
+    try:
+        cal = Calendar.from_ical(cal_data)
+    except (ValueError, TypeError):
+        return False
+    for component in cal.walk():
+        if component.name != "VEVENT":
+            continue
+        for attendee in get_attendee_list(component):
+            if hasattr(attendee, "params"):
+                rsvp = str(attendee.params.get("RSVP", "")).upper()
+                if rsvp == "TRUE":
+                    return True
+    return False
+
+
+def import_calendars(
+    calendars: list[bytes],
+    calendar_name: str,
+    calendars_dir: str = "~/.local/share/calendars",
+) -> tuple[int, bool]:
+    """Import calendar data. Returns (imported_count, has_rsvp)."""
+    imported = 0
+    has_rsvp = False
+
+    for cal_data in calendars:
+        if _calendar_has_rsvp(cal_data):
+            has_rsvp = True
+
+        if import_to_local(cal_data, calendar_name, calendars_dir):
+            imported += 1
+            print("Successfully imported calendar")
+        else:
+            print("Warning: Failed to import calendar", file=sys.stderr)
+
+    return imported, has_rsvp
+
+
+def run(config: ImportConfig) -> int:
+    """Run the import command with the given configuration."""
+    calendars = process_input(config.file_path)
+
+    if not calendars:
+        print("No .ics files found in the input", file=sys.stderr)
+        return 1
+
+    imported, has_rsvp = import_calendars(
+        calendars, config.calendar, config.calendars_dir
+    )
+
+    if imported == 0:
+        return 1
+
+    sync_calendar()
+
+    print(f"Successfully imported {imported} calendar invite(s) to {config.calendar}")
+
+    if has_rsvp:
+        print(
+            "Hint: This invite requests an RSVP. "
+            "Use 'calendar-cli reply accept|decline|tentative <file>' to respond."
+        )
+
+    return 0
+
+
+def _handle_args(args: argparse.Namespace) -> int:
+    """Handle parsed arguments and run the command."""
+    from .store import _resolve_calendars_dir  # noqa: PLC0415
+
+    calendars_dir = str(_resolve_calendars_dir(getattr(args, "calendar_dir", None)))
+    config = ImportConfig(
+        file_path=args.file,
+        calendar=args.calendar,
+        calendars_dir=calendars_dir,
+    )
+    return run(config)
+
+
+def register_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the import subcommand."""
+    parser = subparsers.add_parser(
+        "import",
+        help="Import invites, process RSVP replies, and handle cancellations",
+        description="Process any incoming calendar email:\n\n"
+        "  - New invites        → saved to local calendar\n"
+        "  - Attendee responses → updates their accept/decline status\n"
+        "  - Cancellations      → removes the event locally\n\n"
+        "Pipe any calendar email through this command — the action\n"
+        "is detected automatically from the .ics content.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-c",
+        "--calendar",
+        default="personal",
+        help="Calendar name (default: personal)",
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        help="File to import (reads from stdin if not provided)",
+    )
+
+    parser.set_defaults(func=_handle_args)

--- a/calendar-cli/calendar_cli/main.py
+++ b/calendar-cli/calendar_cli/main.py
@@ -1,0 +1,640 @@
+"""calendar-cli — manage local vdirsyncer calendars from the command line."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from datetime import UTC, date, datetime, timedelta
+
+from . import create, import_invite, reply, store
+from .errors import (
+    CalendarCliError,
+    EventNotFoundError,
+    InvalidInputError,
+)
+from .timeutil import parse_datetime
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _today() -> date:
+    return datetime.now(tz=UTC).date()
+
+
+def _parse_date(s: str) -> date:
+    """Parse YYYY-MM-DD or relative like 'today', '+7d'.
+
+    Raises ``InvalidInputError`` for malformed input.
+    """
+    low = s.lower().strip()
+    today = _today()
+    if low == "today":
+        return today
+    if low == "tomorrow":
+        return today + timedelta(days=1)
+    if low.startswith("+") and low.endswith("d"):
+        try:
+            return today + timedelta(days=int(low[1:-1]))
+        except ValueError:
+            msg = f"Invalid relative date: {s!r} (expected e.g. +7d)"
+            raise InvalidInputError(msg) from None
+    try:
+        return date.fromisoformat(s)
+    except ValueError:
+        msg = f"Invalid date: {s!r} (expected YYYY-MM-DD, today, tomorrow, or +Nd)"
+        raise InvalidInputError(msg) from None
+
+
+def _format_dt(dt: datetime | date) -> str:
+    if isinstance(dt, datetime):
+        return dt.strftime("%Y-%m-%d %H:%M %Z")
+    return dt.isoformat()
+
+
+def _sync() -> None:
+    """Run vdirsyncer sync (silently)."""
+    try:
+        result = subprocess.run(
+            ["vdirsyncer", "sync"],
+            check=False,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        print("Warning: vdirsyncer not found, skipping sync", file=sys.stderr)
+        return
+    if result.returncode != 0:
+        stderr = result.stderr.decode(errors="replace").strip()
+        print(f"Warning: vdirsyncer sync failed: {stderr}", file=sys.stderr)
+
+
+_MAX_DESCRIPTION_LEN = 200
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate text to *max_len* chars, appending '…' if shortened."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 1] + "…"
+
+
+def _print_event(
+    ev: store.CalendarEvent,
+    *,
+    verbose: bool = False,
+    full: bool = False,
+) -> None:
+    start = _format_dt(ev.dtstart)
+    end = _format_dt(ev.dtend) if ev.dtend else ""
+    status = f" [{ev.status}]" if ev.status else ""
+    print(f"{start}  {end}  | {ev.summary}{status} | {ev.calendar} | [{ev.uid}]")
+    if verbose or full:
+        if ev.location:
+            print(f"  Location: {ev.location}")
+        if ev.url:
+            print(f"  URL: {ev.url}")
+        if ev.organizer:
+            print(f"  Organizer: {ev.organizer}")
+        if ev.attendees:
+            print(f"  Attendees: {', '.join(str(a) for a in ev.attendees)}")
+        if ev.description:
+            desc = (
+                ev.description
+                if full
+                else _truncate(ev.description, _MAX_DESCRIPTION_LEN)
+            )
+            print(f"  Description: {desc}")
+        if ev.rrule:
+            print(f"  Recurrence: {ev.rrule}")
+        if ev.alarms:
+            print(f"  Alarms: {', '.join(ev.alarms)}")
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+def cmd_calendars(args: argparse.Namespace) -> int:
+    names = store.discover_calendars(args.calendar_dir)
+    if not names:
+        print("No calendars found.", file=sys.stderr)
+        return 1
+    for n in names:
+        print(n)
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    from_date = _parse_date(args.from_date) if args.from_date else _today()
+    to_date = (
+        _parse_date(args.to_date)
+        if args.to_date
+        else from_date + timedelta(days=args.days)
+    )
+
+    if args.sync:
+        _sync()
+
+    events = store.list_events(
+        calendars_dir=args.calendar_dir,
+        calendar_filter=args.calendar,
+        from_date=from_date,
+        to_date=to_date,
+    )
+
+    if not events:
+        print("No events found.")
+        return 0
+
+    limit = args.limit
+    shown = events[:limit] if limit else events
+    for ev in shown:
+        _print_event(ev, verbose=args.verbose)
+
+    remaining = len(events) - len(shown)
+    if remaining > 0:
+        print(f"\n... {remaining} more event(s) not shown (use --limit to increase)")
+
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    if args.sync:
+        _sync()
+    ev = store.get_event(args.uid, args.calendar_dir)
+    if ev is None:
+        msg = f"Event not found: {args.uid}"
+        raise EventNotFoundError(msg)
+    _print_event(ev, full=True)
+    return 0
+
+
+def cmd_search(args: argparse.Namespace) -> int:
+    if args.sync:
+        _sync()
+
+    events = store.search_events(
+        query=args.query,
+        calendars_dir=args.calendar_dir,
+        calendar_filter=args.calendar,
+    )
+
+    if not events:
+        print("No matching events found.")
+        return 0
+
+    limit = args.limit
+    shown = events[:limit] if limit else events
+    for ev in shown:
+        _print_event(ev, verbose=args.verbose)
+
+    remaining = len(events) - len(shown)
+    if remaining > 0:
+        print(f"\n... {remaining} more event(s) not shown (use --limit to increase)")
+
+    return 0
+
+
+def _parse_date_only(s: str) -> date:
+    """Parse 'YYYY-MM-DD' into a date object."""
+    return datetime.strptime(s, "%Y-%m-%d").date()  # noqa: DTZ007
+
+
+def _parse_all_day_times(
+    args: argparse.Namespace,
+) -> tuple[date, date]:
+    """Parse start/end for --all-day events.
+
+    Per RFC 5545, DTEND for DATE values is exclusive and must be
+    strictly after DTSTART.  If end == start we treat it as a
+    single-day event (bump to start + 1 day).  If end < start
+    we reject it.
+    """
+    try:
+        dtstart = _parse_date_only(args.start.replace("T", " ").split(" ")[0])
+    except ValueError:
+        msg = f"Invalid start date: {args.start!r}"
+        raise InvalidInputError(msg) from None
+    if args.end:
+        try:
+            dtend = _parse_date_only(args.end.replace("T", " ").split(" ")[0])
+        except ValueError:
+            msg = f"Invalid end date: {args.end!r}"
+            raise InvalidInputError(msg) from None
+        if dtend < dtstart:
+            msg = f"End date ({dtend}) is before start date ({dtstart})"
+            raise InvalidInputError(msg)
+        if dtend == dtstart:
+            # Single-day event — DTEND is exclusive per RFC 5545
+            dtend = dtstart + timedelta(days=1)
+    else:
+        dtend = dtstart + timedelta(days=args.days or 1)
+    return dtstart, dtend
+
+
+def _parse_timed_times(
+    args: argparse.Namespace,
+) -> tuple[datetime, datetime]:
+    """Parse start/end for timed events."""
+    if not args.timezone:
+        msg = "--timezone is required (unless --all-day)"
+        raise InvalidInputError(msg)
+    tz_name = args.timezone
+    dtstart = parse_datetime(args.start, tz_name)
+    if args.end:
+        dtend = parse_datetime(args.end, tz_name)
+    else:
+        dtend = dtstart + timedelta(minutes=args.duration)
+    return dtstart, dtend
+
+
+def _parse_new_times(
+    args: argparse.Namespace,
+) -> tuple[datetime | date, datetime | date]:
+    """Parse start/end from 'new' args."""
+    return _parse_all_day_times(args) if args.all_day else _parse_timed_times(args)
+
+
+def cmd_new(args: argparse.Namespace) -> int:
+    dtstart, dtend = _parse_new_times(args)
+
+    alarm_minutes = _parse_alarms(args.alarm) if args.alarm else None
+
+    ev = store.create_event(
+        summary=args.summary,
+        dtstart=dtstart,
+        dtend=dtend,
+        calendar_name=args.calendar,
+        calendars_dir=args.calendar_dir,
+        location=args.location or "",
+        description=args.description or "",
+        rrule=args.rrule or "",
+        alarm_minutes=alarm_minutes,
+    )
+
+    if args.sync:
+        _sync()
+
+    print(f"Created: {ev.uid}")
+    _print_event(ev)
+    return 0
+
+
+def _parse_edit_times(args: argparse.Namespace, kwargs: dict[str, object]) -> None:
+    """Parse --start/--end into kwargs."""
+    if args.start is None and args.end is None:
+        return
+    if not args.timezone:
+        msg = "--timezone is required when changing --start or --end"
+        raise InvalidInputError(msg)
+    for flag, key in [("start", "dtstart"), ("end", "dtend")]:
+        value = getattr(args, flag)
+        if value is not None:
+            kwargs[key] = parse_datetime(value, args.timezone)
+
+
+def _collect_edit_kwargs(args: argparse.Namespace) -> dict[str, object]:
+    """Extract edit fields from args."""
+    kwargs: dict[str, object] = {}
+    if args.summary is not None:
+        kwargs["summary"] = args.summary
+    _parse_edit_times(args, kwargs)
+    if args.location is not None:
+        kwargs["location"] = args.location
+    if args.description is not None:
+        kwargs["description"] = args.description
+    if args.rrule is not None:
+        kwargs["rrule"] = args.rrule
+    if args.alarm is not None:
+        kwargs["alarm_minutes"] = _parse_alarms(args.alarm)
+    return kwargs
+
+
+def cmd_edit(args: argparse.Namespace) -> int:
+    kwargs = _collect_edit_kwargs(args)
+
+    ev = store.update_event(args.uid, args.calendar_dir, **kwargs)  # type: ignore[arg-type]
+    if ev is None:
+        msg = f"Event not found: {args.uid}"
+        raise EventNotFoundError(msg)
+
+    if args.sync:
+        _sync()
+
+    print(f"Updated: {ev.uid}")
+    _print_event(ev)
+    return 0
+
+
+def cmd_delete(args: argparse.Namespace) -> int:
+    if not store.delete_event(args.uid, args.calendar_dir):
+        msg = f"Event not found: {args.uid}"
+        raise EventNotFoundError(msg)
+
+    if args.sync:
+        _sync()
+
+    print(f"Deleted: {args.uid}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Alarm helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_alarms(raw: list[str]) -> list[int]:
+    """Parse alarm specs like '15m', '1h', '1d' into minutes.
+
+    Raises ``InvalidInputError`` for malformed specs.
+    """
+    multipliers = {"m": 1, "h": 60, "d": 60 * 24}
+    result: list[int] = []
+    for raw_spec in raw:
+        spec = raw_spec.strip().lower()
+        if not spec:
+            msg = f"Invalid alarm spec: {raw_spec!r} (expected e.g. 15m, 1h, 1d, or bare minutes)"
+            raise InvalidInputError(msg)
+        if spec[-1] in multipliers:
+            digits = spec[:-1]
+            multiplier = multipliers[spec[-1]]
+        else:
+            digits = spec
+            multiplier = 1
+        try:
+            result.append(int(digits) * multiplier)
+        except ValueError:
+            msg = f"Invalid alarm spec: {raw_spec!r} (expected e.g. 15m, 1h, 1d, or bare minutes)"
+            raise InvalidInputError(msg) from None
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parser
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="calendar-cli",
+        description="Manage local vdirsyncer calendars",
+    )
+    parser.add_argument(
+        "--calendar-dir",
+        default=None,
+        help=f"Calendar root dir (default: {store.DEFAULT_CALENDARS_DIR} or $CALENDAR_DIR)",
+    )
+    parser.add_argument(
+        "--no-sync",
+        action="store_true",
+        help="Skip vdirsyncer sync",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # --- calendars ---
+    sub.add_parser("calendars", help="List available calendars")
+
+    # --- list ---
+    p_list = sub.add_parser(
+        "list",
+        help="List events",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  calendar-cli list                        # today + 7 days
+  calendar-cli list --from today --days 30
+  calendar-cli list --calendar personal
+  calendar-cli list --from 2025-04-01 --to 2025-04-07
+""",
+    )
+    p_list.add_argument("-c", "--calendar", help="Filter by calendar name")
+    p_list.add_argument(
+        "--from",
+        dest="from_date",
+        default="today",
+        help="Start date: YYYY-MM-DD, 'today', 'tomorrow', '+Nd' (default: today)",
+    )
+    p_list.add_argument(
+        "--to",
+        dest="to_date",
+        help="End date (exclusive). Overrides --days.",
+    )
+    p_list.add_argument(
+        "--days",
+        type=int,
+        default=7,
+        help="Number of days to show (default: 7)",
+    )
+    p_list.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show location, description, rrule",
+    )
+    p_list.add_argument(
+        "-n",
+        "--limit",
+        type=int,
+        default=50,
+        help="Max events to show (default: 50, 0 = unlimited)",
+    )
+
+    # --- show ---
+    p_show = sub.add_parser("show", help="Show a single event by UID")
+    p_show.add_argument("uid", help="Event UID")
+
+    # --- search ---
+    p_search = sub.add_parser(
+        "search",
+        help="Search events by regex",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  calendar-cli search dentist
+  calendar-cli search "team.*meeting" -v
+  calendar-cli search "sprint|retro" -c work
+""",
+    )
+    p_search.add_argument(
+        "query", help="Regex to match against summary, location, description"
+    )
+    p_search.add_argument("-c", "--calendar", help="Filter by calendar name")
+    p_search.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show location, description, rrule",
+    )
+    p_search.add_argument(
+        "-n",
+        "--limit",
+        type=int,
+        default=20,
+        help="Max results to show (default: 20, 0 = unlimited)",
+    )
+
+    # --- new ---
+    p_new = sub.add_parser(
+        "new",
+        help="Create a new event",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  calendar-cli new "Team Meeting" --start 2025-04-01T14:00 --timezone Europe/Berlin -d 60 -c personal
+  calendar-cli new "Dinner" --start "2025-04-01 19:00" --end "2025-04-01 21:00" \\
+      --location "Restaurant" --timezone Europe/Berlin
+  calendar-cli new "Day Off" --start 2025-04-01 --all-day
+  calendar-cli new "Vacation" --start 2025-04-01 --end 2025-04-05 --all-day
+  calendar-cli new "Standup" --start 2025-04-01T09:00 --timezone America/New_York -d 15 \\
+      --rrule "FREQ=WEEKLY;BYDAY=MO,WE,FR" --alarm 15m
+""",
+    )
+    p_new.add_argument("summary", help="Event title")
+    p_new.add_argument(
+        "--start",
+        required=True,
+        help="Start: 'YYYY-MM-DD HH:MM' or 'YYYY-MM-DDTHH:MM' (date only for --all-day)",
+    )
+    p_new.add_argument(
+        "--end",
+        help="End: 'YYYY-MM-DD HH:MM' or 'YYYY-MM-DDTHH:MM' (date only for --all-day)",
+    )
+    p_new.add_argument(
+        "-d",
+        "--duration",
+        type=int,
+        default=60,
+        help="Duration in minutes (default: 60, ignored for --all-day)",
+    )
+    p_new.add_argument(
+        "--all-day",
+        action="store_true",
+        help="Create an all-day event (DTSTART/DTEND are dates, not datetimes)",
+    )
+    p_new.add_argument(
+        "--days",
+        type=int,
+        help="Duration in days for --all-day events (default: 1)",
+    )
+    p_new.add_argument(
+        "-c",
+        "--calendar",
+        default="personal",
+        help="Calendar name (default: personal)",
+    )
+    p_new.add_argument("-l", "--location", help="Location")
+    p_new.add_argument("--description", help="Description text")
+    p_new.add_argument(
+        "--timezone",
+        help="Olson timezone, e.g. Europe/Berlin, America/New_York (required unless --all-day)",
+    )
+    p_new.add_argument(
+        "--rrule",
+        help="iCalendar RRULE, e.g. 'FREQ=WEEKLY;COUNT=10'",
+    )
+    p_new.add_argument(
+        "--alarm",
+        action="append",
+        help="Alarm before event: '15m', '1h', '1d' (repeatable)",
+    )
+
+    # --- edit ---
+    p_edit = sub.add_parser(
+        "edit",
+        help="Edit an existing event",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  calendar-cli edit <uid> --summary "New Title"
+  calendar-cli edit <uid> --start "2025-04-02 10:00" --end "2025-04-02 11:00"
+  calendar-cli edit <uid> --location "Room 42"
+""",
+    )
+    p_edit.add_argument("uid", help="Event UID")
+    p_edit.add_argument("--summary", help="New title")
+    p_edit.add_argument("--start", help="New start time: 'YYYY-MM-DD HH:MM'")
+    p_edit.add_argument("--end", help="New end time: 'YYYY-MM-DD HH:MM'")
+    p_edit.add_argument("-l", "--location", help="New location")
+    p_edit.add_argument("--description", help="New description")
+    p_edit.add_argument(
+        "--timezone",
+        help="Olson timezone, e.g. Europe/Berlin (required when changing times)",
+    )
+    p_edit.add_argument("--rrule", help="New RRULE (empty string to clear)")
+    p_edit.add_argument(
+        "--alarm",
+        action="append",
+        help="New alarm(s): '15m', '1h', '1d' (replaces all)",
+    )
+
+    # --- delete ---
+    p_delete = sub.add_parser("delete", help="Delete an event by UID")
+    p_delete.add_argument("uid", help="Event UID")
+
+    # --- vcal subcommands (create invite, import, reply) ---
+    create.register_parser(sub)
+    import_invite.register_parser(sub)
+    reply.register_parser(sub)
+
+    return parser
+
+
+def _global_flag_parser() -> argparse.ArgumentParser:
+    """Parser that only knows global flags, used to extract them from remaining args."""
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("--calendar-dir", default=None)
+    p.add_argument("--no-sync", action="store_true")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    # Use parse_known_args so global flags (--no-sync, --calendar-dir)
+    # are accepted both before and after the subcommand.
+    args, remaining = parser.parse_known_args(argv)
+    if remaining:
+        gp = _global_flag_parser()
+        extra, unknown = gp.parse_known_args(remaining)
+        if unknown:
+            # Truly unknown flags — re-parse strictly for the error message.
+            parser.parse_args(argv)
+        if extra.calendar_dir is not None:
+            args.calendar_dir = extra.calendar_dir
+        if extra.no_sync:
+            args.no_sync = True
+
+    # Inject sync flag (inverted from --no-sync)
+    args.sync = not args.no_sync
+
+    dispatch = {
+        "calendars": cmd_calendars,
+        "list": cmd_list,
+        "show": cmd_show,
+        "search": cmd_search,
+        "new": cmd_new,
+        "edit": cmd_edit,
+        "delete": cmd_delete,
+    }
+
+    # vcal subcommands (create, import, reply) use args.func
+    handler = dispatch.get(args.command) or getattr(args, "func", None)
+    if handler is None:
+        parser.print_help()
+        return 1
+
+    try:
+        return handler(args)
+    except CalendarCliError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:
+        print("\nAborted.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/calendar-cli/calendar_cli/models.py
+++ b/calendar-cli/calendar_cli/models.py
@@ -1,0 +1,90 @@
+"""Data models for calendar events and attendees."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _format_trigger(td: timedelta) -> str:
+    """Format an alarm trigger timedelta as a human-readable string.
+
+    Alarm triggers are negative timedeltas (e.g. -15 minutes = timedelta(-1, 85500)).
+    Convert to a positive "Xm/Xh/Xd before" string that LLMs can understand.
+    """
+    total_seconds = int(abs(td.total_seconds()))
+    if total_seconds == 0:
+        return "at event time"
+    minutes = total_seconds // 60
+    if minutes < 60:
+        return f"{minutes}m before"
+    hours = minutes // 60
+    remaining_minutes = minutes % 60
+    if hours < 24:
+        if remaining_minutes:
+            return f"{hours}h{remaining_minutes}m before"
+        return f"{hours}h before"
+    days = hours // 24
+    remaining_hours = hours % 24
+    if remaining_hours:
+        return f"{days}d{remaining_hours}h before"
+    return f"{days}d before"
+
+
+@dataclass
+class Attendee:
+    """An event attendee with RSVP status."""
+
+    email: str
+    name: str = ""
+    status: str = "NEEDS-ACTION"  # ACCEPTED, DECLINED, TENTATIVE, NEEDS-ACTION
+
+    def __str__(self) -> str:
+        label = self.name or self.email
+        if self.status and self.status != "NEEDS-ACTION":
+            return f"{label} ({self.status.lower()})"
+        return label
+
+
+@dataclass
+class CalendarEvent:
+    """Parsed representation of a VEVENT for display."""
+
+    uid: str
+    summary: str
+    dtstart: datetime | date
+    dtend: datetime | date | None
+    location: str
+    description: str
+    calendar: str
+    rrule: str
+    filepath: Path
+    alarm_minutes: list[int] = field(default_factory=list)
+    url: str = ""
+    organizer: str = ""
+    attendees: list[Attendee] = field(default_factory=list)
+    status: str = ""  # CONFIRMED, TENTATIVE, CANCELLED
+    recurrence_id: datetime | date | None = None
+    exdates: list[datetime | date] = field(default_factory=list)
+    rdates: list[datetime | date] = field(default_factory=list)
+
+    @property
+    def alarms(self) -> list[str]:
+        """Human-readable alarm descriptions."""
+        return [_format_trigger(timedelta(minutes=-m)) for m in self.alarm_minutes]
+
+    @property
+    def is_all_day(self) -> bool:
+        return isinstance(self.dtstart, date) and not isinstance(self.dtstart, datetime)
+
+    def start_dt(self) -> datetime:
+        """Return dtstart as a timezone-aware datetime."""
+        if isinstance(self.dtstart, datetime):
+            if self.dtstart.tzinfo is None:
+                return self.dtstart.replace(tzinfo=UTC)
+            return self.dtstart
+        return datetime.combine(self.dtstart, datetime.min.time(), tzinfo=UTC)

--- a/calendar-cli/calendar_cli/parse.py
+++ b/calendar-cli/calendar_cli/parse.py
@@ -1,0 +1,186 @@
+"""Parse VEVENT components from icalendar objects into CalendarEvent models."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from icalendar import Calendar, Event
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from .models import Attendee, CalendarEvent
+from .timeutil import coerce_to_datetime, sanitize_timerange
+from .util import get_attendee_list, strip_mailto
+
+log = logging.getLogger(__name__)
+
+
+def _parse_rrule(event: Event) -> str:
+    rrule = event.get("rrule")
+    if rrule is None:
+        return ""
+    result: str = rrule.to_ical().decode()
+    return result
+
+
+def _parse_alarm_minutes(event: Event) -> list[int]:
+    """Extract alarm triggers as positive minutes-before values.
+
+    Handles three trigger forms per RFC 5545 §3.8.6.3:
+    - Duration relative to DTSTART (default): e.g. -PT15M
+    - Duration relative to DTEND (RELATED=END): e.g. -PT5M
+    - Absolute datetime: e.g. 20250401T120000Z — converted to a
+      duration relative to the reference point so it fits our
+      minutes model.
+
+    When the trigger's RELATED parameter is END, DTEND is used as the
+    reference; otherwise DTSTART (the default per RFC 5545).
+
+    Note: our data model stores a flat list of minute values and cannot
+    distinguish "before start" from "before end".  The stored value
+    represents how many minutes before the *reference point* the alarm
+    fires.
+    """
+    dtstart = _dt_value(event.get("dtstart"))
+    dtend = _dt_value(event.get("dtend"))
+    minutes: list[int] = []
+    for component in event.subcomponents:
+        if component.name == "VALARM":
+            trigger = component.get("trigger")
+            if trigger is None:
+                continue
+            related = trigger.params.get("RELATED", "START").upper()
+            ref = dtend if related == "END" and dtend is not None else dtstart
+            dt = trigger.dt
+            if isinstance(dt, timedelta):
+                minutes.append(int(abs(dt.total_seconds()) / 60))
+            elif isinstance(dt, datetime) and ref is not None:
+                # Absolute trigger — compute offset from reference
+                ref_dt = coerce_to_datetime(ref)
+                delta = ref_dt - dt
+                minutes.append(max(0, int(delta.total_seconds() / 60)))
+    return minutes
+
+
+def _dt_value(val: object) -> datetime | date | None:
+    """Extract a date or datetime from an icalendar property."""
+    if val is None:
+        return None
+    # icalendar wraps values in vDate/vDatetime with a .dt attribute
+    dt = getattr(val, "dt", val)
+    if isinstance(dt, datetime):
+        return dt
+    if isinstance(dt, date):
+        return dt
+    return None
+
+
+def _parse_organizer(component: Event) -> str:
+    """Extract organizer as 'Name (email)' or just email."""
+    org = component.get("organizer")
+    if org is None:
+        return ""
+    cn = org.params.get("CN", "")
+    addr = strip_mailto(str(org))
+    if cn:
+        return f"{cn} ({addr})"
+    return addr
+
+
+def _parse_date_list(component: Event, prop_name: str) -> list[datetime | date]:
+    """Extract a list of date/datetime values from a multi-value property.
+
+    Works for both EXDATE and RDATE which share the same vDDDLists
+    structure — either a single vDDDLists or a list of them.
+    """
+    result: list[datetime | date] = []
+    raw = component.get(prop_name)
+    if raw is None:
+        return result
+    items = raw if isinstance(raw, list) else [raw]
+    for item in items:
+        for dt_val in item.dts:
+            dt = dt_val.dt
+            if isinstance(dt, (datetime, date)):
+                result.append(dt)
+    return result
+
+
+def _parse_exdates(component: Event) -> list[datetime | date]:
+    """Extract EXDATE values from a VEVENT component."""
+    return _parse_date_list(component, "exdate")
+
+
+def _parse_rdates(component: Event) -> list[datetime | date]:
+    """Extract RDATE values from a VEVENT component (RFC 5545 §3.8.5.2)."""
+    return _parse_date_list(component, "rdate")
+
+
+def _parse_attendees(component: Event) -> list[Attendee]:
+    """Extract attendees with name, email, and PARTSTAT."""
+    attendees: list[Attendee] = []
+    for addr in get_attendee_list(component):
+        email_addr = strip_mailto(str(addr))
+        name = addr.params.get("CN", "")
+        status = addr.params.get("PARTSTAT", "NEEDS-ACTION")
+        attendees.append(Attendee(email=email_addr, name=str(name), status=str(status)))
+    return attendees
+
+
+def read_event_file(path: Path, calendar_name: str) -> list[CalendarEvent]:
+    """Parse a single .ics file and return CalendarEvent(s)."""
+    events: list[CalendarEvent] = []
+    try:
+        data = path.read_bytes()
+        cal = Calendar.from_ical(data)
+    except (ValueError, OSError):
+        return events
+
+    for component in cal.walk():
+        if component.name != "VEVENT":
+            continue
+        uid = str(component.get("uid", path.stem))
+        summary = str(component.get("summary", "(no title)"))
+        dtstart = _dt_value(component.get("dtstart"))
+        if dtstart is None:
+            continue
+        raw_dtend = _dt_value(component.get("dtend"))
+        duration_prop = component.get("duration")
+        duration = duration_prop.dt if duration_prop is not None else None
+        dtstart, dtend = sanitize_timerange(dtstart, raw_dtend, duration)
+        location = str(component.get("location", ""))
+        description = str(component.get("description", ""))
+        rrule = _parse_rrule(component)
+        alarms = _parse_alarm_minutes(component)
+        url = str(component.get("url", ""))
+        organizer = _parse_organizer(component)
+        attendees = _parse_attendees(component)
+        status = str(component.get("status", ""))
+        recurrence_id = _dt_value(component.get("recurrence-id"))
+        exdates = _parse_exdates(component)
+        rdates = _parse_rdates(component)
+        events.append(
+            CalendarEvent(
+                uid=uid,
+                summary=summary,
+                dtstart=dtstart,
+                dtend=dtend,
+                location=location,
+                description=description,
+                calendar=calendar_name,
+                rrule=rrule,
+                filepath=path,
+                alarm_minutes=alarms,
+                url=url,
+                organizer=organizer,
+                attendees=attendees,
+                status=status,
+                recurrence_id=recurrence_id,
+                exdates=exdates,
+                rdates=rdates,
+            )
+        )
+    return events

--- a/calendar-cli/calendar_cli/reply.py
+++ b/calendar-cli/calendar_cli/reply.py
@@ -1,0 +1,385 @@
+"""Reply to calendar invites with RSVP responses."""
+
+from __future__ import annotations
+
+import email.utils
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from icalendar import Calendar, Event, vCalAddress, vText
+
+from .config import resolve_user_name
+from .errors import InvalidInputError, ParseError, SendError
+from .util import (
+    extract_calendar_parts_from_email,
+    extract_recipient_email,
+    get_attendee_list,
+    new_calendar,
+    strip_mailto,
+)
+
+if TYPE_CHECKING:
+    import argparse
+
+
+@dataclass
+class ReplyConfig:
+    """Configuration for reply command."""
+
+    status: str  # accept, decline, tentative
+    file_path: str | None = None
+    comment: str | None = None
+    dry_run: bool = False
+    calendars_dir: str | None = None
+
+
+def extract_calendar_from_email(
+    email_content: str,
+) -> tuple[Calendar | None, str | None]:
+    """Extract calendar and recipient email from email message.
+
+    Uses the shared ``extract_calendar_parts_from_email`` helper for
+    MIME extraction and falls back to parsing the raw content as ICS.
+    """
+    content_bytes = email_content.encode("utf-8", errors="surrogateescape")
+    to_email = extract_recipient_email(content_bytes)
+
+    # Try MIME extraction first
+    parts = extract_calendar_parts_from_email(content_bytes)
+    for part_data in parts:
+        try:
+            cal = Calendar.from_ical(part_data)
+            if isinstance(cal, Calendar):
+                return cal, to_email
+        except (ValueError, TypeError):
+            continue
+
+    # Fallback: try to parse the raw content as ICS directly
+    if "BEGIN:VCALENDAR" in email_content:
+        try:
+            result = Calendar.from_ical(email_content)
+            if isinstance(result, Calendar):
+                return result, to_email
+        except (ValueError, TypeError):
+            pass
+
+    return None, to_email
+
+
+def create_reply(  # noqa: C901
+    original_cal: Calendar,
+    status: str,
+    user_email: str,
+    comment: str | None = None,
+) -> Calendar:
+    """Create REPLY calendar for RSVP response."""
+    reply_cal = new_calendar(method="REPLY")
+
+    user_name = resolve_user_name(user_email)
+
+    # Find the original event
+    for component in original_cal.walk():
+        if component.name == "VEVENT":
+            # Create reply event with minimal required fields
+            reply_event = Event()
+
+            # Copy fields relevant to the reply
+            for field in ["uid", "sequence", "dtstart", "dtend", "summary"]:
+                if field in component:
+                    reply_event.add(field, component[field])
+
+            # DTSTAMP is required (RFC 5545 §3.6.1) — always set to now
+            reply_event.add("dtstamp", datetime.now(tz=UTC))
+
+            # Copy RECURRENCE-ID so the reply targets the correct
+            # instance of a recurring event (RFC 6047 §3.2.3)
+            if "recurrence-id" in component:
+                reply_event.add("recurrence-id", component["recurrence-id"])
+
+            # Set organizer from original
+            if "organizer" in component:
+                reply_event.add("organizer", component["organizer"])
+
+            # Find our attendee entry and update status
+            found_self = False
+            for attendee in get_attendee_list(component):
+                attendee_email = strip_mailto(str(attendee)).lower()
+                if attendee_email == user_email.lower():
+                    # Update our attendance status
+                    reply_attendee = vCalAddress(f"mailto:{user_email}")
+                    reply_attendee.params["cn"] = vText(user_name)
+                    reply_attendee.params["partstat"] = vText(status)
+                    reply_attendee.params["rsvp"] = vText("FALSE")
+                    if "role" in attendee.params:
+                        reply_attendee.params["role"] = attendee.params["role"]
+                    reply_event.add("attendee", reply_attendee)
+                    found_self = True
+                    break
+
+            # If we weren't in the attendee list, add ourselves
+            if not found_self:
+                reply_attendee = vCalAddress(f"mailto:{user_email}")
+                reply_attendee.params["cn"] = vText(user_name)
+                reply_attendee.params["partstat"] = vText(status)
+                reply_attendee.params["rsvp"] = vText("FALSE")
+                reply_attendee.params["role"] = vText("REQ-PARTICIPANT")
+                reply_event.add("attendee", reply_attendee)
+
+            # Add comment if provided
+            if comment:
+                reply_event.add("comment", comment)
+
+            reply_cal.add_component(reply_event)
+            break
+    else:
+        msg = "Original calendar contains no VEVENT"
+        raise ParseError(msg)
+
+    return reply_cal
+
+
+def send_reply(
+    reply_cal: Calendar,
+    organizer_email: str,
+    event_summary: str,
+    status: str,
+    user_email: str,
+) -> bool:
+    """Send REPLY via msmtp."""
+    user_name = resolve_user_name(user_email)
+
+    # Create email message
+    msg = MIMEMultipart("mixed")
+
+    # Map status to human-readable response
+    status_map = {
+        "ACCEPTED": "Accepted",
+        "DECLINED": "Declined",
+        "TENTATIVE": "Tentative",
+    }
+    human_status = status_map.get(status, status)
+
+    msg["Subject"] = f"Re: {event_summary} - {human_status}"
+    msg["From"] = f"{user_name} <{user_email}>"
+    msg["To"] = organizer_email
+    msg["Date"] = email.utils.formatdate(localtime=True)
+
+    # Body
+    body = MIMEText(
+        f"This is an automatic reply to your meeting invitation.\n\nStatus: {human_status}\n",
+    )
+    msg.attach(body)
+
+    # Calendar attachment
+    cal_part = MIMEText(reply_cal.to_ical().decode(), "calendar")
+    cal_part.add_header("Content-Disposition", 'attachment; filename="reply.ics"')
+    cal_part.set_param("method", "REPLY")
+    msg.attach(cal_part)
+
+    # Send via msmtp
+    try:
+        result = subprocess.run(
+            ["msmtp", "-t"],
+            input=msg.as_string(),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:
+        msg_str = f"Failed to run msmtp: {e}"
+        raise SendError(msg_str) from e
+    if result.returncode != 0:
+        msg_str = f"msmtp failed: {result.stderr.strip()}"
+        raise SendError(msg_str)
+    return True
+
+
+def _set_attendee_partstat(cal: Calendar, user_email: str, ical_status: str) -> bool:
+    """Set PARTSTAT for *user_email* in all VEVENTs of *cal*. Returns True if changed."""
+    changed = False
+    lower_email = user_email.lower()
+    for component in cal.walk():
+        if component.name != "VEVENT":
+            continue
+        for att in get_attendee_list(component):
+            att_email = strip_mailto(str(att)).lower()
+            if att_email == lower_email:
+                att.params["PARTSTAT"] = ical_status
+                changed = True
+    return changed
+
+
+def _update_local_partstat(
+    original_cal: Calendar,
+    user_email: str,
+    ical_status: str,
+    calendars_dir: str | None = None,
+) -> None:
+    """Update our PARTSTAT in the locally stored .ics file.
+
+    After sending a REPLY, the local copy should reflect our new
+    status (ACCEPTED/DECLINED/TENTATIVE) so that `calendar-cli list -v`
+    shows the correct value.
+    """
+    # Lazy import to avoid circular dependency (import_invite → reply)
+    from .import_invite import _find_existing_ics  # noqa: PLC0415
+    from .store import _resolve_calendars_dir, atomic_write  # noqa: PLC0415
+
+    resolved_dir = str(_resolve_calendars_dir(calendars_dir))
+
+    for component in original_cal.walk():
+        if component.name != "VEVENT":
+            continue
+        uid = str(component.get("uid", ""))
+        if not uid:
+            continue
+
+        existing = _find_existing_ics(uid, resolved_dir)
+        if existing is None:
+            continue
+
+        try:
+            cal = Calendar.from_ical(existing.read_bytes())
+        except (ValueError, OSError):
+            continue
+
+        if _set_attendee_partstat(cal, user_email, ical_status):
+            atomic_write(existing, cal.to_ical())
+        break
+
+
+def read_email_content(file_path: str | None) -> str:
+    """Read email content from file or stdin.
+
+    Raises ``InvalidInputError`` if the file doesn't exist.
+    """
+    if file_path:
+        p = Path(file_path)
+        if not p.exists():
+            msg = f"File not found: {file_path}"
+            raise InvalidInputError(msg)
+        try:
+            with p.open(encoding="utf-8", errors="surrogateescape") as f:
+                return f.read()
+        except OSError as e:
+            msg = f"Failed to read {file_path}: {e}"
+            raise InvalidInputError(msg) from e
+    return sys.stdin.read()
+
+
+def extract_event_info(original_cal: Calendar) -> tuple[str | None, str]:
+    """Extract organizer email and event summary from calendar."""
+    organizer_email = None
+    event_summary = "Meeting"
+
+    for component in original_cal.walk():
+        if component.name == "VEVENT":
+            if "organizer" in component:
+                organizer_email = strip_mailto(str(component["organizer"]))
+            if "summary" in component:
+                event_summary = str(component["summary"])
+            break
+
+    return organizer_email, event_summary
+
+
+def run(config: ReplyConfig) -> int:
+    """Run the reply command with the given configuration."""
+    # Map user-friendly status to iCalendar format
+    status_map = {
+        "accept": "ACCEPTED",
+        "decline": "DECLINED",
+        "tentative": "TENTATIVE",
+    }
+    ical_status = status_map[config.status]
+
+    # Read input
+    email_content = read_email_content(config.file_path)
+
+    # Extract calendar from email
+    original_cal, user_email = extract_calendar_from_email(email_content)
+    if not original_cal:
+        msg = "No calendar invite found in input"
+        raise ParseError(msg)
+
+    if not user_email:
+        msg = "No recipient email found in input"
+        raise ParseError(msg)
+
+    # Find organizer email and event summary
+    organizer_email, event_summary = extract_event_info(original_cal)
+
+    if not organizer_email:
+        msg = "No organizer found in calendar invite"
+        raise ParseError(msg)
+
+    # Create reply
+    reply_cal = create_reply(original_cal, ical_status, user_email, config.comment)
+
+    if config.dry_run:
+        print(f"Would send reply to: {organizer_email}")
+        print(f"Status: {ical_status}")
+        print("\nReply calendar:")
+        print(reply_cal.to_ical().decode())
+    else:
+        send_reply(reply_cal, organizer_email, event_summary, ical_status, user_email)
+        print(f"Successfully sent {config.status} reply to {organizer_email}")
+        # Update our PARTSTAT in the local calendar store
+        _update_local_partstat(
+            original_cal, user_email, ical_status, config.calendars_dir
+        )
+
+    return 0
+
+
+def _handle_args(args: argparse.Namespace) -> int:
+    """Handle parsed arguments and run the command."""
+    config = ReplyConfig(
+        status=args.status,
+        file_path=args.file,
+        comment=args.comment,
+        dry_run=args.dry_run,
+        calendars_dir=getattr(args, "calendar_dir", None),
+    )
+    return run(config)
+
+
+def register_parser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the reply subcommand."""
+    parser = subparsers.add_parser(
+        "reply",
+        help="Reply to calendar invites with RSVP responses",
+        description="Send RSVP responses (accept/decline/tentative) to calendar invitations",
+    )
+
+    parser.add_argument(
+        "status",
+        choices=["accept", "decline", "tentative"],
+        help="RSVP response status",
+    )
+    parser.add_argument(
+        "-c",
+        "--comment",
+        help="Optional comment to include with response",
+    )
+    parser.add_argument(
+        "-n",
+        "--dry-run",
+        action="store_true",
+        help="Print the reply instead of sending",
+    )
+    parser.add_argument(
+        "file",
+        nargs="?",
+        help="Email file containing invite (reads from stdin if not provided)",
+    )
+
+    parser.set_defaults(func=_handle_args)

--- a/calendar-cli/calendar_cli/store.py
+++ b/calendar-cli/calendar_cli/store.py
@@ -1,0 +1,704 @@
+"""Read/write vdirsyncer filesystem calendar stores.
+
+vdirsyncer stores one .ics file per event in a directory per calendar:
+  ~/.local/share/calendars/<calendar>/<uid>.ics
+
+This module provides a thin layer over the icalendar library to
+list, read, create, update and delete events without depending on khal.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import re
+import tempfile
+import uuid
+from datetime import UTC, date, datetime, timedelta
+from hashlib import sha1
+from pathlib import Path
+
+from dateutil.rrule import rruleset, rrulestr
+from icalendar import Alarm, Calendar, Event
+
+from .errors import CalendarNotFoundError, InvalidInputError
+from .models import CalendarEvent
+from .parse import read_event_file
+from .timeutil import (
+    coerce_to_datetime,
+    default_duration,
+)
+from .util import add_vtimezones, new_calendar, parse_rrule_string
+
+__all__ = [
+    "DEFAULT_CALENDARS_DIR",
+    "CalendarEvent",
+    "atomic_write",
+    "create_event",
+    "delete_event",
+    "discover_calendars",
+    "generate_uid",
+    "get_event",
+    "list_events",
+    "search_events",
+    "uid_to_filename",
+    "update_event",
+]
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CALENDARS_DIR = "~/.local/share/calendars"
+
+# Characters safe for use in filenames — matches khal/vdirsyncer convention.
+_SAFE_UID_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-+@"
+)
+
+
+def uid_to_filename(uid: str) -> str:
+    """Convert a UID to a safe filename, hashing if it contains unsafe chars.
+
+    vdirsyncer expects filenames to be safe for the filesystem and to
+    match the UID where possible.  If the UID contains characters outside
+    the safe set (e.g. slashes, spaces, colons), we hash it with SHA-1
+    instead — the same strategy khal uses.
+    """
+    if uid and not (set(uid) - _SAFE_UID_CHARS):
+        return uid
+    return sha1(uid.encode(), usedforsecurity=False).hexdigest()
+
+
+def atomic_write(dest: Path, data: bytes) -> None:
+    """Write *data* to *dest* atomically via rename.
+
+    Uses a temporary file in the same directory so the rename is
+    guaranteed to be on the same filesystem.  This prevents vdirsyncer
+    from picking up a half-written .ics file.
+    """
+    fd, tmp = tempfile.mkstemp(prefix=dest.name, dir=str(dest.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        Path(tmp).rename(dest)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            Path(tmp).unlink()
+        raise
+
+
+def generate_uid() -> str:
+    """Generate a UID for events that lack one."""
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Calendar discovery
+# ---------------------------------------------------------------------------
+
+
+def _resolve_calendars_dir(calendars_dir: str | None) -> Path:
+    if calendars_dir is not None:
+        return Path(calendars_dir).expanduser()
+    return Path(os.environ.get("CALENDAR_DIR", DEFAULT_CALENDARS_DIR)).expanduser()
+
+
+def _resolve_calendar_name(base: Path, name: str) -> str:
+    """Resolve a calendar name case-insensitively against existing directories.
+
+    Returns the actual directory name if found, or the input unchanged
+    (for new calendars that don't exist yet).
+    """
+    if (base / name).is_dir():
+        return name
+    lower = name.lower()
+    for entry in base.iterdir():
+        if entry.is_dir() and entry.name.lower() == lower:
+            return entry.name
+    return name
+
+
+def discover_calendars(calendars_dir: str | None = None) -> list[str]:
+    """Return sorted list of calendar names (subdirectories containing .ics)."""
+    base = _resolve_calendars_dir(calendars_dir)
+    if not base.is_dir():
+        return []
+    names: list[str] = []
+    for entry in sorted(base.iterdir()):
+        if not entry.is_dir():
+            continue
+        if any(entry.glob("*.ics")):
+            names.append(entry.name)
+        # Also check one level deeper (e.g. clan/personal)
+        names.extend(
+            f"{entry.name}/{sub.name}"
+            for sub in sorted(entry.iterdir())
+            if sub.is_dir() and any(sub.glob("*.ics"))
+        )
+    return sorted(set(names))
+
+
+# ---------------------------------------------------------------------------
+# Recurrence expansion
+# ---------------------------------------------------------------------------
+
+
+def _to_naive(dt: datetime | date) -> datetime:
+    """Convert to a naive datetime for dateutil.rrule compatibility.
+
+    dateutil.rrule.between() requires naive datetimes when the rule
+    itself was created with a naive dtstart.  We strip tzinfo for the
+    comparison and re-attach it afterwards.
+    """
+    if isinstance(dt, datetime):
+        return dt.replace(tzinfo=None)
+    return datetime.combine(dt, datetime.min.time())
+
+
+def _make_rrule_set(ev: CalendarEvent) -> rruleset:
+    """Build a dateutil rruleset from an event's RRULE + EXDATE + RDATE."""
+    rset = rruleset()
+
+    dtstart = ev.dtstart
+    naive_start = _to_naive(dtstart)
+
+    rset.rrule(rrulestr(ev.rrule, dtstart=naive_start))
+
+    for exdt in ev.exdates:
+        rset.exdate(_to_naive(exdt))
+
+    for rdt in ev.rdates:
+        rset.rdate(_to_naive(rdt))
+
+    return rset
+
+
+def _expand_recurring(
+    ev: CalendarEvent,
+    from_dt: datetime,
+    to_dt: datetime,
+    override_dts: frozenset[datetime],
+) -> list[CalendarEvent]:
+    """Expand a recurring event into individual occurrences within [from_dt, to_dt).
+
+    *override_dts* contains naive datetimes of RECURRENCE-ID overrides
+    for this UID — those occurrences are suppressed since they're
+    replaced by the override VEVENT.  Matching is by exact datetime
+    (not just date) per RFC 5545 §3.8.4.4.
+    """
+    rset = _make_rrule_set(ev)
+
+    # dateutil works with naive datetimes when dtstart is naive
+    naive_from = _to_naive(from_dt)
+    naive_to = _to_naive(to_dt)
+
+    occurrences = rset.between(naive_from, naive_to, inc=True)
+
+    # Compute event duration to derive dtend for each occurrence
+    if ev.dtend is not None:
+        duration = coerce_to_datetime(ev.dtend) - coerce_to_datetime(ev.dtstart)
+    else:
+        duration = default_duration(ev.dtstart)
+
+    # Recover the original timezone (if any)
+    orig_tz = ev.dtstart.tzinfo if isinstance(ev.dtstart, datetime) else None
+
+    expanded: list[CalendarEvent] = []
+    for occ_naive in occurrences:
+        # Filter: to_dt is exclusive
+        if occ_naive >= naive_to:
+            continue
+
+        # Suppress occurrences overridden by RECURRENCE-ID
+        if occ_naive in override_dts:
+            continue
+
+        # Reconstruct the occurrence with original type (date or datetime)
+        if ev.is_all_day:
+            occ_start: datetime | date = occ_naive.date()
+            occ_end: datetime | date = occ_start + duration
+        else:
+            occ_dt = occ_naive.replace(tzinfo=orig_tz) if orig_tz else occ_naive
+            occ_start = occ_dt
+            occ_end = occ_dt + duration
+
+        expanded.append(
+            CalendarEvent(
+                uid=ev.uid,
+                summary=ev.summary,
+                dtstart=occ_start,
+                dtend=occ_end,
+                location=ev.location,
+                description=ev.description,
+                calendar=ev.calendar,
+                rrule=ev.rrule,
+                filepath=ev.filepath,
+                alarm_minutes=ev.alarm_minutes,
+                url=ev.url,
+                organizer=ev.organizer,
+                attendees=ev.attendees,
+                status=ev.status,
+            )
+        )
+    return expanded
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+
+def _ev_date(ev: CalendarEvent) -> date:
+    return ev.dtstart.date() if isinstance(ev.dtstart, datetime) else ev.dtstart
+
+
+def _ev_end_date(ev: CalendarEvent) -> date:
+    """Return the last date an event occupies.
+
+    For timed events (datetime DTEND), the event occupies the DTEND
+    date if it has any time > 00:00 on that day.  For all-day events
+    (date DTEND), DTEND is already exclusive per RFC 5545, so the last
+    occupied date is DTEND - 1 day.  We return the exclusive end date
+    (one past the last occupied day) for overlap calculations.
+    """
+    if ev.dtend is None:
+        # No end → single-point event, exclusive end = start + 1 day
+        return _ev_date(ev) + timedelta(days=1)
+    if isinstance(ev.dtend, datetime):
+        # A timed event ending at midnight exactly doesn't occupy that day
+        if ev.dtend.hour == 0 and ev.dtend.minute == 0 and ev.dtend.second == 0:
+            return ev.dtend.date()
+        # Otherwise it occupies the end date; exclusive end = date + 1
+        return ev.dtend.date() + timedelta(days=1)
+    # All-day DTEND is already exclusive per RFC 5545
+    return ev.dtend
+
+
+def _in_date_range(
+    ev: CalendarEvent,
+    from_date: date | None,
+    to_date: date | None,
+) -> bool:
+    """Return True if an event overlaps [from_date, to_date).
+
+    Uses overlap logic (event_start < exclusive_end AND event_exclusive_end > from_date)
+    so that multi-day events appear when querying any day they span.
+    Both from_date and to_date are treated as dates (day granularity).
+    """
+    ev_start = _ev_date(ev)
+    ev_exclusive_end = _ev_end_date(ev)
+    if from_date and ev_exclusive_end <= from_date:
+        return False
+    return not (to_date and ev_start >= to_date)
+
+
+def _collect_raw_events(
+    calendars_dir: str | None,
+    calendar_filter: str | None,
+) -> list[CalendarEvent]:
+    """Read all .ics files and return parsed CalendarEvents."""
+    base = _resolve_calendars_dir(calendars_dir)
+    if not base.is_dir():
+        return []
+
+    all_cals = discover_calendars(calendars_dir)
+    if calendar_filter:
+        resolved = _resolve_calendar_name(base, calendar_filter)
+        cal_names = [resolved] if resolved in all_cals else [calendar_filter]
+    else:
+        cal_names = all_cals
+
+    events: list[CalendarEvent] = []
+    for cal_name in cal_names:
+        cal_dir = base / cal_name
+        if not cal_dir.is_dir():
+            continue
+        for ics_file in cal_dir.glob("*.ics"):
+            events.extend(read_event_file(ics_file, cal_name))
+    return events
+
+
+def _split_masters_overrides(
+    raw_events: list[CalendarEvent],
+) -> tuple[list[CalendarEvent], dict[str, list[CalendarEvent]]]:
+    """Separate master/standalone events from RECURRENCE-ID overrides."""
+    overrides: dict[str, list[CalendarEvent]] = {}
+    masters: list[CalendarEvent] = []
+    for ev in raw_events:
+        if ev.recurrence_id is not None:
+            overrides.setdefault(ev.uid, []).append(ev)
+        else:
+            masters.append(ev)
+    return masters, overrides
+
+
+def _override_datetimes(
+    overrides: dict[str, list[CalendarEvent]],
+) -> dict[str, frozenset[datetime]]:
+    """Build a mapping of UID → set of naive datetimes suppressed by RECURRENCE-ID overrides.
+
+    Uses the exact RECURRENCE-ID value (not just the date) so that
+    multiple occurrences on the same day are handled correctly per
+    RFC 5545 §3.8.4.4.  Values are converted to naive datetimes to
+    match the naive occurrence datetimes produced by dateutil.rrule.
+    """
+    result: dict[str, frozenset[datetime]] = {}
+    for uid, ovrs in overrides.items():
+        dts: set[datetime] = set()
+        for ov in ovrs:
+            if ov.recurrence_id is not None:
+                dts.add(_to_naive(ov.recurrence_id))
+        result[uid] = frozenset(dts)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API — list / get / create / update / delete
+# ---------------------------------------------------------------------------
+
+
+def list_events(
+    calendars_dir: str | None = None,
+    calendar_filter: str | None = None,
+    from_date: date | None = None,
+    to_date: date | None = None,
+) -> list[CalendarEvent]:
+    """List events from the local store, optionally filtered.
+
+    Recurring events (those with an RRULE) are expanded into individual
+    occurrences within the requested date range, matching khal behaviour.
+    EXDATE exclusions and RECURRENCE-ID overrides are respected.
+    """
+    raw_events = _collect_raw_events(calendars_dir, calendar_filter)
+    masters, overrides = _split_masters_overrides(raw_events)
+    override_dts_by_uid = _override_datetimes(overrides)
+
+    events: list[CalendarEvent] = []
+
+    # Process master / standalone events
+    for ev in masters:
+        if ev.rrule and from_date is not None and to_date is not None:
+            from_dt = datetime.combine(from_date, datetime.min.time(), tzinfo=UTC)
+            to_dt = datetime.combine(to_date, datetime.min.time(), tzinfo=UTC)
+            suppressed = override_dts_by_uid.get(ev.uid, frozenset())
+            events.extend(_expand_recurring(ev, from_dt, to_dt, suppressed))
+        elif _in_date_range(ev, from_date, to_date):
+            events.append(ev)
+
+    # Add override events (they have their own DTSTART)
+    for ovr_list in overrides.values():
+        events.extend(ov for ov in ovr_list if _in_date_range(ov, from_date, to_date))
+
+    events.sort(key=lambda e: e.start_dt())
+    return events
+
+
+def search_events(
+    query: str,
+    calendars_dir: str | None = None,
+    calendar_filter: str | None = None,
+) -> list[CalendarEvent]:
+    """Search events by regex against summary, location, and description.
+
+    *query* is a Python regex matched case-insensitively.  Plain text
+    works as-is since regex treats literal characters as themselves.
+
+    Returns master/standalone events (no recurrence expansion) whose
+    summary, location, or description matches.  Results are sorted by
+    start time.
+
+    Raises ``InvalidInputError`` for invalid regex patterns.
+    """
+    try:
+        pattern = re.compile(query, re.IGNORECASE)
+    except re.error as e:
+        msg = f"Invalid search pattern: {e}"
+        raise InvalidInputError(msg) from e
+    raw_events = _collect_raw_events(calendars_dir, calendar_filter)
+
+    # De-duplicate by UID so recurring masters appear only once
+    seen_uids: set[str] = set()
+    matches: list[CalendarEvent] = []
+    for ev in raw_events:
+        if ev.recurrence_id is not None:
+            continue  # skip overrides — master is enough
+        if ev.uid in seen_uids:
+            continue
+        if (
+            pattern.search(ev.summary)
+            or pattern.search(ev.location)
+            or pattern.search(ev.description)
+        ):
+            matches.append(ev)
+            seen_uids.add(ev.uid)
+
+    matches.sort(key=lambda e: e.start_dt())
+    return matches
+
+
+def get_event(
+    uid: str,
+    calendars_dir: str | None = None,
+) -> CalendarEvent | None:
+    """Find a single event by UID."""
+    base = _resolve_calendars_dir(calendars_dir)
+    if not base.is_dir():
+        return None
+    for cal_name in discover_calendars(calendars_dir):
+        cal_dir = base / cal_name
+        for ics_file in cal_dir.glob("*.ics"):
+            for ev in read_event_file(ics_file, cal_name):
+                if ev.uid == uid:
+                    return ev
+    return None
+
+
+def _build_ics(  # noqa: PLR0913
+    uid: str,
+    summary: str,
+    dtstart: datetime | date,
+    dtend: datetime | date,
+    *,
+    location: str = "",
+    description: str = "",
+    rrule: str = "",
+    alarm_minutes: list[int] | None = None,
+    sequence: int = 0,
+) -> bytes:
+    """Build a minimal VCALENDAR with one VEVENT."""
+    cal = new_calendar()
+
+    now = datetime.now(tz=UTC)
+
+    event = Event()
+    event.add("uid", uid)
+    event.add("summary", summary)
+    event.add("dtstart", dtstart)
+    event.add("dtend", dtend)
+    event.add("dtstamp", now)
+    event.add("created", now)
+    event.add("last-modified", now)
+    event.add("sequence", sequence)
+    if location:
+        event.add("location", location)
+    if description:
+        event.add("description", description)
+    if rrule:
+        event.add("rrule", parse_rrule_string(rrule))
+
+    for minutes in alarm_minutes or []:
+        alarm = Alarm()
+        alarm.add("action", "DISPLAY")
+        alarm.add("description", f"Reminder: {summary}")
+        alarm.add("trigger", timedelta(minutes=-minutes))
+        event.add_component(alarm)
+
+    add_vtimezones(cal, dtstart, dtend)
+    cal.add_component(event)
+    result: bytes = cal.to_ical()
+    return result
+
+
+def create_event(  # noqa: PLR0913
+    summary: str,
+    dtstart: datetime | date,
+    dtend: datetime | date,
+    calendar_name: str = "personal",
+    calendars_dir: str | None = None,
+    *,
+    location: str = "",
+    description: str = "",
+    rrule: str = "",
+    alarm_minutes: list[int] | None = None,
+) -> CalendarEvent:
+    """Create a new event in the local store.
+
+    Raises CalendarNotFoundError if the calendar directory doesn't exist
+    (to avoid silently creating calendars that vdirsyncer won't sync).
+    """
+    base = _resolve_calendars_dir(calendars_dir)
+    calendar_name = _resolve_calendar_name(base, calendar_name)
+    cal_dir = base / calendar_name
+    if not cal_dir.is_dir():
+        available = discover_calendars(calendars_dir)
+        msg = f"Calendar {calendar_name!r} does not exist."
+        if available:
+            msg += f" Available: {', '.join(available)}"
+        raise CalendarNotFoundError(msg)
+
+    uid = generate_uid()
+    ics_data = _build_ics(
+        uid,
+        summary,
+        dtstart,
+        dtend,
+        location=location,
+        description=description,
+        rrule=rrule,
+        alarm_minutes=alarm_minutes,
+    )
+
+    filepath = cal_dir / f"{uid_to_filename(uid)}.ics"
+    atomic_write(filepath, ics_data)
+
+    return CalendarEvent(
+        uid=uid,
+        summary=summary,
+        dtstart=dtstart,
+        dtend=dtend,
+        location=location,
+        description=description,
+        calendar=calendar_name,
+        rrule=rrule,
+        filepath=filepath,
+        alarm_minutes=alarm_minutes or [],
+    )
+
+
+def delete_event(
+    uid: str,
+    calendars_dir: str | None = None,
+) -> bool:
+    """Delete an event by UID. Returns True if found and deleted."""
+    ev = get_event(uid, calendars_dir)
+    if ev is None:
+        return False
+    try:
+        ev.filepath.unlink()
+    except OSError as e:
+        msg = f"Failed to delete {ev.filepath}: {e}"
+        raise CalendarNotFoundError(msg) from e
+    return True
+
+
+def _patch_vevent(  # noqa: PLR0913, C901
+    filepath: Path,
+    uid: str,
+    *,
+    summary: str | None = None,
+    dtstart: datetime | date | None = None,
+    dtend: datetime | date | None = None,
+    location: str | None = None,
+    description: str | None = None,
+    rrule: str | None = None,
+    alarm_minutes: list[int] | None = None,
+) -> bytes:
+    """Patch a VEVENT in-place, preserving all unmodified properties.
+
+    Reads the existing .ics file, modifies only the requested fields in
+    the matching VEVENT, increments SEQUENCE, updates LAST-MODIFIED and
+    DTSTAMP, and returns the serialized VCALENDAR bytes.
+
+    This preserves ORGANIZER, ATTENDEE, STATUS, URL, CATEGORIES, CLASS,
+    GEO, RECURRENCE-ID, X-* properties, and VTIMEZONE components that
+    would be lost by a full rebuild.
+    """
+    try:
+        data = filepath.read_bytes()
+    except OSError as e:
+        msg = f"Failed to read {filepath}: {e}"
+        raise CalendarNotFoundError(msg) from e
+    cal = Calendar.from_ical(data)
+
+    now = datetime.now(tz=UTC)
+
+    for component in cal.walk():
+        if component.name != "VEVENT":
+            continue
+        if str(component.get("uid", "")) != uid:
+            continue
+
+        # Patch simple text properties
+        _patch_prop(component, "summary", summary)
+        _patch_prop(component, "location", location)
+        _patch_prop(component, "description", description)
+
+        # Patch time properties
+        if dtstart is not None:
+            _patch_prop(component, "dtstart", dtstart)
+        if dtend is not None:
+            _patch_prop(component, "dtend", dtend)
+
+        # Patch RRULE
+        if rrule is not None:
+            if "rrule" in component:
+                del component["rrule"]
+            if rrule:
+                component.add("rrule", parse_rrule_string(rrule))
+
+        # Patch alarms — replace all VALARM subcomponents
+        if alarm_minutes is not None:
+            component.subcomponents = [
+                sc for sc in component.subcomponents if sc.name != "VALARM"
+            ]
+            event_summary = str(component.get("summary", "Event"))
+            for minutes in alarm_minutes:
+                alarm = Alarm()
+                alarm.add("action", "DISPLAY")
+                alarm.add("description", f"Reminder: {event_summary}")
+                alarm.add("trigger", timedelta(minutes=-minutes))
+                component.add_component(alarm)
+
+        # Increment SEQUENCE (RFC 5545 §3.8.7.4)
+        old_seq = int(component.get("sequence", 0))
+        _patch_prop(component, "sequence", old_seq + 1)
+
+        # Update timestamps
+        _patch_prop(component, "last-modified", now)
+        _patch_prop(component, "dtstamp", now)
+
+        break
+
+    result: bytes = cal.to_ical()
+    return result
+
+
+def _patch_prop(component: Event, name: str, value: object) -> None:
+    """Set a property on a VEVENT, replacing any existing value."""
+    if value is None:
+        return
+    if name in component:
+        del component[name]
+    component.add(name, value)
+
+
+def update_event(  # noqa: PLR0913
+    uid: str,
+    calendars_dir: str | None = None,
+    *,
+    summary: str | None = None,
+    dtstart: datetime | date | None = None,
+    dtend: datetime | date | None = None,
+    location: str | None = None,
+    description: str | None = None,
+    rrule: str | None = None,
+    alarm_minutes: list[int] | None = None,
+) -> CalendarEvent | None:
+    """Update an existing event. Only provided fields are changed.
+
+    Patches the existing .ics file in-place so that unmodified
+    properties (ORGANIZER, ATTENDEE, STATUS, URL, X-* etc.) are
+    preserved.  Increments SEQUENCE per RFC 5545 §3.8.7.4.
+    """
+    ev = get_event(uid, calendars_dir)
+    if ev is None:
+        return None
+
+    ics_data = _patch_vevent(
+        ev.filepath,
+        uid,
+        summary=summary,
+        dtstart=dtstart,
+        dtend=dtend,
+        location=location,
+        description=description,
+        rrule=rrule,
+        alarm_minutes=alarm_minutes,
+    )
+
+    atomic_write(ev.filepath, ics_data)
+
+    # Re-read the patched event to return accurate data
+    return get_event(uid, calendars_dir)

--- a/calendar-cli/calendar_cli/timeutil.py
+++ b/calendar-cli/calendar_cli/timeutil.py
@@ -1,0 +1,135 @@
+"""Date/time helpers for sanitizing and coercing calendar values."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from icalendar.timezone.windows_to_olson import WINDOWS_TO_OLSON
+
+from .errors import InvalidInputError
+
+log = logging.getLogger(__name__)
+
+
+def localize_naive(naive: datetime, tz: ZoneInfo) -> datetime:
+    """Attach a timezone to a naive datetime, handling DST transitions.
+
+    - Gap (spring-forward): uses the post-transition offset (fold=1).
+    - Ambiguous (fall-back): uses the first occurrence (fold=0).
+    """
+    dt0 = naive.replace(tzinfo=tz, fold=0)
+    dt1 = naive.replace(tzinfo=tz, fold=1)
+    off0 = dt0.utcoffset()
+    off1 = dt1.utcoffset()
+    if off0 != off1 and off0 is not None and off1 is not None and off0 < off1:
+        return dt1
+    return dt0
+
+
+def parse_datetime(s: str, tz_name: str) -> datetime:
+    """Parse 'YYYY-MM-DD HH:MM' or 'YYYY-MM-DDTHH:MM' in the given Olson timezone.
+
+    Raises ``InvalidInputError`` for unparseable input or unknown timezones.
+    Handles DST transitions correctly via ``localize_naive``.
+    """
+    try:
+        tz = ZoneInfo(tz_name)
+    except (KeyError, ZoneInfoNotFoundError):
+        msg = f"Unknown timezone: {tz_name}"
+        raise InvalidInputError(msg) from None
+    try:
+        normalized = s.replace("T", " ")
+        naive = datetime.strptime(normalized, "%Y-%m-%d %H:%M")  # noqa: DTZ007
+    except ValueError:
+        msg = f"Invalid date/time format: {s!r} (expected YYYY-MM-DD HH:MM)"
+        raise InvalidInputError(msg) from None
+    return localize_naive(naive, tz)
+
+
+def normalize_windows_tzid(tzid: str) -> str:
+    """Convert Windows timezone names to Olson (e.g. 'Eastern Standard Time' → 'America/New_York').
+
+    Outlook sends Windows-style TZIDs that most Unix tools don't
+    understand.  Returns the input unchanged if it's already Olson.
+    """
+    result: str = WINDOWS_TO_OLSON.get(tzid, tzid)
+    return result
+
+
+def default_duration(dtstart: datetime | date) -> timedelta:
+    return timedelta(hours=1) if isinstance(dtstart, datetime) else timedelta(days=1)
+
+
+def _fix_mismatched_tz(dtstart: datetime, dtend: datetime) -> tuple[datetime, datetime]:
+    if dtstart.tzinfo and not dtend.tzinfo:
+        log.warning("DTEND has no timezone, copying from DTSTART")
+        dtend = dtend.replace(tzinfo=dtstart.tzinfo)
+    elif not dtstart.tzinfo and dtend.tzinfo:
+        log.warning("DTSTART has no timezone, copying from DTEND")
+        dtstart = dtstart.replace(tzinfo=dtend.tzinfo)
+    return dtstart, dtend
+
+
+def coerce_to_datetime(dt: datetime | date) -> datetime:
+    """Promote a bare ``date`` to a midnight UTC ``datetime``.
+
+    Needed so that mixed date/datetime pairs can be compared without
+    raising ``TypeError``.  Already-datetime values pass through unchanged.
+    """
+    if isinstance(dt, datetime):
+        return dt
+    return datetime.combine(dt, datetime.min.time(), tzinfo=UTC)
+
+
+def _coerce_mixed_types(
+    dtstart: datetime | date,
+    dtend: datetime | date,
+) -> tuple[datetime | date, datetime | date]:
+    """Coerce a date/datetime pair to a common type.
+
+    Real-world ICS producers (Outlook, some Google Calendar exports)
+    sometimes emit a DATE for DTSTART but a DATETIME for DTEND or vice
+    versa.  Coerce to datetime so comparisons don't crash.
+    """
+    start_is_dt = isinstance(dtstart, datetime)
+    end_is_dt = isinstance(dtend, datetime)
+    if start_is_dt != end_is_dt:
+        log.warning("DTSTART/DTEND type mismatch (date vs datetime), coercing")
+        return coerce_to_datetime(dtstart), coerce_to_datetime(dtend)
+    return dtstart, dtend
+
+
+def sanitize_timerange(
+    dtstart: datetime | date,
+    dtend: datetime | date | None,
+    duration: timedelta | None = None,
+) -> tuple[datetime | date, datetime | date]:
+    """Fix missing or broken DTEND — same heuristics as khal.
+
+    - Missing DTEND + no DURATION → 1 hour (datetime) or 1 day (date)
+    - DTEND == DTSTART → assume 1 hour / 1 day
+    - Mismatched tzinfo → copy from the one that has it
+    - Mixed date/datetime → coerce to datetime (prevents TypeError)
+    """
+    if dtend is not None:
+        dtstart, dtend = _coerce_mixed_types(dtstart, dtend)
+
+    if isinstance(dtstart, datetime) and isinstance(dtend, datetime):
+        dtstart, dtend = _fix_mismatched_tz(dtstart, dtend)
+
+    if dtend is None:
+        effective_duration = duration or default_duration(dtstart)
+        if effective_duration.total_seconds() < 0:
+            log.warning("Negative DURATION, using absolute value")
+            effective_duration = abs(effective_duration)
+        dtend = dtstart + effective_duration
+    elif dtend < dtstart:
+        log.warning("DTEND < DTSTART, swapping")
+        dtstart, dtend = dtend, dtstart
+    elif dtend == dtstart:
+        log.warning("DTEND == DTSTART, assuming 1 hour / 1 day")
+        dtend = dtstart + default_duration(dtstart)
+
+    return dtstart, dtend

--- a/calendar-cli/calendar_cli/util.py
+++ b/calendar-cli/calendar_cli/util.py
@@ -1,0 +1,129 @@
+"""Shared utilities used across calendar-cli modules."""
+
+from __future__ import annotations
+
+import email as email_lib
+import email.utils
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING, Any
+
+from icalendar import Calendar, Timezone
+
+if TYPE_CHECKING:
+    from icalendar import Event, vCalAddress
+
+
+def strip_mailto(s: str) -> str:
+    """Remove the mailto: prefix from a calendar address string.
+
+    Calendar producers use both ``MAILTO:`` and ``mailto:``; handle both.
+    """
+    return s.replace("MAILTO:", "").replace("mailto:", "")
+
+
+def get_attendee_list(component: Event) -> list[vCalAddress]:
+    """Return the ATTENDEE property as a list, even if there's only one."""
+    raw = component.get("attendee")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        return [raw]
+    return raw
+
+
+def new_calendar(*, method: str | None = None) -> Calendar:
+    """Create a VCALENDAR with the standard calendar-cli headers.
+
+    Optionally sets the METHOD property (e.g. REQUEST, REPLY, CANCEL).
+    """
+    cal = Calendar()
+    cal.add("prodid", "-//calendar-cli//mics-skills//")
+    cal.add("version", "2.0")
+    cal.add("calscale", "GREGORIAN")
+    if method:
+        cal.add("method", method)
+    return cal
+
+
+def parse_rrule_string(rrule: str) -> dict[str, Any]:
+    """Parse an iCalendar RRULE string like ``FREQ=WEEKLY;COUNT=10`` into a dict.
+
+    Handles special value types that icalendar expects:
+    - UNTIL with a ``Z`` suffix is converted to a UTC datetime
+    - BYDAY comma-separated values are split into a list
+    """
+    parts: dict[str, Any] = {}
+    for segment in rrule.split(";"):
+        if "=" not in segment:
+            continue
+        k, v = segment.split("=", 1)
+        if k == "UNTIL" and v.endswith("Z"):
+            parts[k] = datetime.strptime(v, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+        elif k == "BYDAY":
+            parts[k] = [day.strip() for day in v.split(",")]
+        else:
+            parts[k] = v
+    return parts
+
+
+def add_vtimezones(cal: Calendar, *dts: datetime | date) -> None:
+    """Add VTIMEZONE components for any Olson timezones referenced by the datetimes.
+
+    RFC 5545 §3.6.5 requires a VTIMEZONE for every TZID referenced in
+    the calendar object.  Uses icalendar's Timezone.from_tzinfo() to
+    generate standard-compliant VTIMEZONE definitions.
+    """
+    seen: set[str] = set()
+    for dt in dts:
+        if not isinstance(dt, datetime) or dt.tzinfo is None:
+            continue
+        tzname = str(dt.tzinfo)
+        # Skip UTC (no VTIMEZONE needed) and duplicates
+        if tzname in seen or tzname in ("UTC", "utc"):
+            continue
+        seen.add(tzname)
+        try:
+            vtz = Timezone.from_tzinfo(dt.tzinfo)
+            cal.add_component(vtz)
+        except (KeyError, ValueError):
+            # Not all tzinfo objects can be converted; skip gracefully
+            pass
+
+
+def extract_calendar_parts_from_email(content: bytes) -> list[bytes]:
+    """Extract raw calendar data from a MIME email message.
+
+    A MIME part can match by content-type (text/calendar, application/ics)
+    **or** by filename (*.ics).  Each part is only added once even if it
+    matches both criteria.
+    """
+    msg = email_lib.message_from_bytes(content)
+    calendars: list[bytes] = []
+
+    for part in msg.walk():
+        if part.get_content_type() in ["text/calendar", "application/ics"]:
+            cal_data = part.get_payload(decode=True)
+            if isinstance(cal_data, bytes) and b"BEGIN:VCALENDAR" in cal_data:
+                calendars.append(cal_data)
+                continue  # Don't also check filename for this part
+        # Also check for .ics attachments (fallback for unknown content-type)
+        filename = part.get_filename()
+        if filename and filename.lower().endswith(".ics"):
+            cal_data = part.get_payload(decode=True)
+            if isinstance(cal_data, bytes) and b"BEGIN:VCALENDAR" in cal_data:
+                calendars.append(cal_data)
+
+    return calendars
+
+
+def extract_recipient_email(content: str | bytes) -> str | None:
+    """Extract the To: email address from an email message."""
+    if isinstance(content, bytes):
+        msg = email_lib.message_from_bytes(content)
+    else:
+        msg = email_lib.message_from_string(content)
+    if "To" in msg:
+        _name, addr = email.utils.parseaddr(msg["To"])
+        if addr:
+            return addr
+    return None

--- a/calendar-cli/default.nix
+++ b/calendar-cli/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python3,
+  vdirsyncer,
+  msmtp ? null,
+}:
+
+python3.pkgs.buildPythonApplication {
+  pname = "calendar-cli";
+  version = "1.0.0";
+
+  src = ./.;
+
+  pyproject = true;
+
+  build-system = with python3.pkgs; [
+    hatchling
+  ];
+
+  dependencies = with python3.pkgs; [
+    icalendar
+    python-dateutil
+  ];
+
+  makeWrapperArgs =
+    let
+      bins = [ vdirsyncer ] ++ lib.optional (msmtp != null) msmtp;
+    in
+    [
+      "--suffix PATH : ${lib.makeBinPath bins}"
+    ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "CLI tool for managing local vdirsyncer calendars";
+    homepage = "https://github.com/Mic92/mics-skills";
+    license = lib.licenses.mit;
+    mainProgram = "calendar-cli";
+  };
+}

--- a/calendar-cli/pyproject.toml
+++ b/calendar-cli/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "calendar-cli"
+version = "1.0.0"
+description = "CLI tool for managing local vdirsyncer calendars"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { text = "MIT" }
+authors = [{ name = "Joerg Thalheim", email = "joerg@thalheim.io" }]
+dependencies = [
+    "icalendar>=6.0.0",
+    "python-dateutil>=2.8.0",
+]
+
+[project.scripts]
+calendar-cli = "calendar_cli.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["calendar_cli"]
+
+[tool.pytest.ini_options]
+# Make tests/ importable so test modules can share helpers via conftest.
+pythonpath = ["tests"]
+

--- a/calendar-cli/tests/conftest.py
+++ b/calendar-cli/tests/conftest.py
@@ -1,0 +1,78 @@
+"""Shared pytest fixtures for calendar-cli tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .helpers import ICSEvent, make_ics, setup_calendar_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_WEEKLY_STANDUP_ICS = (
+    "BEGIN:VCALENDAR\n"
+    "VERSION:2.0\n"
+    "PRODID:-//test//test//\n"
+    "BEGIN:VEVENT\n"
+    "UID:event3-uid\n"
+    "SUMMARY:Weekly standup\n"
+    "DTSTART;TZID=Europe/Berlin:20250401T090000\n"
+    "DTEND;TZID=Europe/Berlin:20250401T091500\n"
+    "RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10\n"
+    "BEGIN:VALARM\n"
+    "TRIGGER:-PT15M\n"
+    "ACTION:DISPLAY\n"
+    "DESCRIPTION:Standup reminder\n"
+    "END:VALARM\n"
+    "END:VEVENT\n"
+    "END:VCALENDAR\n"
+)
+
+
+@pytest.fixture
+def cal_dir(tmp_path: Path) -> str:
+    """Create a temporary calendar directory with sample events.
+
+    Contains two calendars (``personal`` with 3 events, ``work`` with 1).
+    Used by both test_cli.py and test_store.py.
+    """
+    return setup_calendar_dir(
+        tmp_path,
+        {
+            "personal": {
+                "event1.ics": make_ics(
+                    ICSEvent(
+                        uid="event1-uid",
+                        summary="Dentist appointment",
+                        dtstart="20250401T100000Z",
+                        dtend="20250401T110000Z",
+                        vevent_lines=[
+                            "LOCATION:Dr. Smith",
+                            "DESCRIPTION:Annual checkup",
+                        ],
+                    ),
+                ),
+                "event2.ics": make_ics(
+                    ICSEvent(
+                        uid="event2-uid",
+                        summary="Company Holiday",
+                        dtstart=";VALUE=DATE:20250401",
+                        dtend=";VALUE=DATE:20250402",
+                    ),
+                ),
+                "event3.ics": _WEEKLY_STANDUP_ICS,
+            },
+            "work": {
+                "event4.ics": make_ics(
+                    ICSEvent(
+                        uid="event4-uid",
+                        summary="Sprint planning",
+                        dtstart="20250402T140000Z",
+                        dtend="20250402T150000Z",
+                    ),
+                ),
+            },
+        },
+    )

--- a/calendar-cli/tests/helpers.py
+++ b/calendar-cli/tests/helpers.py
@@ -1,0 +1,237 @@
+"""Shared helpers for calendar-cli tests.
+
+Provides ICS builders, email template builders, MIME extraction, and
+CLI runner wrappers that eliminate boilerplate across test modules.
+"""
+
+from __future__ import annotations
+
+import email as email_lib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from calendar_cli.main import main
+from icalendar import Calendar
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# ICS builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ICSEvent:
+    """Parameters for building a VCALENDAR string.
+
+    *dtstart*/*dtend* are raw iCalendar property values — pass a full
+    property line suffix, e.g. ``"20250401T090000Z"`` or
+    ``";VALUE=DATE:20250401"``.
+
+    *vevent_lines* are injected inside the VEVENT.
+    *vcalendar_lines* are injected inside the VCALENDAR (e.g. METHOD).
+    *extra_components* are injected after the VEVENT (e.g. a second VEVENT).
+    """
+
+    uid: str
+    summary: str
+    dtstart: str = "20240320T140000Z"
+    dtend: str | None = "20240320T150000Z"
+    vevent_lines: Sequence[str] = ()
+    vcalendar_lines: Sequence[str] = ()
+    extra_components: str = ""
+
+
+def _format_dt_prop(name: str, value: str) -> str:
+    """Format a DTSTART/DTEND property, detecting if a param prefix is present."""
+    if ":" in value or ";" in value:
+        return f"{name}{value}"
+    return f"{name}:{value}"
+
+
+def make_ics(event: ICSEvent) -> str:
+    """Build a minimal VCALENDAR string from an ICSEvent."""
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//test//test//",
+        *event.vcalendar_lines,
+        "BEGIN:VEVENT",
+        f"UID:{event.uid}",
+        f"SUMMARY:{event.summary}",
+        _format_dt_prop("DTSTART", event.dtstart),
+    ]
+    if event.dtend is not None:
+        lines.append(_format_dt_prop("DTEND", event.dtend))
+    lines.extend(event.vevent_lines)
+    lines.append("END:VEVENT")
+    if event.extra_components:
+        lines.append(event.extra_components)
+    lines.append("END:VCALENDAR")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Email / MIME template builder
+# ---------------------------------------------------------------------------
+
+_EMAIL_INVITE_TEMPLATE = """\
+From: sender@example.com
+To: {to}
+Subject: Meeting Invitation
+Content-Type: text/calendar
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:{uid}
+DTSTART:{dtstart}
+DTEND:{dtend}
+SUMMARY:{summary}
+ORGANIZER:{organizer}
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:{to}
+{extra}END:VEVENT
+END:VCALENDAR"""
+
+
+@dataclass
+class EmailInvite:
+    """Parameters for building an RFC 822 email with a calendar invite."""
+
+    uid: str = "test@example.com"
+    to: str = "attendee@example.com"
+    summary: str = "Test Meeting"
+    organizer: str = "mailto:organizer@example.com"
+    dtstart: str = "20240320T140000Z"
+    dtend: str = "20240320T150000Z"
+    extra: str = ""
+
+
+def make_email_invite(invite: EmailInvite) -> str:
+    """Build an RFC 822 email with an embedded iCalendar invite."""
+    extra = invite.extra
+    if extra and not extra.endswith("\n"):
+        extra += "\n"
+    return _EMAIL_INVITE_TEMPLATE.format(
+        uid=invite.uid,
+        to=invite.to,
+        summary=invite.summary,
+        organizer=invite.organizer,
+        dtstart=invite.dtstart,
+        dtend=invite.dtend,
+        extra=extra,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MIME / ICS extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_ics_from_email(raw: str) -> Calendar:
+    """Parse a raw email string and return the first calendar attachment."""
+    msg = email_lib.message_from_string(raw)
+    for part in msg.walk():
+        ct = part.get_content_type()
+        fn = part.get_filename() or ""
+        if ct == "text/calendar" or fn.endswith(".ics"):
+            payload = part.get_payload(decode=True)
+            assert isinstance(payload, bytes)
+            return Calendar.from_ical(payload)
+    err_msg = "No calendar attachment found in email"
+    raise AssertionError(err_msg)
+
+
+def parse_reply_email(
+    raw: str,
+) -> tuple[email_lib.message.Message, Calendar]:
+    """Parse a reply email and extract the iCalendar attachment."""
+    msg = email_lib.message_from_string(raw)
+    cal = extract_ics_from_email(raw)
+    return msg, cal
+
+
+# ---------------------------------------------------------------------------
+# Store fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def setup_calendar_dir(tmp_path: Path, ics_files: dict[str, dict[str, str]]) -> str:
+    """Create a calendar directory tree with ICS files.
+
+    *ics_files* maps ``calendar_name -> {filename: ics_content}``.
+    Returns the root calendar directory as a string.
+    """
+    for cal_name, files in ics_files.items():
+        cal_dir = tmp_path / cal_name
+        cal_dir.mkdir(parents=True, exist_ok=True)
+        for filename, content in files.items():
+            (cal_dir / filename).write_text(content)
+    return str(tmp_path)
+
+
+def setup_single_calendar(
+    tmp_path: Path,
+    ics_content: str,
+    *,
+    calendar: str = "personal",
+    filename: str = "event.ics",
+) -> str:
+    """Create a calendar dir with a single ICS file. Returns cal_dir."""
+    return setup_calendar_dir(tmp_path, {calendar: {filename: ics_content}})
+
+
+# ---------------------------------------------------------------------------
+# CLI runner helpers
+# ---------------------------------------------------------------------------
+
+
+def run_cli(cal_dir: str, *args: str) -> int:
+    """Run calendar-cli with --no-sync and the given calendar dir."""
+    return main(["--calendar-dir", cal_dir, "--no-sync", *args])
+
+
+@dataclass
+class InviteArgs:
+    """Parameters for running the ``invite`` subcommand."""
+
+    summary: str
+    attendees: str = "a@b.com"
+    organizer: str = "org@example.com"
+    start: str = "2024-03-20 14:00"
+    timezone: str = "UTC"
+    extra_args: Sequence[str] = ()
+    output_email: str | None = None
+    output_ics: str | None = None
+
+
+def run_invite(tmp_path: Path, invite: InviteArgs) -> int:
+    """Run the ``invite`` subcommand with common defaults."""
+    args: list[str] = [
+        "--no-sync",
+        "invite",
+        "-s",
+        invite.summary,
+        "--start",
+        invite.start,
+        "--timezone",
+        invite.timezone,
+        "-a",
+        invite.attendees,
+        "--organizer-email",
+        invite.organizer,
+        "--no-local-save",
+    ]
+    if invite.output_email is not None:
+        args.extend(["--output-email", invite.output_email])
+    else:
+        args.extend(["--output-email", str(tmp_path / "invite.eml")])
+    if invite.output_ics is not None:
+        args.extend(["--output-ics", invite.output_ics])
+    args.extend(invite.extra_args)
+    return main(args)

--- a/calendar-cli/tests/test_cli.py
+++ b/calendar-cli/tests/test_cli.py
@@ -1,0 +1,389 @@
+"""Tests for the calendar-cli command-line interface.
+
+Only covers CLI-specific logic (arg parsing, output formatting, sync wiring)
+that isn't already tested by test_store.py.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from calendar_cli import store
+from calendar_cli.main import main
+from calendar_cli.timeutil import parse_datetime
+
+from .helpers import run_cli
+
+
+def test_calendars_smoke(cal_dir: str, capsys: pytest.CaptureFixture[str]) -> None:
+    result = run_cli(cal_dir, "calendars")
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "personal" in out
+    assert "work" in out
+
+
+def test_list_verbose_shows_details(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = run_cli(
+        cal_dir, "list", "-v", "--from", "2025-04-01", "--to", "2025-04-02"
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "Room 5" in out or "Dr. Smith" in out
+    assert "Weekly sync" in out or "Annual checkup" in out
+
+
+def test_new_event_alarm_parsing(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = run_cli(
+        cal_dir,
+        "new",
+        "Alarm Test",
+        "--start",
+        "2025-05-01 10:00",
+        "--timezone",
+        "Europe/Berlin",
+        "-d",
+        "30",
+        "--alarm",
+        "15m",
+        "--alarm",
+        "1h",
+        "-c",
+        "personal",
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "Alarm Test" in out
+
+
+@pytest.mark.parametrize("bad_spec", ["m", "xh", "abc", ""])
+def test_new_event_bad_alarm_spec(
+    cal_dir: str,
+    capsys: pytest.CaptureFixture[str],
+    bad_spec: str,
+) -> None:
+    """Malformed alarm specs produce a clean error, not a traceback."""
+    result = run_cli(
+        cal_dir,
+        "new",
+        "Alarm Fail",
+        "--start",
+        "2025-05-01 10:00",
+        "--timezone",
+        "UTC",
+        "--alarm",
+        bad_spec,
+    )
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "Invalid alarm spec" in err
+
+
+@pytest.mark.parametrize("bad_date", ["+d", "+xd", "not-a-date"])
+def test_list_bad_date(
+    cal_dir: str,
+    capsys: pytest.CaptureFixture[str],
+    bad_date: str,
+) -> None:
+    """Malformed --from values produce a clean error, not a traceback."""
+    result = run_cli(cal_dir, "list", "--from", bad_date)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_new_event_bad_time(cal_dir: str, capsys: pytest.CaptureFixture[str]) -> None:
+    result = run_cli(
+        cal_dir,
+        "new",
+        "Bad time",
+        "--start",
+        "not-a-date",
+        "--timezone",
+        "UTC",
+    )
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "Error" in err
+
+
+def test_new_event_requires_timezone(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = run_cli(
+        cal_dir,
+        "new",
+        "No TZ",
+        "--start",
+        "2025-05-01 10:00",
+    )
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "--timezone is required" in err
+
+
+def test_edit_requires_timezone_for_time_changes(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    result = run_cli(cal_dir, "edit", "meeting-uid", "--start", "2025-04-02 10:00")
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "--timezone is required" in err
+
+
+def test_no_sync_flag(cal_dir: str) -> None:
+    with patch("calendar_cli.main.subprocess.run") as mock_run:
+        result = run_cli(cal_dir, "list", "--from", "2025-04-01", "--to", "2025-04-02")
+        assert result == 0
+        mock_run.assert_not_called()
+
+
+def test_new_event_iso_datetime(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ISO 8601 T separator is accepted in --start/--end."""
+    result = run_cli(
+        cal_dir,
+        "new",
+        "ISO Test",
+        "--start",
+        "2025-05-01T10:00",
+        "--timezone",
+        "Europe/Berlin",
+        "-c",
+        "personal",
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "ISO Test" in out
+
+
+def test_new_all_day_event(cal_dir: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """--all-day creates a date-only event without requiring --timezone."""
+    result = run_cli(
+        cal_dir,
+        "new",
+        "Holiday",
+        "--start",
+        "2025-12-25",
+        "--all-day",
+        "-c",
+        "personal",
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "Holiday" in out
+    assert "2025-12-25" in out
+
+
+def test_case_insensitive_calendar(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Calendar names are resolved case-insensitively."""
+    # The fixture creates 'personal' and 'work' directories (lowercase)
+    result = run_cli(
+        cal_dir, "list", "-c", "Personal", "--from", "2025-04-01", "--to", "2025-04-02"
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "Dentist appointment" in out
+
+
+def test_alarm_display(cal_dir: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """Alarms display as human-readable '15m before' not raw timedelta."""
+    result = run_cli(
+        cal_dir,
+        "new",
+        "Alarm Display",
+        "--start",
+        "2025-05-01T10:00",
+        "--timezone",
+        "Europe/Berlin",
+        "--alarm",
+        "15m",
+        "-c",
+        "personal",
+    )
+    assert result == 0
+    # Read back with verbose to see alarm display
+    capsys.readouterr()  # clear
+
+    events = store.list_events(calendars_dir=cal_dir)
+    alarm_event = next(e for e in events if e.summary == "Alarm Display")
+    assert alarm_event.alarms == ["15m before"]
+
+
+def test_update_preserves_alarms(cal_dir: str) -> None:
+    """Editing summary should not erase existing alarms."""
+
+    start = datetime(2025, 5, 1, 10, 0, tzinfo=UTC)
+    end = datetime(2025, 5, 1, 11, 0, tzinfo=UTC)
+    ev = store.create_event(
+        summary="Keep Alarms",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+        alarm_minutes=[15, 60],
+    )
+    updated = store.update_event(ev.uid, cal_dir, summary="Renamed")
+    assert updated is not None
+    assert updated.alarm_minutes == [15, 60]
+    assert updated.alarms == ["15m before", "1h before"]
+
+
+def test_parse_datetime_dst_gap() -> None:
+    """Time in a DST gap (spring-forward) must get the post-transition offset."""
+    dt = parse_datetime("2025-03-09 02:30", "America/New_York")
+    # In the gap, 02:30 should become EDT (UTC-4), not EST (UTC-5)
+    assert dt.utcoffset() == timedelta(hours=-4)
+
+
+def test_parse_datetime_dst_fall_back() -> None:
+    """Ambiguous time (fall-back) should resolve to the first occurrence."""
+    dt = parse_datetime("2025-11-02 01:30", "America/New_York")
+    # First occurrence = EDT (UTC-4)
+    assert dt.utcoffset() == timedelta(hours=-4)
+
+
+def test_new_event_during_dst_gap(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Creating an event during a DST gap should succeed with correct offset."""
+    result = run_cli(
+        cal_dir,
+        "new",
+        "DST Gap Meeting",
+        "--start",
+        "2025-03-09 02:30",
+        "--timezone",
+        "America/New_York",
+        "-c",
+        "personal",
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "DST Gap Meeting" in out
+
+
+def test_all_day_end_equals_start(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--all-day with --end equal to --start should produce a 1-day event."""
+    result = run_cli(
+        cal_dir,
+        "new",
+        "Single Day",
+        "--start",
+        "2025-04-01",
+        "--end",
+        "2025-04-01",
+        "--all-day",
+        "-c",
+        "personal",
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "Single Day" in out
+
+    # Verify DTEND was bumped
+    events = store.list_events(calendars_dir=cal_dir)
+    ev = next(e for e in events if e.summary == "Single Day")
+
+    assert str(ev.dtstart) == "2025-04-01"
+    assert str(ev.dtend) == "2025-04-02"
+
+
+def test_all_day_end_before_start(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--all-day with --end before --start should error."""
+    result = run_cli(
+        cal_dir,
+        "new",
+        "Bad Range",
+        "--start",
+        "2025-04-05",
+        "--end",
+        "2025-04-01",
+        "--all-day",
+        "-c",
+        "personal",
+    )
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "end" in err.lower() or "before" in err.lower() or "Error" in err
+
+
+def test_global_flags_after_subcommand(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Global flags like --no-sync and --calendar-dir work after the subcommand."""
+    result = main(["calendars", "--calendar-dir", cal_dir, "--no-sync"])
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "personal" in out
+
+
+def test_search_limit(cal_dir: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """Search respects --limit."""
+    result = run_cli(cal_dir, "search", "e", "--limit", "1")
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "more event(s) not shown" in out
+
+
+def test_list_limit_truncates(cal_dir: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """--limit caps displayed events and shows a remainder message."""
+    result = run_cli(
+        cal_dir, "list", "--from", "2025-04-01", "--to", "2025-04-30", "--limit", "2"
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "more event(s) not shown" in out
+
+
+def test_list_limit_zero_shows_all(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--limit 0 disables truncation."""
+    result = run_cli(
+        cal_dir, "list", "--from", "2025-04-01", "--to", "2025-04-30", "--limit", "0"
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "more event(s) not shown" not in out
+
+
+def test_list_verbose_truncates_description(
+    cal_dir: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Verbose list truncates long descriptions; show gives full text."""
+    # Create an event with a long description
+    start = datetime(2025, 5, 1, 10, 0, tzinfo=UTC)
+    end = datetime(2025, 5, 1, 11, 0, tzinfo=UTC)
+    long_desc = "A" * 300
+    ev = store.create_event(
+        summary="Long Desc",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+        description=long_desc,
+    )
+
+    # list -v should truncate
+    run_cli(cal_dir, "list", "-v", "--from", "2025-05-01", "--to", "2025-05-02")
+    out = capsys.readouterr().out
+    assert "…" in out
+    assert long_desc not in out
+
+    # show should give full text
+    run_cli(cal_dir, "show", ev.uid)
+    out = capsys.readouterr().out
+    assert long_desc in out
+    assert "…" not in out

--- a/calendar-cli/tests/test_import.py
+++ b/calendar-cli/tests/test_import.py
@@ -1,0 +1,521 @@
+"""Tests for the calendar-cli import command."""
+
+from hashlib import sha1
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from calendar_cli.import_invite import (
+    _calendar_has_rsvp,
+    extract_calendar_from_email,
+    import_to_local,
+)
+from calendar_cli.main import main
+from icalendar import Calendar
+
+from .helpers import ICSEvent, make_ics
+
+BASIC_ICS = make_ics(
+    ICSEvent(
+        uid="test-uid@example.com",
+        summary="Test Meeting",
+        dtstart="20240320T140000Z",
+        dtend="20240320T150000Z",
+    )
+)
+
+
+def _find_imported_ics(base: Path) -> list[Path]:
+    return sorted(base.rglob("*.ics"))
+
+
+def _parse_imported(path: Path) -> Calendar:
+    return Calendar.from_ical(path.read_bytes())
+
+
+def test_import_basic_ics(tmp_path: Path) -> None:
+    """Test importing a .ics file writes a parseable event to the store."""
+    cal_dir = tmp_path / "calendars"
+    result = import_to_local(BASIC_ICS.encode(), "personal", str(cal_dir))
+
+    assert result is True
+
+    files = _find_imported_ics(cal_dir)
+    assert len(files) == 1
+    assert "test-uid@example.com" in files[0].name
+
+    cal = _parse_imported(files[0])
+    event = next(iter(cal.walk("VEVENT")))
+    assert str(event["UID"]) == "test-uid@example.com"
+    assert str(event["SUMMARY"]) == "Test Meeting"
+
+
+@patch("calendar_cli.import_invite.subprocess.run")
+def test_import_from_email(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Test importing calendar invite from multipart email."""
+    mock_run.return_value = MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+    email_content = """\
+From: sender@example.com
+To: recipient@example.com
+Subject: Meeting Invitation
+Content-Type: multipart/mixed; boundary="boundary"
+
+--boundary
+Content-Type: text/plain
+
+You're invited to a meeting.
+
+--boundary
+Content-Type: text/calendar; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:email-invite@example.com
+DTSTART:20240320T140000Z
+DTEND:20240320T150000Z
+SUMMARY:Email Meeting
+ORGANIZER:mailto:organizer@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:attendee@example.com
+END:VEVENT
+END:VCALENDAR
+--boundary--"""
+
+    email_file = tmp_path / "email.eml"
+    email_file.write_text(email_content)
+
+    cal_dir = str(tmp_path / "calendars")
+    result = main(["--calendar-dir", cal_dir, "--no-sync", "import", str(email_file)])
+    assert result == 0
+
+
+def test_import_invalid_ics(tmp_path: Path) -> None:
+    """Test importing invalid ICS file fails."""
+    (tmp_path / "invalid.ics").write_text("This is not a valid ICS file")
+    result = main(["--no-sync", "import", str(tmp_path / "invalid.ics")])
+    assert result == 1
+
+
+def test_import_nonexistent_file() -> None:
+    """Test importing non-existent file fails."""
+    result = main(["--no-sync", "import", "/non/existent/file.ics"])
+    assert result == 1
+
+
+def test_import_groups_by_uid(tmp_path: Path) -> None:
+    """Import with multiple VEVENTs sharing a UID writes one file."""
+    override_vevent = (
+        "BEGIN:VEVENT\n"
+        "UID:recurring@example.com\n"
+        "RECURRENCE-ID:20240327T140000Z\n"
+        "DTSTART:20240327T150000Z\n"
+        "DTEND:20240327T160000Z\n"
+        "SUMMARY:Weekly Meeting (rescheduled)\n"
+        "END:VEVENT"
+    )
+    ics = make_ics(
+        ICSEvent(
+            uid="recurring@example.com",
+            summary="Weekly Meeting",
+            dtstart="20240320T140000Z",
+            dtend="20240320T150000Z",
+            vevent_lines=["RRULE:FREQ=WEEKLY;COUNT=3"],
+            extra_components=override_vevent,
+        )
+    )
+
+    cal_dir = tmp_path / "calendars"
+    result = import_to_local(ics.encode(), "personal", str(cal_dir))
+    assert result is True
+
+    files = sorted((cal_dir / "personal").rglob("*.ics"))
+    assert len(files) == 1  # One file for the UID, not two
+
+    cal = _parse_imported(files[0])
+    events = list(cal.walk("VEVENT"))
+    assert len(events) == 2  # Both VEVENTs in the same file
+
+
+def test_import_unsafe_uid(tmp_path: Path) -> None:
+    """UIDs with filesystem-unsafe characters get hashed filenames."""
+    uid = "uid with spaces/and:colons"
+    ics = make_ics(ICSEvent(uid=uid, summary="Unsafe UID Test"))
+
+    cal_dir = tmp_path / "calendars"
+    result = import_to_local(ics.encode(), "personal", str(cal_dir))
+    assert result is True
+
+    files = sorted((cal_dir / "personal").rglob("*.ics"))
+    assert len(files) == 1
+    expected_name = sha1(uid.encode(), usedforsecurity=False).hexdigest() + ".ics"
+    assert files[0].name == expected_name
+
+    cal = _parse_imported(files[0])
+    event = next(iter(cal.walk("VEVENT")))
+    assert str(event["UID"]) == uid  # UID preserved inside the file
+
+
+def test_import_windows_timezone(tmp_path: Path) -> None:
+    """Outlook-style Windows timezone names are normalized during import."""
+    ics = """\
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VTIMEZONE
+TZID:Eastern Standard Time
+BEGIN:STANDARD
+DTSTART:16011104T020000
+RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=11
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:outlook-tz@example.com
+DTSTART;TZID=Eastern Standard Time:20240320T140000
+DTEND;TZID=Eastern Standard Time:20240320T150000
+SUMMARY:Outlook Meeting
+END:VEVENT
+END:VCALENDAR"""
+
+    cal_dir = tmp_path / "calendars"
+    result = import_to_local(ics.encode(), "personal", str(cal_dir))
+    assert result is True
+
+    files = _find_imported_ics(cal_dir / "personal")
+    assert len(files) == 1
+
+    cal = _parse_imported(files[0])
+    # The VTIMEZONE should be included in the output
+    tzs = [c for c in cal.walk() if c.name == "VTIMEZONE"]
+    assert len(tzs) == 1
+
+
+def test_import_missing_uid(tmp_path: Path) -> None:
+    """Events without UID get a generated one."""
+    ics = make_ics(ICSEvent(uid="", summary="No UID Event"))
+    # Remove the UID line entirely to simulate a truly missing UID
+    ics = "\n".join(line for line in ics.splitlines() if not line.startswith("UID:"))
+
+    cal_dir = tmp_path / "calendars"
+    result = import_to_local(ics.encode(), "personal", str(cal_dir))
+    assert result is True
+
+    files = _find_imported_ics(cal_dir / "personal")
+    assert len(files) == 1
+
+    cal = _parse_imported(files[0])
+    event = next(iter(cal.walk("VEVENT")))
+    assert event.get("UID") is not None
+
+
+def test_import_calscale_in_output(tmp_path: Path) -> None:
+    """Imported events include CALSCALE:GREGORIAN."""
+    cal_dir = tmp_path / "calendars"
+    import_to_local(BASIC_ICS.encode(), "personal", str(cal_dir))
+    files = _find_imported_ics(cal_dir)
+    assert len(files) == 1
+    raw = files[0].read_bytes().decode()
+    assert "CALSCALE:GREGORIAN" in raw
+
+
+def test_rsvp_detection_uses_parsed_params(tmp_path: Path) -> None:
+    """RSVP detection works via iCalendar parameter parsing, not byte search."""
+    ics_with_rsvp = make_ics(
+        ICSEvent(
+            uid="rsvp-test@example.com",
+            summary="RSVP Test",
+            vevent_lines=["ATTENDEE;RSVP=TRUE:mailto:test@example.com"],
+        )
+    ).encode()
+
+    ics_without_rsvp = make_ics(
+        ICSEvent(
+            uid="no-rsvp@example.com",
+            summary="No RSVP",
+            vevent_lines=[
+                "DESCRIPTION:This text mentions RSVP=TRUE but is not an attendee param"
+            ],
+        )
+    ).encode()
+
+    assert _calendar_has_rsvp(ics_with_rsvp) is True
+    assert _calendar_has_rsvp(ics_without_rsvp) is False
+
+
+@patch("calendar_cli.import_invite.sys.stdin")
+def test_import_from_stdin(
+    mock_stdin: MagicMock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test importing from stdin."""
+    mock_stdin.buffer.read.return_value = BASIC_ICS.encode()
+
+    cal_dir = str(tmp_path / "calendars")
+    with patch("calendar_cli.import_invite.subprocess.run"):
+        result = main(["--calendar-dir", cal_dir, "--no-sync", "import"])
+
+    assert result == 0
+    captured = capsys.readouterr()
+    assert "Successfully imported 1 calendar invite(s)" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Issue #13: METHOD:CANCEL and METHOD:REPLY handling
+# ---------------------------------------------------------------------------
+
+
+def test_import_method_cancel_deletes_event(tmp_path: Path) -> None:
+    """METHOD:CANCEL should delete the matching local event."""
+    cal_dir = tmp_path / "calendars"
+
+    # First, import a normal event
+    import_to_local(BASIC_ICS.encode(), "personal", str(cal_dir))
+    files_before = _find_imported_ics(cal_dir / "personal")
+    assert len(files_before) == 1
+
+    # Now import a cancellation for the same UID
+    cancel_ics = make_ics(
+        ICSEvent(
+            uid="test-uid@example.com",
+            summary="Test Meeting",
+            vcalendar_lines=["METHOD:CANCEL"],
+            vevent_lines=["STATUS:CANCELLED", "SEQUENCE:1"],
+        )
+    )
+
+    result = import_to_local(cancel_ics.encode(), "personal", str(cal_dir))
+    assert result is True
+
+    # The original file should be gone
+    files_after = _find_imported_ics(cal_dir / "personal")
+    assert len(files_after) == 0
+
+
+def test_import_method_reply_updates_partstat(tmp_path: Path) -> None:
+    """METHOD:REPLY should update the attendee's PARTSTAT in the local event."""
+    cal_dir = tmp_path / "calendars"
+
+    # Import an event with attendees
+    invite_ics = make_ics(
+        ICSEvent(
+            uid="reply-test@example.com",
+            summary="Reply Test",
+            vcalendar_lines=["METHOD:REQUEST"],
+            vevent_lines=[
+                "ORGANIZER:mailto:alice@example.com",
+                "ATTENDEE;CN=Bob;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com",
+            ],
+        )
+    )
+
+    import_to_local(invite_ics.encode(), "personal", str(cal_dir))
+
+    # Verify initial state
+    files = _find_imported_ics(cal_dir / "personal")
+    assert len(files) == 1
+    cal = _parse_imported(files[0])
+    event = next(iter(cal.walk("VEVENT")))
+    attendee = event.get("attendee")
+    assert attendee.params["PARTSTAT"] == "NEEDS-ACTION"
+
+    # Now import Bob's REPLY accepting the invite
+    reply_ics = make_ics(
+        ICSEvent(
+            uid="reply-test@example.com",
+            summary="Reply Test",
+            vcalendar_lines=["METHOD:REPLY"],
+            vevent_lines=[
+                "ATTENDEE;CN=Bob;PARTSTAT=ACCEPTED:mailto:bob@example.com",
+            ],
+        )
+    )
+
+    result = import_to_local(reply_ics.encode(), "personal", str(cal_dir))
+    assert result is True
+
+    # Verify PARTSTAT was updated
+    cal = _parse_imported(files[0])
+    event = next(iter(cal.walk("VEVENT")))
+    attendee = event.get("attendee")
+    assert attendee.params["PARTSTAT"] == "ACCEPTED"
+
+
+def test_import_method_cancel_unknown_uid(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """METHOD:CANCEL for an unknown UID should warn, not crash."""
+    cal_dir = tmp_path / "calendars"
+    (cal_dir / "personal").mkdir(parents=True)
+
+    cancel_ics = make_ics(
+        ICSEvent(
+            uid="nonexistent@example.com",
+            summary="Ghost Event",
+            vcalendar_lines=["METHOD:CANCEL"],
+            vevent_lines=["STATUS:CANCELLED", "SEQUENCE:1"],
+        )
+    )
+
+    result = import_to_local(cancel_ics.encode(), "personal", str(cal_dir))
+    assert result is False
+    err = capsys.readouterr().err
+    assert "unknown event" in err.lower() or "nonexistent" in err.lower()
+
+
+def test_import_method_reply_decline(tmp_path: Path) -> None:
+    """METHOD:REPLY with DECLINED updates the attendee status."""
+    cal_dir = tmp_path / "calendars"
+
+    invite_ics = make_ics(
+        ICSEvent(
+            uid="decline-test@example.com",
+            summary="Decline Test",
+            vcalendar_lines=["METHOD:REQUEST"],
+            vevent_lines=[
+                "ORGANIZER:mailto:alice@example.com",
+                "ATTENDEE;CN=Bob;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com",
+            ],
+        )
+    )
+    import_to_local(invite_ics.encode(), "personal", str(cal_dir))
+
+    reply_ics = make_ics(
+        ICSEvent(
+            uid="decline-test@example.com",
+            summary="Decline Test",
+            vcalendar_lines=["METHOD:REPLY"],
+            vevent_lines=[
+                "ATTENDEE;CN=Bob;PARTSTAT=DECLINED:mailto:bob@example.com",
+            ],
+        )
+    )
+    result = import_to_local(reply_ics.encode(), "personal", str(cal_dir))
+    assert result is True
+
+    files = _find_imported_ics(cal_dir / "personal")
+    cal = _parse_imported(files[0])
+    event = next(iter(cal.walk("VEVENT")))
+    attendee = event.get("attendee")
+    assert attendee.params["PARTSTAT"] == "DECLINED"
+
+
+def test_import_method_reply_multiple_attendees(tmp_path: Path) -> None:
+    """REPLY from one attendee should not change another attendee's status."""
+    cal_dir = tmp_path / "calendars"
+
+    invite_ics = make_ics(
+        ICSEvent(
+            uid="multi-att@example.com",
+            summary="Multi Attendee",
+            vcalendar_lines=["METHOD:REQUEST"],
+            vevent_lines=[
+                "ORGANIZER:mailto:alice@example.com",
+                "ATTENDEE;CN=Bob;PARTSTAT=NEEDS-ACTION:mailto:bob@example.com",
+                "ATTENDEE;CN=Carol;PARTSTAT=NEEDS-ACTION:mailto:carol@example.com",
+            ],
+        )
+    )
+    import_to_local(invite_ics.encode(), "personal", str(cal_dir))
+
+    # Bob accepts
+    reply_ics = make_ics(
+        ICSEvent(
+            uid="multi-att@example.com",
+            summary="Multi Attendee",
+            vcalendar_lines=["METHOD:REPLY"],
+            vevent_lines=[
+                "ATTENDEE;CN=Bob;PARTSTAT=ACCEPTED:mailto:bob@example.com",
+            ],
+        )
+    )
+    import_to_local(reply_ics.encode(), "personal", str(cal_dir))
+
+    files = _find_imported_ics(cal_dir / "personal")
+    cal = _parse_imported(files[0])
+    event = next(iter(cal.walk("VEVENT")))
+    attendees = event.get("attendee")
+    assert isinstance(attendees, list)
+
+    by_email = {
+        str(a).replace("mailto:", "").replace("MAILTO:", ""): a for a in attendees
+    }
+    assert by_email["bob@example.com"].params["PARTSTAT"] == "ACCEPTED"
+    assert by_email["carol@example.com"].params["PARTSTAT"] == "NEEDS-ACTION"
+
+
+def test_import_method_reply_unknown_uid(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """REPLY for an unknown UID should warn and return False."""
+    cal_dir = tmp_path / "calendars"
+    (cal_dir / "personal").mkdir(parents=True)
+
+    reply_ics = make_ics(
+        ICSEvent(
+            uid="ghost@example.com",
+            summary="Ghost Reply",
+            vcalendar_lines=["METHOD:REPLY"],
+            vevent_lines=[
+                "ATTENDEE;CN=Bob;PARTSTAT=ACCEPTED:mailto:bob@example.com",
+            ],
+        )
+    )
+    result = import_to_local(reply_ics.encode(), "personal", str(cal_dir))
+    assert result is False
+    err = capsys.readouterr().err
+    assert "unknown event" in err.lower() or "ghost" in err.lower()
+
+
+def test_import_cancel_across_calendars(tmp_path: Path) -> None:
+    """CANCEL finds and removes the event even if it's in a different calendar."""
+    cal_dir = tmp_path / "calendars"
+
+    # Import into "work" calendar
+    import_to_local(BASIC_ICS.encode(), "work", str(cal_dir))
+    assert len(_find_imported_ics(cal_dir / "work")) == 1
+
+    # Cancel without specifying calendar — should find it in "work"
+    cancel_ics = make_ics(
+        ICSEvent(
+            uid="test-uid@example.com",
+            summary="Test Meeting",
+            vcalendar_lines=["METHOD:CANCEL"],
+            vevent_lines=["STATUS:CANCELLED"],
+        )
+    )
+    result = import_to_local(cancel_ics.encode(), "personal", str(cal_dir))
+    assert result is True
+    assert len(_find_imported_ics(cal_dir / "work")) == 0
+
+
+def test_extract_calendar_no_duplicates() -> None:
+    """A MIME part matching both content-type and filename should be extracted once."""
+    email_content = b"""\
+From: sender@example.com
+To: recipient@example.com
+Subject: Meeting
+Content-Type: multipart/mixed; boundary="boundary"
+
+--boundary
+Content-Type: text/calendar; charset=utf-8
+Content-Disposition: attachment; filename="invite.ics"
+
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:dup-test@example.com
+DTSTART:20240320T140000Z
+DTEND:20240320T150000Z
+SUMMARY:Duplicate Test
+END:VEVENT
+END:VCALENDAR
+--boundary--"""
+
+    cals = extract_calendar_from_email(email_content)
+    assert len(cals) == 1

--- a/calendar-cli/tests/test_invite.py
+++ b/calendar-cli/tests/test_invite.py
@@ -1,0 +1,262 @@
+"""Tests for the calendar-cli invite command (send meeting invitations)."""
+
+import email
+import email.utils
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from calendar_cli.email_invite import _format_time_with_tz
+from calendar_cli.main import main
+from icalendar import Calendar
+
+from .helpers import InviteArgs, extract_ics_from_email, run_invite
+
+
+def _parse_email(path: Path) -> email.message.Message:
+    return email.message_from_string(path.read_text())
+
+
+def test_invite_email_structure(tmp_path: Path) -> None:
+    """Test the email has correct headers, body, and ics attachment."""
+    email_file = tmp_path / "invite.eml"
+
+    result = run_invite(
+        tmp_path,
+        InviteArgs(
+            summary="Project Review",
+            attendees="alice@example.com,Bob <bob@example.com>",
+            extra_args=["-d", "90", "--reminder", "30"],
+            output_email=str(email_file),
+        ),
+    )
+
+    assert result == 0
+    msg = _parse_email(email_file)
+
+    # Headers
+    assert msg["Subject"] == "Invitation: Project Review"
+    _, from_addr = email.utils.parseaddr(msg["From"])
+    assert from_addr == "org@example.com"
+    to_addrs = [addr for _, addr in email.utils.getaddresses([msg["To"]])]
+    assert "alice@example.com" in to_addrs
+    assert "bob@example.com" in to_addrs
+
+    # Body text
+    body = None
+    for part in msg.walk():
+        if part.get_content_type() == "text/plain":
+            body = part.get_payload(decode=True)
+            assert isinstance(body, bytes)
+            body = body.decode()
+            break
+    assert body is not None
+    assert "Project Review" in body
+
+    # Calendar attachment
+    cal = extract_ics_from_email(msg.as_string())
+    events = list(cal.walk("VEVENT"))
+    assert len(events) == 1
+    event = events[0]
+    assert str(event["SUMMARY"]) == "Project Review"
+    method = str(event["METHOD"]) if "METHOD" in event else str(cal["METHOD"])
+    assert method == "REQUEST"
+
+    # Alarm
+    alarms = [c for c in event.subcomponents if c.name == "VALARM"]
+    assert len(alarms) == 1
+
+
+def test_invite_with_timezone(tmp_path: Path) -> None:
+    """Test invite preserves timezone in the ics."""
+    ics_file = tmp_path / "invite.ics"
+
+    result = run_invite(
+        tmp_path,
+        InviteArgs(
+            summary="Berlin Meeting",
+            timezone="America/New_York",
+            output_ics=str(ics_file),
+        ),
+    )
+
+    assert result == 0
+    cal = Calendar.from_ical(ics_file.read_bytes())
+    event = next(iter(cal.walk("VEVENT")))
+    assert str(event["SUMMARY"]) == "Berlin Meeting"
+    dtstart = event["DTSTART"].dt
+    assert "New_York" in str(dtstart.tzinfo)
+
+
+def test_invite_with_recurrence(tmp_path: Path) -> None:
+    """Test invite with rrule."""
+    ics_file = tmp_path / "recurring.ics"
+
+    result = run_invite(
+        tmp_path,
+        InviteArgs(
+            summary="Weekly Meeting",
+            extra_args=["--rrule", "FREQ=WEEKLY;COUNT=10"],
+            output_ics=str(ics_file),
+        ),
+    )
+
+    assert result == 0
+    cal = Calendar.from_ical(ics_file.read_bytes())
+    event = next(iter(cal.walk("VEVENT")))
+    rrule = event["RRULE"]
+    assert rrule["FREQ"] == ["WEEKLY"]
+    assert rrule["COUNT"] == [10]
+
+
+def test_invite_invalid_time_format(tmp_path: Path) -> None:
+    """Test that invalid time format fails."""
+    result = run_invite(tmp_path, InviteArgs(summary="Bad", start="invalid"))
+    assert result == 1
+
+
+def test_invite_missing_required_fields() -> None:
+    """Test that missing required fields fail with argparse error."""
+    # Missing --attendees
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "invite",
+                "-s",
+                "Test",
+                "--start",
+                "2024-03-20 14:00",
+                "--timezone",
+                "UTC",
+                "--organizer-email",
+                "test@example.com",
+            ],
+        )
+    assert exc_info.value.code == 2
+
+    # Missing --timezone
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "invite",
+                "-s",
+                "Test",
+                "--start",
+                "2024-03-20 14:00",
+                "-a",
+                "a@b.com",
+                "--organizer-email",
+                "test@example.com",
+            ],
+        )
+    assert exc_info.value.code == 2
+
+
+def test_invite_invalid_email_format(tmp_path: Path) -> None:
+    """Test that invalid attendee email is rejected."""
+    result = run_invite(tmp_path, InviteArgs(summary="Test", attendees="not-an-email"))
+    assert result == 1
+
+
+def test_invite_has_calscale_no_organizer_role(tmp_path: Path) -> None:
+    """Invite includes CALSCALE:GREGORIAN and no ROLE on ORGANIZER (RFC 5545)."""
+    ics_file = tmp_path / "rfc.ics"
+
+    result = run_invite(
+        tmp_path,
+        InviteArgs(summary="RFC Test", output_ics=str(ics_file)),
+    )
+
+    assert result == 0
+    raw = ics_file.read_bytes().decode()
+    assert "CALSCALE:GREGORIAN" in raw
+    # ROLE should only appear on ATTENDEE lines, not ORGANIZER
+    for line in raw.splitlines():
+        if "ORGANIZER" in line:
+            assert "ROLE" not in line
+
+
+def test_invite_output_email_stdout(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Test --output-email - writes parseable email to stdout."""
+    result = run_invite(
+        tmp_path,
+        InviteArgs(summary="Stdout Test", output_email="-"),
+    )
+
+    assert result == 0
+    out = capsys.readouterr().out
+    msg = email.message_from_string(out)
+    assert msg["Subject"] == "Invitation: Stdout Test"
+    assert any(part.get_content_type() == "text/calendar" for part in msg.walk())
+
+
+def test_invite_includes_vtimezone(tmp_path: Path) -> None:
+    """Invites with non-UTC timezones should include a VTIMEZONE component."""
+    eml = tmp_path / "tz-invite.eml"
+    result = run_invite(
+        tmp_path,
+        InviteArgs(
+            summary="TZ Invite",
+            timezone="Europe/Berlin",
+            output_email=str(eml),
+        ),
+    )
+    assert result == 0
+
+    msg = _parse_email(eml)
+    cal = extract_ics_from_email(msg.as_string())
+    assert cal is not None
+    tzs = [c for c in cal.walk() if c.name == "VTIMEZONE"]
+    assert len(tzs) >= 1
+
+    # Also check CREATED property
+    event = next(iter(cal.walk("VEVENT")))
+    assert event.get("created") is not None
+
+
+def test_invite_utc_no_vtimezone(tmp_path: Path) -> None:
+    """UTC invites should not include a VTIMEZONE."""
+    eml = tmp_path / "utc-invite.eml"
+    result = run_invite(
+        tmp_path,
+        InviteArgs(summary="UTC Invite", output_email=str(eml)),
+    )
+    assert result == 0
+
+    msg = _parse_email(eml)
+    cal = extract_ics_from_email(msg.as_string())
+    assert cal is not None
+    tzs = [c for c in cal.walk() if c.name == "VTIMEZONE"]
+    assert len(tzs) == 0
+
+
+# ---------------------------------------------------------------------------
+# _format_time_with_tz unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_time_with_tz_utc() -> None:
+    """Aware UTC datetime includes 'UTC' suffix."""
+    dt = datetime(2024, 3, 20, 14, 0, tzinfo=ZoneInfo("UTC"))
+    assert _format_time_with_tz(dt) == "02:00 PM UTC"
+
+
+def test_format_time_with_tz_named() -> None:
+    """Aware non-UTC datetime includes the timezone abbreviation."""
+    dt = datetime(2024, 3, 20, 14, 0, tzinfo=ZoneInfo("America/New_York"))
+    result = _format_time_with_tz(dt)
+    # Should end with a tz abbreviation (EDT or EST depending on date)
+    assert result.startswith("02:00 PM ")
+    assert not result.endswith(" ")  # no trailing space
+
+
+def test_format_time_with_tz_naive() -> None:
+    """Naive datetime must not produce a trailing space."""
+    dt = datetime(2024, 3, 20, 14, 0)  # noqa: DTZ001 — intentionally naive
+    result = _format_time_with_tz(dt)
+    assert result == "02:00 PM"
+    assert not result.endswith(" ")

--- a/calendar-cli/tests/test_reply.py
+++ b/calendar-cli/tests/test_reply.py
@@ -1,0 +1,432 @@
+"""Test cases for the vcal reply command."""
+
+import email.utils
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from calendar_cli.import_invite import import_to_local
+from calendar_cli.main import main
+from icalendar import Calendar
+
+from .helpers import (
+    EmailInvite,
+    ICSEvent,
+    make_email_invite,
+    make_ics,
+    parse_reply_email,
+)
+
+
+def _write_invite(tmp_path: Path, invite: EmailInvite) -> Path:
+    """Write an email invite file and return its path."""
+    path = tmp_path / f"{invite.uid}.ics"
+    path.write_text(make_email_invite(invite))
+    return path
+
+
+def test_reply_dry_run(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Test dry-run prints reply details without sending."""
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(uid="dry-run@example.com", summary="Dry Run Meeting"),
+    )
+
+    result = main(["reply", "accept", "--dry-run", str(invite)])
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "Would send reply to: organizer@example.com" in out
+    assert "Status: ACCEPTED" in out
+    assert "METHOD:REPLY" in out
+
+
+@patch("calendar_cli.reply.subprocess.run")
+def test_reply_send_via_email(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Test sending reply via msmtp produces valid email with ics attachment."""
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(
+            uid="email-test@example.com",
+            to="testuser@example.com",
+            summary="Email Reply Test",
+            organizer="mailto:organizer@example.com",
+        ),
+    )
+
+    result = main(["reply", "accept", str(invite)])
+    assert result == 0
+
+    mock_run.assert_called_once()
+    raw = mock_run.call_args[1]["input"]
+    msg, cal = parse_reply_email(raw)
+
+    # Email headers
+    _, from_addr = email.utils.parseaddr(msg["From"])
+    assert from_addr == "testuser@example.com"
+    _, to_addr = email.utils.parseaddr(msg["To"])
+    assert to_addr == "organizer@example.com"
+    assert "Accepted" in msg["Subject"]
+
+    # Calendar attachment
+    assert str(cal["METHOD"]) == "REPLY"
+    event = next(iter(cal.walk("VEVENT")))
+    assert str(event["UID"]) == "email-test@example.com"
+    attendees = event.get("ATTENDEE")
+    # Single attendee comes back as vCalAddress, not list
+    if isinstance(attendees, list):
+        partstat = attendees[0].params.get("PARTSTAT")
+    else:
+        partstat = attendees.params.get("PARTSTAT")
+    assert partstat == "ACCEPTED"
+
+
+def test_reply_with_comment(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Test reply includes COMMENT in the ics."""
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(uid="comment@example.com", summary="Comment Test"),
+    )
+
+    result = main(
+        [
+            "reply",
+            "tentative",
+            "--comment",
+            "I might be 10 minutes late",
+            "--dry-run",
+            str(invite),
+        ]
+    )
+
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "COMMENT:I might be 10 minutes late" in out
+    assert "Status: TENTATIVE" in out
+
+
+def test_reply_to_recurring_event(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test replying to a recurring event."""
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(
+            uid="recurring-reply@example.com",
+            summary="Weekly Standup",
+            to="dev@example.com",
+            organizer="mailto:scrum@example.com",
+            dtstart="20240320T090000Z",
+            dtend="20240320T100000Z",
+            extra="RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR",
+        ),
+    )
+
+    result = main(["reply", "accept", "--dry-run", str(invite)])
+    assert result == 0
+
+    out = capsys.readouterr().out
+    assert "Status: ACCEPTED" in out
+
+
+def test_reply_missing_organizer(tmp_path: Path) -> None:
+    """Test reply fails when organizer is missing."""
+    invite_content = """\
+From: sender@example.com
+To: attendee@example.com
+Subject: Meeting Invitation
+Content-Type: text/calendar
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:no-organizer@example.com
+DTSTART:20240320T140000Z
+DTEND:20240320T150000Z
+SUMMARY:No Organizer Meeting
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:attendee@example.com
+END:VEVENT
+END:VCALENDAR"""
+
+    invite = tmp_path / "no-org.ics"
+    invite.write_text(invite_content)
+
+    result = main(["reply", "accept", str(invite)])
+    assert result == 1
+
+
+def test_reply_invalid_ics_file(tmp_path: Path) -> None:
+    """Test reply fails on invalid ics."""
+    (tmp_path / "invalid.ics").write_text("This is not a valid ICS file")
+    result = main(["reply", "accept", str(tmp_path / "invalid.ics")])
+    assert result == 1
+
+
+def test_reply_missing_to_header(tmp_path: Path) -> None:
+    """Test reply fails when To header is missing (can't determine attendee email)."""
+    invite_content = """\
+From: sender@example.com
+Subject: Meeting Invitation
+Content-Type: text/calendar
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:no-to-header@example.com
+DTSTART:20240320T140000Z
+DTEND:20240320T150000Z
+SUMMARY:No To Header Meeting
+ORGANIZER:mailto:organizer@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:attendee@example.com
+END:VEVENT
+END:VCALENDAR"""
+
+    invite = tmp_path / "no-to.ics"
+    invite.write_text(invite_content)
+
+    result = main(["reply", "accept", str(invite)])
+    assert result == 1
+
+
+@patch("calendar_cli.reply.subprocess.run")
+def test_reply_msmtp_failure(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Test msmtp failure returns error but still builds valid email."""
+    mock_run.return_value = MagicMock(
+        returncode=1, stdout="", stderr="msmtp: connection failed"
+    )
+
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(
+            uid="msmtp-fail@example.com",
+            to="testuser@example.com",
+            summary="MSMTP Fail Test",
+        ),
+    )
+
+    result = main(["reply", "accept", str(invite)])
+    assert result == 1
+
+    raw = mock_run.call_args[1]["input"]
+    msg, cal = parse_reply_email(raw)
+
+    _, to_addr = email.utils.parseaddr(msg["To"])
+    assert to_addr == "organizer@example.com"
+    assert str(cal["METHOD"]) == "REPLY"
+    event = next(iter(cal.walk("VEVENT")))
+    assert str(event["UID"]) == "msmtp-fail@example.com"
+
+
+def test_reply_from_email_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test replying to calendar invite embedded in multipart email."""
+    email_content = """\
+From: sender@example.com
+To: recipient@example.com
+Subject: Meeting Invitation
+Content-Type: multipart/mixed; boundary="boundary"
+
+--boundary
+Content-Type: text/plain
+
+You're invited to a meeting.
+
+--boundary
+Content-Type: text/calendar; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:email-embedded@example.com
+DTSTART:20240320T140000Z
+DTEND:20240320T150000Z
+SUMMARY:Email Embedded Meeting
+ORGANIZER:mailto:organizer@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:recipient@example.com
+END:VEVENT
+END:VCALENDAR
+--boundary--"""
+
+    (tmp_path / "meeting.eml").write_text(email_content)
+
+    result = main(["reply", "accept", "--dry-run", str(tmp_path / "meeting.eml")])
+    assert result == 0
+
+    out = capsys.readouterr().out
+    assert "Would send reply to: organizer@example.com" in out
+    assert "Status: ACCEPTED" in out
+
+
+def test_reply_always_has_dtstamp(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Reply VEVENT always has DTSTAMP even if original lacks it (RFC 5545 §3.6.1)."""
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(
+            uid="no-dtstamp@example.com",
+            summary="No DTSTAMP Meeting",
+        ),
+    )
+
+    result = main(["reply", "accept", "--dry-run", str(invite)])
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "DTSTAMP" in out
+
+
+def test_reply_copies_recurrence_id(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Reply copies RECURRENCE-ID to target the right instance (RFC 6047 §3.2.3)."""
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(
+            uid="recurrence-reply@example.com",
+            summary="Rescheduled Instance",
+            dtstart="20240327T140000Z",
+            dtend="20240327T150000Z",
+            extra="RECURRENCE-ID:20240327T140000Z",
+        ),
+    )
+
+    result = main(["reply", "accept", "--dry-run", str(invite)])
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "RECURRENCE-ID" in out
+
+
+def test_reply_has_calscale(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Reply calendar includes CALSCALE:GREGORIAN."""
+    invite = _write_invite(
+        tmp_path,
+        EmailInvite(uid="calscale@example.com"),
+    )
+    result = main(["reply", "accept", "--dry-run", str(invite)])
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "CALSCALE:GREGORIAN" in out
+
+
+def test_reply_from_stdin(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test replying from stdin."""
+    invite = make_email_invite(
+        EmailInvite(
+            uid="stdin-reply@example.com",
+            summary="Stdin Reply Test",
+        )
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(invite))
+
+    result = main(["reply", "decline", "--dry-run"])
+    assert result == 0
+
+    out = capsys.readouterr().out
+    assert "Status: DECLINED" in out
+
+
+def test_reply_matches_uppercase_mailto(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """MAILTO: (uppercase) in ATTENDEE should be matched when creating a reply."""
+    invite_ics = """\
+From: sender@example.com
+To: attendee@example.com
+Subject: Meeting
+Content-Type: text/calendar
+
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:uppercase-mailto@example.com
+DTSTART:20240320T140000Z
+DTEND:20240320T150000Z
+SUMMARY:Uppercase MAILTO Test
+ORGANIZER:MAILTO:organizer@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:MAILTO:attendee@example.com
+END:VEVENT
+END:VCALENDAR"""
+
+    invite_file = tmp_path / "invite.eml"
+    invite_file.write_text(invite_ics)
+
+    result = main(["reply", "accept", "--dry-run", str(invite_file)])
+    assert result == 0
+
+    out = capsys.readouterr().out
+    assert "ACCEPTED" in out
+    # The reply should target the organizer
+    assert "organizer@example.com" in out
+
+
+@patch("calendar_cli.reply.subprocess.run")
+def test_reply_updates_local_partstat(mock_run: MagicMock, tmp_path: Path) -> None:
+    """After sending a reply, our PARTSTAT in the local store should be updated."""
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+    cal_dir = tmp_path / "calendars"
+
+    # First import the invite into the local store
+    invite_ics = make_ics(
+        ICSEvent(
+            uid="local-update@example.com",
+            summary="Local Update Test",
+            vcalendar_lines=["METHOD:REQUEST"],
+            vevent_lines=[
+                "ORGANIZER:mailto:organizer@example.com",
+                "ATTENDEE;CN=Me;PARTSTAT=NEEDS-ACTION:mailto:me@example.com",
+            ],
+        )
+    )
+    import_to_local(invite_ics.encode(), "personal", str(cal_dir))
+
+    # Write the email invite file (reply reads from this)
+    invite_email = make_email_invite(
+        EmailInvite(
+            uid="local-update@example.com",
+            to="me@example.com",
+            summary="Local Update Test",
+            organizer="mailto:organizer@example.com",
+        )
+    )
+    email_file = tmp_path / "invite.eml"
+    email_file.write_text(invite_email)
+
+    # Send accept reply — this should update the local store too
+    result = main(
+        [
+            "--calendar-dir",
+            str(cal_dir),
+            "--no-sync",
+            "reply",
+            "accept",
+            str(email_file),
+        ]
+    )
+    assert result == 0
+
+    # Verify local store was updated
+    ics_files = sorted((cal_dir / "personal").rglob("*.ics"))
+    assert len(ics_files) == 1
+    cal = Calendar.from_ical(ics_files[0].read_bytes())
+    event = next(iter(cal.walk("VEVENT")))
+    attendee = event.get("attendee")
+    # Single attendee comes back as vCalAddress, not list
+    att = attendee[0] if isinstance(attendee, list) else attendee
+    assert att.params["PARTSTAT"] == "ACCEPTED"

--- a/calendar-cli/tests/test_store.py
+++ b/calendar-cli/tests/test_store.py
@@ -1,0 +1,912 @@
+"""Tests for the calendar store (direct ics file manipulation)."""
+
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+from calendar_cli import store
+from calendar_cli.errors import CalendarNotFoundError, InvalidInputError
+from calendar_cli.timeutil import sanitize_timerange
+
+from .helpers import ICSEvent, make_ics, setup_single_calendar
+
+
+def test_discover_calendars(cal_dir: str) -> None:
+    names = store.discover_calendars(cal_dir)
+    assert "personal" in names
+    assert "work" in names
+
+
+def test_list_events_all(cal_dir: str) -> None:
+    events = store.list_events(calendars_dir=cal_dir)
+    assert len(events) == 4
+    # Sorted by start time
+    summaries = [e.summary for e in events]
+    assert "Dentist appointment" in summaries
+    assert "Sprint planning" in summaries
+
+
+def test_list_events_filter_calendar(cal_dir: str) -> None:
+    events = store.list_events(calendars_dir=cal_dir, calendar_filter="work")
+    assert len(events) == 1
+    assert events[0].summary == "Sprint planning"
+
+
+def test_list_events_date_range(cal_dir: str) -> None:
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 2),
+        to_date=date(2025, 4, 3),  # exclusive end
+    )
+    summaries = [e.summary for e in events]
+    # Sprint planning is on April 2, and the weekly standup (MO,WE,FR)
+    # has a Wednesday occurrence on April 2 too.
+    assert "Sprint planning" in summaries
+    assert "Weekly standup" in summaries
+    assert len(events) == 2
+
+
+def test_list_events_date_range_excludes(cal_dir: str) -> None:
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 10),
+        to_date=date(2025, 4, 20),
+    )
+    # The weekly standup (MO,WE,FR, COUNT=10, starting April 1) has
+    # occurrences on April 11 (Fri), 14 (Mon), 16 (Wed), 18 (Fri).
+    assert len(events) == 4
+    assert all(e.summary == "Weekly standup" for e in events)
+
+
+def test_get_event(cal_dir: str) -> None:
+    ev = store.get_event("event1-uid", cal_dir)
+    assert ev is not None
+    assert ev.summary == "Dentist appointment"
+    assert ev.location == "Dr. Smith"
+    assert ev.description == "Annual checkup"
+    assert ev.calendar == "personal"
+
+
+def test_get_event_not_found(cal_dir: str) -> None:
+    ev = store.get_event("nonexistent-uid", cal_dir)
+    assert ev is None
+
+
+def test_get_event_all_day(cal_dir: str) -> None:
+    ev = store.get_event("event2-uid", cal_dir)
+    assert ev is not None
+    assert ev.is_all_day
+    assert ev.summary == "Company Holiday"
+
+
+def test_get_event_recurring(cal_dir: str) -> None:
+    ev = store.get_event("event3-uid", cal_dir)
+    assert ev is not None
+    assert "FREQ=WEEKLY" in ev.rrule
+    assert len(ev.alarms) == 1
+
+
+def test_create_event(cal_dir: str) -> None:
+    tz = ZoneInfo("Europe/Berlin")
+    start = datetime(2025, 5, 1, 10, 0, tzinfo=tz)
+    end = datetime(2025, 5, 1, 11, 0, tzinfo=tz)
+
+    ev = store.create_event(
+        summary="New Meeting",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+        location="Room 42",
+        description="Discuss project",
+        alarm_minutes=[15, 60],
+    )
+
+    assert ev.summary == "New Meeting"
+    assert ev.location == "Room 42"
+    assert ev.filepath.exists()
+
+    # Verify it can be read back
+    ev2 = store.get_event(ev.uid, cal_dir)
+    assert ev2 is not None
+    assert ev2.summary == "New Meeting"
+    assert ev2.location == "Room 42"
+    assert ev2.description == "Discuss project"
+    assert len(ev2.alarms) == 2
+
+
+def test_create_event_unknown_calendar(cal_dir: str) -> None:
+    """Creating an event in a non-existent calendar raises CalendarNotFoundError."""
+    start = datetime(2025, 5, 1, 10, 0, tzinfo=UTC)
+    end = datetime(2025, 5, 1, 11, 0, tzinfo=UTC)
+
+    with pytest.raises(CalendarNotFoundError, match="does not exist"):
+        store.create_event(
+            summary="Test",
+            dtstart=start,
+            dtend=end,
+            calendar_name="nonexistent",
+            calendars_dir=cal_dir,
+        )
+
+
+def test_delete_event(cal_dir: str) -> None:
+    assert store.delete_event("event1-uid", cal_dir)
+    assert store.get_event("event1-uid", cal_dir) is None
+
+
+def test_delete_event_not_found(cal_dir: str) -> None:
+    assert not store.delete_event("nonexistent", cal_dir)
+
+
+def test_update_event_summary(cal_dir: str) -> None:
+    ev = store.update_event("event1-uid", cal_dir, summary="Updated title")
+    assert ev is not None
+    assert ev.summary == "Updated title"
+
+    # Other fields preserved
+    ev2 = store.get_event("event1-uid", cal_dir)
+    assert ev2 is not None
+    assert ev2.summary == "Updated title"
+    assert ev2.location == "Dr. Smith"
+
+
+def test_update_event_time(cal_dir: str) -> None:
+    new_start = datetime(2025, 4, 5, 14, 0, tzinfo=UTC)
+    new_end = datetime(2025, 4, 5, 15, 0, tzinfo=UTC)
+    ev = store.update_event("event1-uid", cal_dir, dtstart=new_start, dtend=new_end)
+    assert ev is not None
+    assert ev.dtstart == new_start
+    assert ev.dtend == new_end
+
+
+def test_update_event_not_found(cal_dir: str) -> None:
+    ev = store.update_event("nonexistent", cal_dir, summary="Nope")
+    assert ev is None
+
+
+def test_update_event_location(cal_dir: str) -> None:
+    ev = store.update_event("event1-uid", cal_dir, location="New Office")
+    assert ev is not None
+    assert ev.location == "New Office"
+    # Summary preserved
+    assert ev.summary == "Dentist appointment"
+
+
+def test_create_event_with_rrule(cal_dir: str) -> None:
+    start = datetime(2025, 5, 1, 9, 0, tzinfo=UTC)
+    end = datetime(2025, 5, 1, 9, 30, tzinfo=UTC)
+
+    ev = store.create_event(
+        summary="Daily sync",
+        dtstart=start,
+        dtend=end,
+        calendar_name="work",
+        calendars_dir=cal_dir,
+        rrule="FREQ=DAILY;COUNT=5",
+    )
+
+    ev2 = store.get_event(ev.uid, cal_dir)
+    assert ev2 is not None
+    assert "FREQ=DAILY" in ev2.rrule
+
+
+def test_empty_calendar_dir(tmp_path: Path) -> None:
+    events = store.list_events(calendars_dir=str(tmp_path))
+    assert events == []
+
+    names = store.discover_calendars(str(tmp_path))
+    assert names == []
+
+
+def test_nonexistent_calendar_dir(tmp_path: Path) -> None:
+    fake = str(tmp_path / "does-not-exist")
+    assert store.list_events(calendars_dir=fake) == []
+    assert store.discover_calendars(fake) == []
+    assert store.get_event("x", fake) is None
+    assert not store.delete_event("x", fake)
+
+
+def test_sanitize_timerange_equal() -> None:
+    """DTEND == DTSTART gets bumped to +1h."""
+    start = datetime(2025, 6, 1, 10, 0, tzinfo=UTC)
+    _, e = sanitize_timerange(start, start)
+    assert e == start + timedelta(hours=1)
+
+
+def test_sanitize_timerange_swapped() -> None:
+    """DTEND < DTSTART gets swapped."""
+    early = datetime(2025, 6, 1, 9, 0, tzinfo=UTC)
+    late = datetime(2025, 6, 1, 10, 0, tzinfo=UTC)
+    s, e = sanitize_timerange(late, early)
+    assert s == early
+    assert e == late
+
+
+def test_read_event_missing_dtend(tmp_path: Path) -> None:
+    """Events without DTEND get a synthesized end time."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="no-end@example.com",
+                summary="No End Time",
+                dtstart="20250601T100000Z",
+                dtend=None,
+            )
+        ),
+        filename="no-end.ics",
+    )
+
+    events = store.list_events(calendars_dir=cal_dir)
+    assert len(events) == 1
+    assert events[0].dtend == datetime(2025, 6, 1, 11, 0, tzinfo=UTC)
+
+
+def test_create_event_has_calscale_and_sequence(cal_dir: str) -> None:
+    """New events include CALSCALE:GREGORIAN and SEQUENCE:0 per RFC 5545."""
+    start = datetime(2025, 6, 1, 10, 0, tzinfo=UTC)
+    end = datetime(2025, 6, 1, 11, 0, tzinfo=UTC)
+    ev = store.create_event(
+        summary="RFC Test",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+    )
+    raw = ev.filepath.read_bytes().decode()
+    assert "CALSCALE:GREGORIAN" in raw
+    assert "SEQUENCE:0" in raw
+    assert "LAST-MODIFIED:" in raw
+
+
+def test_update_increments_sequence(cal_dir: str) -> None:
+    """Editing an event increments SEQUENCE (RFC 5545 §3.8.7.4)."""
+    start = datetime(2025, 6, 1, 10, 0, tzinfo=UTC)
+    end = datetime(2025, 6, 1, 11, 0, tzinfo=UTC)
+    ev = store.create_event(
+        summary="Seq Test",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+    )
+    raw0 = ev.filepath.read_bytes().decode()
+    assert "SEQUENCE:0" in raw0
+
+    store.update_event(ev.uid, cal_dir, summary="Seq Test v2")
+    raw1 = ev.filepath.read_bytes().decode()
+    assert "SEQUENCE:1" in raw1
+
+    store.update_event(ev.uid, cal_dir, summary="Seq Test v3")
+    raw2 = ev.filepath.read_bytes().decode()
+    assert "SEQUENCE:2" in raw2
+
+
+def test_update_preserves_all_day(cal_dir: str) -> None:
+    """Editing an all-day event preserves DATE type (not coerced to DATETIME)."""
+    start = date(2025, 12, 25)
+    end = date(2025, 12, 26)
+    ev = store.create_event(
+        summary="Holiday",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+    )
+    updated = store.update_event(ev.uid, cal_dir, summary="Christmas")
+    assert updated is not None
+    assert updated.is_all_day
+    assert isinstance(updated.dtstart, date)
+    assert not isinstance(updated.dtstart, datetime)
+
+
+def test_read_attendees_and_organizer(tmp_path: Path) -> None:
+    """Attendees, organizer, status, and URL are parsed from .ics files."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="meeting-with-people@example.com",
+                summary="Team Sync",
+                dtstart="20250601T140000Z",
+                dtend="20250601T150000Z",
+                vevent_lines=[
+                    "STATUS:CONFIRMED",
+                    "URL:https://meet.example.com/team",
+                    "ORGANIZER;CN=Alice:mailto:alice@example.com",
+                    "ATTENDEE;CN=Bob;PARTSTAT=ACCEPTED:mailto:bob@example.com",
+                    "ATTENDEE;CN=Carol;PARTSTAT=TENTATIVE:mailto:carol@example.com",
+                    "ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:dave@example.com",
+                ],
+            )
+        ),
+        filename="meeting.ics",
+    )
+
+    ev = store.get_event("meeting-with-people@example.com", cal_dir)
+    assert ev is not None
+    assert ev.status == "CONFIRMED"
+    assert ev.url == "https://meet.example.com/team"
+    assert ev.organizer == "Alice (alice@example.com)"
+    assert len(ev.attendees) == 3
+    assert ev.attendees[0].name == "Bob"
+    assert ev.attendees[0].email == "bob@example.com"
+    assert ev.attendees[0].status == "ACCEPTED"
+    assert str(ev.attendees[0]) == "Bob (accepted)"
+    assert str(ev.attendees[1]) == "Carol (tentative)"
+    assert str(ev.attendees[2]) == "dave@example.com"  # no name, needs-action
+
+
+def test_sanitize_timerange_mixed_date_datetime(tmp_path: Path) -> None:
+    """Malformed ICS with DATE dtstart and DATETIME dtend must not crash."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="mixed-types@example.com",
+                summary="Mixed Types",
+                dtstart=";VALUE=DATE:20250401",
+                dtend="20250401T170000Z",
+            )
+        ),
+        filename="mixed.ics",
+    )
+
+    events = store.list_events(calendars_dir=cal_dir)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.summary == "Mixed Types"
+    # The coerced types should be comparable without TypeError
+    assert ev.dtend is not None
+    assert ev.dtend >= ev.dtstart
+
+
+def test_sanitize_timerange_mixed_datetime_date() -> None:
+    """datetime DTSTART + date DTEND should not crash."""
+    dtstart = datetime(2025, 4, 1, 10, 0, tzinfo=UTC)
+    dtend_date = date(2025, 4, 2)
+    # Must not raise TypeError
+    s, e = sanitize_timerange(dtstart, dtend_date)
+    assert isinstance(s, datetime)
+    assert isinstance(e, datetime)
+
+
+def test_sanitize_timerange_mixed_date_datetime_swapped() -> None:
+    """Mixed types with DTEND < DTSTART should be swapped, not crash."""
+    dtstart_date = date(2025, 4, 5)
+    dtend = datetime(2025, 4, 1, 10, 0, tzinfo=UTC)
+    s, e = sanitize_timerange(dtstart_date, dtend)
+    # After coercion and swap, start <= end
+    assert s <= e
+
+
+def test_rrule_expansion_in_date_range(tmp_path: Path) -> None:
+    """Recurring events should appear for each occurrence within the date range."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="weekly@example.com",
+                summary="Weekly Standup",
+                dtstart="20250401T090000Z",
+                dtend="20250401T100000Z",
+                vevent_lines=["RRULE:FREQ=WEEKLY;COUNT=5"],
+            )
+        ),
+        filename="weekly.ics",
+    )
+
+    # Ask for the second week only — should see one occurrence on April 8
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 7),
+        to_date=date(2025, 4, 9),
+    )
+    assert len(events) == 1
+    assert events[0].summary == "Weekly Standup"
+    assert isinstance(events[0].dtstart, datetime)
+    assert events[0].dtstart.date() == date(2025, 4, 8)
+
+
+def test_rrule_expansion_with_exdate(tmp_path: Path) -> None:
+    """EXDATE exclusions should suppress the matching occurrence."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="exdate@example.com",
+                summary="Weekly with skip",
+                dtstart="20250401T090000Z",
+                dtend="20250401T100000Z",
+                vevent_lines=[
+                    "RRULE:FREQ=WEEKLY;COUNT=5",
+                    "EXDATE:20250408T090000Z",
+                ],
+            )
+        ),
+        filename="weekly-exdate.ics",
+    )
+
+    # April 7-16: should see April 15 only (April 8 excluded)
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 7),
+        to_date=date(2025, 4, 16),
+    )
+    assert len(events) == 1
+    assert events[0].dtstart.date() == date(2025, 4, 15)  # type: ignore[union-attr]
+
+
+def test_rrule_expansion_recurrence_id_override(tmp_path: Path) -> None:
+    """A VEVENT with RECURRENCE-ID overrides the matching RRULE occurrence."""
+    override_vevent = (
+        "BEGIN:VEVENT\n"
+        "UID:override@example.com\n"
+        "RECURRENCE-ID:20250408T090000Z\n"
+        "DTSTART:20250408T100000Z\n"
+        "DTEND:20250408T110000Z\n"
+        "SUMMARY:Weekly Meeting (rescheduled)\n"
+        "END:VEVENT"
+    )
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="override@example.com",
+                summary="Weekly Meeting",
+                dtstart="20250401T090000Z",
+                dtend="20250401T100000Z",
+                vevent_lines=["RRULE:FREQ=WEEKLY;COUNT=5"],
+                extra_components=override_vevent,
+            )
+        ),
+        filename="weekly-override.ics",
+    )
+
+    # April 7-9: should see the rescheduled version
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 7),
+        to_date=date(2025, 4, 9),
+    )
+    assert len(events) == 1
+    assert events[0].summary == "Weekly Meeting (rescheduled)"
+    assert events[0].dtstart.hour == 10  # type: ignore[union-attr]
+
+
+def test_rrule_all_day_expansion(tmp_path: Path) -> None:
+    """All-day recurring events should also be expanded."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="allday-recur@example.com",
+                summary="Monthly Review",
+                dtstart=";VALUE=DATE:20250101",
+                dtend=";VALUE=DATE:20250102",
+                vevent_lines=["RRULE:FREQ=MONTHLY;COUNT=12"],
+            )
+        ),
+        filename="monthly-allday.ics",
+    )
+
+    # March: should see one occurrence
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 3, 1),
+        to_date=date(2025, 3, 31),
+    )
+    assert len(events) == 1
+    assert events[0].summary == "Monthly Review"
+    assert events[0].dtstart == date(2025, 3, 1)
+
+
+def test_sanitize_timerange_negative_duration() -> None:
+    """Negative DURATION should not produce dtend < dtstart."""
+    dtstart = datetime(2025, 4, 1, 10, 0, tzinfo=UTC)
+    s, e = sanitize_timerange(dtstart, None, duration=timedelta(minutes=-30))
+    assert e >= s
+
+
+def test_read_event_negative_duration(tmp_path: Path) -> None:
+    """Events with negative DURATION should get a corrected time range."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        "BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\n"
+        "UID:neg-dur@example.com\n"
+        "DTSTART:20250401T100000Z\n"
+        "DURATION:-PT30M\n"
+        "SUMMARY:Negative Duration\n"
+        "END:VEVENT\nEND:VCALENDAR",
+        filename="neg-dur.ics",
+    )
+
+    events = store.list_events(calendars_dir=cal_dir)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.dtend is not None
+    assert ev.dtend >= ev.dtstart
+
+
+# ---------------------------------------------------------------------------
+# Issue #4: update_event preserves properties
+# ---------------------------------------------------------------------------
+
+
+def test_update_preserves_attendees_and_organizer(tmp_path: Path) -> None:
+    """Editing summary must not destroy ORGANIZER, ATTENDEE, STATUS, or URL."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="preserve-test@example.com",
+                summary="Original Title",
+                dtstart="20250601T140000Z",
+                dtend="20250601T150000Z",
+                vevent_lines=[
+                    "STATUS:CONFIRMED",
+                    "URL:https://meet.example.com/team",
+                    "ORGANIZER;CN=Alice:mailto:alice@example.com",
+                    "ATTENDEE;CN=Bob;PARTSTAT=ACCEPTED:mailto:bob@example.com",
+                    "ATTENDEE;CN=Carol;PARTSTAT=TENTATIVE:mailto:carol@example.com",
+                    "SEQUENCE:0",
+                ],
+            )
+        ),
+        filename="meeting.ics",
+    )
+
+    ev = store.update_event(
+        "preserve-test@example.com", cal_dir, summary="Renamed Meeting"
+    )
+    assert ev is not None
+    assert ev.summary == "Renamed Meeting"
+    assert ev.status == "CONFIRMED"
+    assert ev.url == "https://meet.example.com/team"
+    assert ev.organizer == "Alice (alice@example.com)"
+    assert len(ev.attendees) == 2
+    assert ev.attendees[0].name == "Bob"
+    assert ev.attendees[0].status == "ACCEPTED"
+
+    # Verify SEQUENCE was incremented
+    raw = ev.filepath.read_bytes().decode()
+    assert "SEQUENCE:1" in raw
+
+
+# ---------------------------------------------------------------------------
+# Issue #6: Multi-day events visible when querying middle days
+# ---------------------------------------------------------------------------
+
+
+def test_multiday_event_visible_on_middle_day(tmp_path: Path) -> None:
+    """A 3-day event starting April 1 should appear when querying April 2."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="conference@example.com",
+                summary="3-Day Conference",
+                dtstart="20250401T090000Z",
+                dtend="20250403T170000Z",
+            )
+        ),
+        filename="conference.ics",
+    )
+
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 2),
+        to_date=date(2025, 4, 3),
+    )
+    assert len(events) == 1
+    assert events[0].summary == "3-Day Conference"
+
+
+def test_multiday_allday_event_visible_on_middle_day(tmp_path: Path) -> None:
+    """A multi-day all-day event should appear on all days it spans."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="vacation@example.com",
+                summary="Vacation",
+                dtstart=";VALUE=DATE:20250401",
+                dtend=";VALUE=DATE:20250404",
+            )
+        ),
+        filename="vacation.ics",
+    )
+
+    # Query only April 2-3 — vacation spans April 1-3 (DTEND exclusive)
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 2),
+        to_date=date(2025, 4, 3),
+    )
+    assert len(events) == 1
+    assert events[0].summary == "Vacation"
+
+
+def test_event_ending_before_range_not_shown(tmp_path: Path) -> None:
+    """An event ending before the query range should not appear."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="past@example.com",
+                summary="Past Event",
+                dtstart="20250401T090000Z",
+                dtend="20250401T100000Z",
+            )
+        ),
+        filename="past.ics",
+    )
+
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 2),
+        to_date=date(2025, 4, 3),
+    )
+    assert len(events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #2: RDATE support
+# ---------------------------------------------------------------------------
+
+
+def test_rrule_expansion_with_rdate(tmp_path: Path) -> None:
+    """RDATE adds extra occurrences beyond the RRULE pattern."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="rdate@example.com",
+                summary="With RDATE",
+                dtstart="20250401T090000Z",
+                dtend="20250401T100000Z",
+                vevent_lines=[
+                    "RRULE:FREQ=WEEKLY;COUNT=2",
+                    "RDATE:20250410T090000Z",
+                ],
+            )
+        ),
+        filename="rdate.ics",
+    )
+
+    # RRULE gives April 1 and 8; RDATE adds April 10
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 1),
+        to_date=date(2025, 4, 11),
+    )
+    assert len(events) == 3
+    dates = [e.dtstart.date() for e in events]  # type: ignore[union-attr]
+    assert date(2025, 4, 1) in dates
+    assert date(2025, 4, 8) in dates
+    assert date(2025, 4, 10) in dates
+
+
+# ---------------------------------------------------------------------------
+# Issue #8: Absolute alarm triggers
+# ---------------------------------------------------------------------------
+
+
+def test_absolute_alarm_trigger(tmp_path: Path) -> None:
+    """Absolute TRIGGER (VALUE=DATE-TIME) should not crash."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="abs-alarm@example.com",
+                summary="Absolute Alarm",
+                dtstart="20250401T140000Z",
+                dtend="20250401T150000Z",
+                vevent_lines=[
+                    "BEGIN:VALARM",
+                    "TRIGGER;VALUE=DATE-TIME:20250401T133000Z",
+                    "ACTION:DISPLAY",
+                    "DESCRIPTION:Reminder",
+                    "END:VALARM",
+                ],
+            )
+        ),
+        filename="abs-alarm.ics",
+    )
+
+    events = store.list_events(calendars_dir=cal_dir)
+    assert len(events) == 1
+    ev = events[0]
+    # 14:00 - 13:30 = 30 minutes before
+    assert ev.alarm_minutes == [30]
+    assert ev.alarms == ["30m before"]
+
+
+def test_alarm_related_end_absolute(tmp_path: Path) -> None:
+    """Absolute TRIGGER with RELATED=END computes offset from DTEND."""
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="rel-end-abs@example.com",
+                summary="Related End Abs",
+                dtstart="20250401T140000Z",
+                dtend="20250401T150000Z",
+                vevent_lines=[
+                    "BEGIN:VALARM",
+                    "TRIGGER;VALUE=DATE-TIME;RELATED=END:20250401T144500Z",
+                    "ACTION:DISPLAY",
+                    "DESCRIPTION:Reminder",
+                    "END:VALARM",
+                ],
+            )
+        ),
+        filename="rel-end-abs.ics",
+    )
+
+    events = store.list_events(calendars_dir=cal_dir)
+    assert len(events) == 1
+    ev = events[0]
+    # 15:00 (DTEND) - 14:45 (trigger) = 15 minutes before end
+    assert ev.alarm_minutes == [15]
+
+
+# ---------------------------------------------------------------------------
+# Issue #1: VTIMEZONE in created events
+# ---------------------------------------------------------------------------
+
+
+def test_create_event_includes_vtimezone(cal_dir: str) -> None:
+    """Events with non-UTC timezones should include a VTIMEZONE component."""
+    tz = ZoneInfo("Europe/Berlin")
+    start = datetime(2025, 5, 1, 10, 0, tzinfo=tz)
+    end = datetime(2025, 5, 1, 11, 0, tzinfo=tz)
+
+    ev = store.create_event(
+        summary="TZ Test",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+    )
+
+    raw = ev.filepath.read_bytes().decode()
+    assert "BEGIN:VTIMEZONE" in raw
+    assert "Europe/Berlin" in raw
+
+
+def test_create_event_utc_no_vtimezone(cal_dir: str) -> None:
+    """UTC events should not include a VTIMEZONE (UTC needs no definition)."""
+    start = datetime(2025, 5, 1, 10, 0, tzinfo=UTC)
+    end = datetime(2025, 5, 1, 11, 0, tzinfo=UTC)
+
+    ev = store.create_event(
+        summary="UTC Test",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+    )
+
+    raw = ev.filepath.read_bytes().decode()
+    assert "BEGIN:VTIMEZONE" not in raw
+
+
+# ---------------------------------------------------------------------------
+# Issue #9: CREATED property
+# ---------------------------------------------------------------------------
+
+
+def test_create_event_has_created(cal_dir: str) -> None:
+    """New events include CREATED per RFC 5545 §3.8.7.1."""
+    start = datetime(2025, 6, 1, 10, 0, tzinfo=UTC)
+    end = datetime(2025, 6, 1, 11, 0, tzinfo=UTC)
+    ev = store.create_event(
+        summary="Created Test",
+        dtstart=start,
+        dtend=end,
+        calendar_name="personal",
+        calendars_dir=cal_dir,
+    )
+    raw = ev.filepath.read_bytes().decode()
+    assert "CREATED:" in raw
+
+
+# ---------------------------------------------------------------------------
+# Issue #3: RECURRENCE-ID matched by exact datetime
+# ---------------------------------------------------------------------------
+
+
+def test_recurrence_id_exact_datetime_match(tmp_path: Path) -> None:
+    """RECURRENCE-ID overrides should match by exact datetime, not just date."""
+    override_vevent = (
+        "BEGIN:VEVENT\n"
+        "UID:twice-daily@example.com\n"
+        "RECURRENCE-ID:20250401T150000Z\n"
+        "DTSTART:20250401T160000Z\n"
+        "DTEND:20250401T170000Z\n"
+        "SUMMARY:Twice Daily (moved)\n"
+        "END:VEVENT"
+    )
+    cal_dir = setup_single_calendar(
+        tmp_path,
+        make_ics(
+            ICSEvent(
+                uid="twice-daily@example.com",
+                summary="Twice Daily",
+                dtstart="20250401T090000Z",
+                dtend="20250401T100000Z",
+                vevent_lines=["RRULE:FREQ=DAILY;BYHOUR=9,15;COUNT=4"],
+                extra_components=override_vevent,
+            )
+        ),
+        filename="twice-daily.ics",
+    )
+
+    events = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2025, 4, 1),
+        to_date=date(2025, 4, 2),
+    )
+    summaries = [e.summary for e in events]
+    # The 09:00 occurrence should still be present
+    assert "Twice Daily" in summaries
+    # The 15:00 occurrence should be replaced
+    assert "Twice Daily (moved)" in summaries
+
+
+# ---------------------------------------------------------------------------
+# search_events
+# ---------------------------------------------------------------------------
+
+
+def test_search_events_matches_summary_location_description(cal_dir: str) -> None:
+    """search_events matches across summary, location, and description."""
+    # Match by summary (case-insensitive)
+    assert len(store.search_events("dentist", calendars_dir=cal_dir)) == 1
+    # Match by description
+    assert len(store.search_events("annual", calendars_dir=cal_dir)) == 1
+    # No match
+    assert store.search_events("xyznonexistent", calendars_dir=cal_dir) == []
+
+
+def test_search_events_calendar_filter(cal_dir: str) -> None:
+    """search_events respects calendar_filter."""
+    assert (
+        len(
+            store.search_events(
+                "planning", calendars_dir=cal_dir, calendar_filter="work"
+            )
+        )
+        == 1
+    )
+    assert (
+        store.search_events(
+            "planning", calendars_dir=cal_dir, calendar_filter="personal"
+        )
+        == []
+    )
+
+
+def test_search_events_deduplicates_recurring(cal_dir: str) -> None:
+    """Recurring events appear once in search results, not per occurrence."""
+    results = store.search_events("standup", calendars_dir=cal_dir)
+    assert len(results) == 1
+    assert results[0].uid == "event3-uid"
+
+
+def test_search_events_regex(cal_dir: str) -> None:
+    """search_events supports regex patterns."""
+    # Alternation: match either dentist or sprint
+    results = store.search_events("dentist|sprint", calendars_dir=cal_dir)
+    summaries = {e.summary for e in results}
+    assert "Dentist appointment" in summaries
+    assert "Sprint planning" in summaries
+
+
+def test_search_events_invalid_regex(cal_dir: str) -> None:
+    """Invalid regex raises InvalidInputError."""
+    with pytest.raises(InvalidInputError):
+        store.search_events("[invalid", calendars_dir=cal_dir)

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,9 @@
           packages = {
             browser-cli = pkgs.python3.pkgs.callPackage ./browser-cli { };
             browser-cli-extension = (pkgs.callPackages ./firefox-extensions { }).browser-cli-extension;
+            calendar-cli = pkgs.callPackage ./calendar-cli {
+              inherit (pkgs) python3 vdirsyncer msmtp;
+            };
             context7-cli = pkgs.python3.pkgs.callPackage ./context7-cli { };
             db-cli = pkgs.callPackage ./db-cli { };
             gmaps-cli = pkgs.python3.pkgs.callPackage ./gmaps-cli { };
@@ -66,6 +69,12 @@
 
             programs.mypy.enable = true;
             programs.mypy.directories = {
+              "calendar-cli" = {
+                extraPythonPackages = with pkgs.python3.pkgs; [
+                  icalendar
+                  pytest
+                ];
+              };
               "pexpect-cli" = {
                 extraPythonPackages = with pkgs.python3.pkgs; [
                   pexpect

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -9,6 +9,7 @@ let
   # Each skill maps to a package name and a skills/ subdirectory.
   allSkills = [
     "browser-cli"
+    "calendar-cli"
     "context7-cli"
     "db-cli"
     "gmaps-cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,13 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "pytest.*"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "icalendar.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "dateutil.*"
+ignore_missing_imports = true
+follow_imports = "skip"
+

--- a/skills/calendar-cli/EMAIL_INVITES.md
+++ b/skills/calendar-cli/EMAIL_INVITES.md
@@ -1,0 +1,29 @@
+# Email Invites, Import & RSVP
+
+Requires `msmtp`. Set organizer in `~/.config/vcal/config.toml`:
+
+```toml
+[user]
+email = "user@example.com"
+name = "User Name"
+```
+
+```bash
+# Send invite
+calendar-cli invite -s "Review" --start "2025-04-01 14:00" --timezone Europe/Berlin \
+  -d 90 -a "john@example.com,Jane <jane@example.com>" --organizer-email "me@example.com"
+
+# Export email to file instead of sending (or - for stdout)
+calendar-cli invite ... --output-email invite.eml
+calendar-cli invite ... --output-ics meeting.ics
+
+# Import — handles all incoming calendar emails:
+#   new invites, attendee responses, and cancellations
+calendar-cli import meeting.ics
+cat email.eml | calendar-cli import
+
+# RSVP (respond to invites you received)
+cat email.eml | calendar-cli reply accept
+cat email.eml | calendar-cli reply decline -c "Sorry, conflict"
+cat email.eml | calendar-cli reply tentative
+```

--- a/skills/calendar-cli/SKILL.md
+++ b/skills/calendar-cli/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: calendar-cli
+description: Manage calendar events and send meeting invitations. Use for listing, creating, editing, deleting events and sending/replying to invites.
+---
+
+# Usage
+
+- Always pass an Olson timezone (`Europe/Berlin`, `America/New_York`) when
+  creating or editing events. Ask the user if unclear.
+- Run `calendar-cli calendars` first to discover available calendar names.
+  Calendar names are resolved case-insensitively.
+- `list` shows at most 50 events by default and truncates descriptions.
+  Use `show <uid>` to get full details of a specific event.
+
+```bash
+calendar-cli calendars
+calendar-cli list                                     # today + 7 days
+calendar-cli list --from 2025-04-01 --to 2025-04-07 -v
+calendar-cli list --days 30 --limit 100               # more events
+calendar-cli search "dentist"                          # find by text
+calendar-cli search "sprint|retro" -c work -v          # regex, one calendar
+calendar-cli show <uid>                                # full details
+
+calendar-cli new "Meeting" --start "2025-04-01 14:00" --timezone Europe/Berlin -d 60 -c personal
+calendar-cli new "Standup" --start "2025-04-01 09:00" --timezone America/New_York \
+  -d 15 --rrule "FREQ=WEEKLY;BYDAY=MO,WE,FR" --alarm 15m
+
+calendar-cli edit <uid> --summary "New Title"
+calendar-cli edit <uid> --start "2025-04-02 10:00" --timezone Europe/Berlin
+calendar-cli delete <uid>
+```
+
+For email invites, import and RSVP see [EMAIL_INVITES.md](./EMAIL_INVITES.md).


### PR DESCRIPTION
khal's interactive TUI and complex output formatting make it difficult to use programmatically. Instead, read and write .ics files directly in the vdirsyncer filesystem store using the icalendar library.

The new calendar-cli combines the local calendar management (list, show, new, edit, delete, calendars) with the existing vcal email functionality (invite, import, reply), removing the khal dependency from the import path.

Timezone is mandatory for event creation and editing rather than relying on fragile local timezone detection — the caller should always know the relevant timezone from context.

The invite subcommand gains --output-email to write the full MIME email to a file instead of sending via msmtp, which makes the email output testable without subprocess mocks.