### PR TITLE
calendar-cli: add type stubs for icalendar and python-dateutil

### DIFF
--- a/calendar-cli/calendar_cli/import_invite.py
+++ b/calendar-cli/calendar_cli/import_invite.py
@@ -8,7 +8,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from icalendar import Calendar, Event
+from icalendar import Calendar, Component
 
 from .store import atomic_write, generate_uid, uid_to_filename
 from .timeutil import normalize_windows_tzid
@@ -33,7 +33,7 @@ class ImportConfig:
 extract_calendar_from_email = extract_calendar_parts_from_email
 
 
-def _collect_tzids(events: list[Event]) -> set[str]:
+def _collect_tzids(events: list[Component]) -> set[str]:
     """Return TZID strings referenced by date properties in events."""
     tzids: set[str] = set()
     for event in events:
@@ -47,8 +47,8 @@ def _collect_tzids(events: list[Event]) -> set[str]:
 
 
 def _build_per_uid_calendar(
-    events: list[Event],
-    timezones: dict[str, object],
+    events: list[Component],
+    timezones: dict[str, Component],
 ) -> bytes:
     """Build a VCALENDAR containing all events for one UID plus their timezones."""
     out_cal = new_calendar()
@@ -85,7 +85,7 @@ def _find_existing_ics(uid: str, calendars_dir: str) -> Path | None:
             # Fallback: parse each file to extract UID properly
             for ics_file in ics_dir.glob("*.ics"):
                 try:
-                    cal = Calendar.from_ical(ics_file.read_bytes())
+                    cal = Calendar.from_ical(ics_file.read_text())
                     for component in cal.walk():
                         if (
                             component.name == "VEVENT"
@@ -98,7 +98,7 @@ def _find_existing_ics(uid: str, calendars_dir: str) -> Path | None:
 
 
 def _handle_cancel(
-    events_by_uid: dict[str, list[Event]],
+    events_by_uid: dict[str, list[Component]],
     calendars_dir: str,
 ) -> int:
     """Handle METHOD:CANCEL — delete or mark matching events as CANCELLED.
@@ -122,7 +122,7 @@ def _handle_cancel(
 
 
 def _extract_reply_statuses(
-    reply_events: list[Event],
+    reply_events: list[Component],
 ) -> list[tuple[str, str]]:
     """Extract (email, new_partstat) pairs from REPLY VEVENTs."""
     result: list[tuple[str, str]] = []
@@ -135,7 +135,7 @@ def _extract_reply_statuses(
 
 
 def _apply_partstat_updates(
-    cal: Calendar,
+    cal: Component,
     updates: list[tuple[str, str]],
     uid: str,
 ) -> int:
@@ -155,7 +155,7 @@ def _apply_partstat_updates(
 
 
 def _handle_reply(
-    events_by_uid: dict[str, list[Event]],
+    events_by_uid: dict[str, list[Component]],
     calendars_dir: str,
 ) -> int:
     """Handle METHOD:REPLY — update PARTSTAT for the replying attendee.
@@ -170,7 +170,7 @@ def _handle_reply(
             continue
 
         try:
-            cal = Calendar.from_ical(existing.read_bytes())
+            cal = Calendar.from_ical(existing.read_text())
         except (ValueError, OSError):
             continue
 
@@ -182,11 +182,11 @@ def _handle_reply(
 
 
 def _collect_components(
-    cal: Calendar,
-) -> tuple[dict[str, object], dict[str, list[Event]]]:
+    cal: Component,
+) -> tuple[dict[str, Component], dict[str, list[Component]]]:
     """Collect VTIMEZONEs and group VEVENTs by UID from a parsed calendar."""
-    timezones: dict[str, object] = {}
-    events_by_uid: dict[str, list[Event]] = {}
+    timezones: dict[str, Component] = {}
+    events_by_uid: dict[str, list[Component]] = {}
     for component in cal.walk():
         if component.name == "VTIMEZONE":
             raw_tzid = component.get("TZID")
@@ -243,8 +243,8 @@ def import_to_local(
     - Writes are atomic (tempfile + rename)
     """
     try:
-        cal = Calendar.from_ical(calendar_data)
-    except (ValueError, TypeError) as e:
+        cal = Calendar.from_ical(calendar_data.decode())
+    except (ValueError, TypeError, UnicodeDecodeError) as e:
         print(f"Error parsing calendar data: {e}", file=sys.stderr)
         return False
 
@@ -322,8 +322,8 @@ def process_input(file_path: str | None) -> list[bytes]:
 def _calendar_has_rsvp(cal_data: bytes) -> bool:
     """Check if calendar data contains RSVP requests by parsing the iCalendar structure."""
     try:
-        cal = Calendar.from_ical(cal_data)
-    except (ValueError, TypeError):
+        cal = Calendar.from_ical(cal_data.decode())
+    except (ValueError, TypeError, UnicodeDecodeError):
         return False
     for component in cal.walk():
         if component.name != "VEVENT":

--- a/calendar-cli/calendar_cli/parse.py
+++ b/calendar-cli/calendar_cli/parse.py
@@ -6,7 +6,7 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from icalendar import Calendar, Event
+from icalendar import Calendar, Component
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -18,7 +18,7 @@ from .util import get_attendee_list, strip_mailto
 log = logging.getLogger(__name__)
 
 
-def _parse_rrule(event: Event) -> str:
+def _parse_rrule(event: Component) -> str:
     rrule = event.get("rrule")
     if rrule is None:
         return ""
@@ -26,7 +26,7 @@ def _parse_rrule(event: Event) -> str:
     return result
 
 
-def _parse_alarm_minutes(event: Event) -> list[int]:
+def _parse_alarm_minutes(event: Component) -> list[int]:
     """Extract alarm triggers as positive minutes-before values.
 
     Handles three trigger forms per RFC 5545 §3.8.6.3:
@@ -78,7 +78,7 @@ def _dt_value(val: object) -> datetime | date | None:
     return None
 
 
-def _parse_organizer(component: Event) -> str:
+def _parse_organizer(component: Component) -> str:
     """Extract organizer as 'Name (email)' or just email."""
     org = component.get("organizer")
     if org is None:
@@ -90,7 +90,7 @@ def _parse_organizer(component: Event) -> str:
     return addr
 
 
-def _parse_date_list(component: Event, prop_name: str) -> list[datetime | date]:
+def _parse_date_list(component: Component, prop_name: str) -> list[datetime | date]:
     """Extract a list of date/datetime values from a multi-value property.
 
     Works for both EXDATE and RDATE which share the same vDDDLists
@@ -109,17 +109,17 @@ def _parse_date_list(component: Event, prop_name: str) -> list[datetime | date]:
     return result
 
 
-def _parse_exdates(component: Event) -> list[datetime | date]:
+def _parse_exdates(component: Component) -> list[datetime | date]:
     """Extract EXDATE values from a VEVENT component."""
     return _parse_date_list(component, "exdate")
 
 
-def _parse_rdates(component: Event) -> list[datetime | date]:
+def _parse_rdates(component: Component) -> list[datetime | date]:
     """Extract RDATE values from a VEVENT component (RFC 5545 §3.8.5.2)."""
     return _parse_date_list(component, "rdate")
 
 
-def _parse_attendees(component: Event) -> list[Attendee]:
+def _parse_attendees(component: Component) -> list[Attendee]:
     """Extract attendees with name, email, and PARTSTAT."""
     attendees: list[Attendee] = []
     for addr in get_attendee_list(component):
@@ -134,7 +134,7 @@ def read_event_file(path: Path, calendar_name: str) -> list[CalendarEvent]:
     """Parse a single .ics file and return CalendarEvent(s)."""
     events: list[CalendarEvent] = []
     try:
-        data = path.read_bytes()
+        data = path.read_text()
         cal = Calendar.from_ical(data)
     except (ValueError, OSError):
         return events

--- a/calendar-cli/calendar_cli/reply.py
+++ b/calendar-cli/calendar_cli/reply.py
@@ -12,7 +12,7 @@ from email.mime.text import MIMEText
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from icalendar import Calendar, Event, vCalAddress, vText
+from icalendar import Calendar, Component, Event, vCalAddress, vText
 
 from .config import resolve_user_name
 from .errors import InvalidInputError, ParseError, SendError
@@ -54,10 +54,10 @@ def extract_calendar_from_email(
     parts = extract_calendar_parts_from_email(content_bytes)
     for part_data in parts:
         try:
-            cal = Calendar.from_ical(part_data)
+            cal = Calendar.from_ical(part_data.decode())
             if isinstance(cal, Calendar):
                 return cal, to_email
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, UnicodeDecodeError):
             continue
 
     # Fallback: try to parse the raw content as ICS directly
@@ -200,7 +200,7 @@ def send_reply(
     return True
 
 
-def _set_attendee_partstat(cal: Calendar, user_email: str, ical_status: str) -> bool:
+def _set_attendee_partstat(cal: Component, user_email: str, ical_status: str) -> bool:
     """Set PARTSTAT for *user_email* in all VEVENTs of *cal*. Returns True if changed."""
     changed = False
     lower_email = user_email.lower()
@@ -245,7 +245,7 @@ def _update_local_partstat(
             continue
 
         try:
-            cal = Calendar.from_ical(existing.read_bytes())
+            cal = Calendar.from_ical(existing.read_text())
         except (ValueError, OSError):
             continue
 

--- a/calendar-cli/calendar_cli/store.py
+++ b/calendar-cli/calendar_cli/store.py
@@ -19,8 +19,8 @@ from datetime import UTC, date, datetime, timedelta
 from hashlib import sha1
 from pathlib import Path
 
-from dateutil.rrule import rruleset, rrulestr
-from icalendar import Alarm, Calendar, Event
+from dateutil.rrule import rrule, rruleset, rrulestr
+from icalendar import Alarm, Calendar, Component, Event
 
 from .errors import CalendarNotFoundError, InvalidInputError
 from .models import CalendarEvent
@@ -164,7 +164,11 @@ def _make_rrule_set(ev: CalendarEvent) -> rruleset:
     dtstart = ev.dtstart
     naive_start = _to_naive(dtstart)
 
-    rset.rrule(rrulestr(ev.rrule, dtstart=naive_start))
+    parsed = rrulestr(ev.rrule, dtstart=naive_start)
+    if not isinstance(parsed, rrule):
+        msg = f"Expected single rrule, got {type(parsed).__name__}"
+        raise TypeError(msg)
+    rset.rrule(parsed)
 
     for exdt in ev.exdates:
         rset.exdate(_to_naive(exdt))
@@ -596,7 +600,7 @@ def _patch_vevent(  # noqa: PLR0913, C901
     would be lost by a full rebuild.
     """
     try:
-        data = filepath.read_bytes()
+        data = filepath.read_text()
     except OSError as e:
         msg = f"Failed to read {filepath}: {e}"
         raise CalendarNotFoundError(msg) from e
@@ -655,7 +659,7 @@ def _patch_vevent(  # noqa: PLR0913, C901
     return result
 
 
-def _patch_prop(component: Event, name: str, value: object) -> None:
+def _patch_prop(component: Component, name: str, value: object) -> None:
     """Set a property on a VEVENT, replacing any existing value."""
     if value is None:
         return

--- a/calendar-cli/calendar_cli/util.py
+++ b/calendar-cli/calendar_cli/util.py
@@ -7,10 +7,10 @@ import email.utils
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING, Any
 
-from icalendar import Calendar, Timezone
+from icalendar import Calendar, Component, Timezone
 
 if TYPE_CHECKING:
-    from icalendar import Event, vCalAddress
+    from icalendar import vCalAddress
 
 
 def strip_mailto(s: str) -> str:
@@ -21,7 +21,7 @@ def strip_mailto(s: str) -> str:
     return s.replace("MAILTO:", "").replace("mailto:", "")
 
 
-def get_attendee_list(component: Event) -> list[vCalAddress]:
+def get_attendee_list(component: Component) -> list[vCalAddress]:
     """Return the ATTENDEE property as a list, even if there's only one."""
     raw = component.get("attendee")
     if raw is None:

--- a/calendar-cli/tests/helpers.py
+++ b/calendar-cli/tests/helpers.py
@@ -142,7 +142,9 @@ def extract_ics_from_email(raw: str) -> Calendar:
         if ct == "text/calendar" or fn.endswith(".ics"):
             payload = part.get_payload(decode=True)
             assert isinstance(payload, bytes)
-            return Calendar.from_ical(payload)
+            cal = Calendar.from_ical(payload.decode())
+            assert isinstance(cal, Calendar)
+            return cal
     err_msg = "No calendar attachment found in email"
     raise AssertionError(err_msg)
 

--- a/calendar-cli/tests/test_import.py
+++ b/calendar-cli/tests/test_import.py
@@ -30,7 +30,9 @@ def _find_imported_ics(base: Path) -> list[Path]:
 
 
 def _parse_imported(path: Path) -> Calendar:
-    return Calendar.from_ical(path.read_bytes())
+    cal = Calendar.from_ical(path.read_text())
+    assert isinstance(cal, Calendar)
+    return cal
 
 
 def test_import_basic_ics(tmp_path: Path) -> None:

--- a/calendar-cli/tests/test_invite.py
+++ b/calendar-cli/tests/test_invite.py
@@ -82,7 +82,7 @@ def test_invite_with_timezone(tmp_path: Path) -> None:
     )
 
     assert result == 0
-    cal = Calendar.from_ical(ics_file.read_bytes())
+    cal = Calendar.from_ical(ics_file.read_text())
     event = next(iter(cal.walk("VEVENT")))
     assert str(event["SUMMARY"]) == "Berlin Meeting"
     dtstart = event["DTSTART"].dt
@@ -103,7 +103,7 @@ def test_invite_with_recurrence(tmp_path: Path) -> None:
     )
 
     assert result == 0
-    cal = Calendar.from_ical(ics_file.read_bytes())
+    cal = Calendar.from_ical(ics_file.read_text())
     event = next(iter(cal.walk("VEVENT")))
     rrule = event["RRULE"]
     assert rrule["FREQ"] == ["WEEKLY"]

--- a/calendar-cli/tests/test_reply.py
+++ b/calendar-cli/tests/test_reply.py
@@ -424,7 +424,7 @@ def test_reply_updates_local_partstat(mock_run: MagicMock, tmp_path: Path) -> No
     # Verify local store was updated
     ics_files = sorted((cal_dir / "personal").rglob("*.ics"))
     assert len(ics_files) == 1
-    cal = Calendar.from_ical(ics_files[0].read_bytes())
+    cal = Calendar.from_ical(ics_files[0].read_text())
     event = next(iter(cal.walk("VEVENT")))
     attendee = event.get("attendee")
     # Single attendee comes back as vCalAddress, not list

--- a/calendar-cli/types-icalendar.nix
+++ b/calendar-cli/types-icalendar.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  python,
+  fetchPypi,
+}:
+
+python.pkgs.buildPythonPackage rec {
+  pname = "types-icalendar";
+  version = "6.3.2.20260223";
+
+  src = fetchPypi {
+    pname = "types_icalendar";
+    inherit version;
+    hash = "sha256-p0688nZ/rf3WgLoOoXrhCFVhdgTup/OnoVgsNIdloeU=";
+  };
+
+  pyproject = true;
+
+  build-system = with python.pkgs; [
+    setuptools
+  ];
+
+  dependencies = with python.pkgs; [
+    types-pytz
+    types-python-dateutil
+  ];
+
+  # This is a type stubs package, it has no tests to run
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "icalendar-stubs"
+  ];
+
+  meta = with lib; {
+    description = "Typing stubs for icalendar";
+    homepage = "https://github.com/python/typeshed";
+    license = licenses.asl20;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -70,10 +70,19 @@
             programs.mypy.enable = true;
             programs.mypy.directories = {
               "calendar-cli" = {
-                extraPythonPackages = with pkgs.python3.pkgs; [
-                  icalendar
-                  pytest
-                ];
+                extraPythonPackages =
+                  let
+                    types-icalendar = pkgs.callPackage ./calendar-cli/types-icalendar.nix {
+                      python = pkgs.python3;
+                    };
+                  in
+                  with pkgs.python3.pkgs;
+                  [
+                    icalendar
+                    pytest
+                    types-icalendar
+                    types-python-dateutil
+                  ];
               };
               "pexpect-cli" = {
                 extraPythonPackages = with pkgs.python3.pkgs; [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,13 +53,3 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "pytest.*"
 ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "icalendar.*"
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = "dateutil.*"
-ignore_missing_imports = true
-follow_imports = "skip"
-


### PR DESCRIPTION
mypy was running without type information for icalendar and dateutil, silently missing type errors across the codebase. Adding types-icalendar (6.3.2.20260223) and types-python-dateutil to the mypy check exposes real issues that would otherwise go unnoticed.

The stubs correctly type from_ical() as accepting str, not bytes. All call sites now decode before parsing since icalendar internally handles encoding anyway. Functions that receive Component objects from cal.walk() are widened from Event/Calendar to Component, since mypy cannot narrow the type through the .name string check.