### PR TITLE
calendar-cli: preserve Olson timezone across cache round-trips

### DIFF
--- a/calendar-cli/calendar_cli/cache.py
+++ b/calendar-cli/calendar_cli/cache.py
@@ -16,6 +16,7 @@ import os
 import sqlite3
 from datetime import date, datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from .models import Attendee, CalendarEvent
 from .parse import read_event_file
@@ -24,7 +25,7 @@ __all__ = ["cached_collect_events"]
 
 log = logging.getLogger(__name__)
 
-_SCHEMA_VERSION = 2
+_SCHEMA_VERSION = 3
 
 _CREATE_SQL = """\
 CREATE TABLE IF NOT EXISTS meta (
@@ -71,9 +72,22 @@ CREATE INDEX IF NOT EXISTS idx_events_calendar ON events(calendar);
 
 
 def _dt_to_str(dt: datetime | date) -> str:
-    """Serialize a date or datetime to a string for storage."""
+    """Serialize a date or datetime to a string for storage.
+
+    For timezone-aware datetimes with an Olson timezone (ZoneInfo), the
+    timezone key is appended in brackets so it survives a round-trip:
+    ``2026-02-23T10:00:00-05:00[America/New_York]``.
+
+    This is critical for recurring events that cross DST boundaries:
+    ``fromisoformat()`` would otherwise convert ZoneInfo to a fixed UTC
+    offset, causing all occurrences to use the DTSTART offset regardless
+    of whether DST is active.
+    """
     if isinstance(dt, datetime):
-        return dt.isoformat()
+        iso = dt.isoformat()
+        if isinstance(dt.tzinfo, ZoneInfo):
+            iso += f"[{dt.tzinfo.key}]"
+        return iso
     return dt.isoformat()
 
 
@@ -81,10 +95,20 @@ def _str_to_dt(s: str) -> datetime | date:
     """Deserialize a date or datetime from storage.
 
     ISO 8601 date strings (YYYY-MM-DD, 10 chars) → ``date``.
+    Strings with a bracketed Olson zone suffix (e.g. ``[America/New_York]``)
+    restore the proper ``ZoneInfo`` so DST transitions work correctly.
     Everything else → ``datetime.fromisoformat()``.
     """
     if len(s) == 10:
         return date.fromisoformat(s)
+    # Check for bracketed Olson timezone suffix
+    if s.endswith("]"):
+        bracket = s.rfind("[")
+        if bracket != -1:
+            tz_key = s[bracket + 1 : -1]
+            iso_part = s[:bracket]
+            dt = datetime.fromisoformat(iso_part)
+            return dt.replace(tzinfo=ZoneInfo(tz_key))
     return datetime.fromisoformat(s)
 
 

--- a/calendar-cli/tests/test_store.py
+++ b/calendar-cli/tests/test_store.py
@@ -947,3 +947,74 @@ def test_search_events_invalid_regex(cal_dir: str) -> None:
     """Invalid regex raises InvalidInputError."""
     with pytest.raises(InvalidInputError):
         store.search_events("[invalid", calendars_dir=cal_dir)
+
+
+def test_recurring_event_dst_transition(tmp_path: Path) -> None:
+    """Recurring events crossing a DST boundary must adjust UTC offset per occurrence.
+
+    Regression test: an event at 10:00 America/New_York recurs weekly.
+    Feb 23 is EST (UTC-5) → 10:00-05:00 = 15:00 UTC.
+    Mar 13 is EDT (UTC-4) → 10:00-04:00 = 14:00 UTC.
+    The wall-clock time stays 10:00 New York, but the UTC offset changes.
+    A cache round-trip through isoformat()/fromisoformat() was losing the
+    Olson timezone, replacing it with a fixed UTC offset, which caused all
+    occurrences to use the DTSTART offset regardless of DST.
+    """
+    # Use a VTIMEZONE so the ICS is realistic (matches real Google Calendar output)
+    ics = (
+        "BEGIN:VCALENDAR\n"
+        "VERSION:2.0\n"
+        "PRODID:-//test//test//\n"
+        "BEGIN:VTIMEZONE\n"
+        "TZID:America/New_York\n"
+        "BEGIN:DAYLIGHT\n"
+        "DTSTART:19700308T020000\n"
+        "RRULE:FREQ=YEARLY;BYDAY=2SU;BYMONTH=3\n"
+        "TZNAME:EDT\n"
+        "TZOFFSETFROM:-0500\n"
+        "TZOFFSETTO:-0400\n"
+        "END:DAYLIGHT\n"
+        "BEGIN:STANDARD\n"
+        "DTSTART:19701101T020000\n"
+        "RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=11\n"
+        "TZNAME:EST\n"
+        "TZOFFSETFROM:-0400\n"
+        "TZOFFSETTO:-0500\n"
+        "END:STANDARD\n"
+        "END:VTIMEZONE\n"
+        "BEGIN:VEVENT\n"
+        "UID:dst-recur@example.com\n"
+        "SUMMARY:DST Recurring\n"
+        "DTSTART;TZID=America/New_York:20260223T100000\n"
+        "DTEND;TZID=America/New_York:20260223T104000\n"
+        "RRULE:FREQ=WEEKLY;BYDAY=FR\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n"
+    )
+    cal_dir = setup_single_calendar(tmp_path, ics, filename="dst-recur.ics")
+
+    # Feb 27 (Fri) — still EST (UTC-5)
+    events_feb = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2026, 2, 27),
+        to_date=date(2026, 2, 28),
+    )
+    assert len(events_feb) == 1
+    feb_occ = events_feb[0]
+    assert isinstance(feb_occ.dtstart, datetime)
+    # 10:00 EST = 15:00 UTC
+    feb_utc = feb_occ.dtstart.astimezone(UTC)
+    assert feb_utc.hour == 15, f"Expected 15:00 UTC for EST occurrence, got {feb_utc}"
+
+    # Mar 13 (Fri) — EDT (UTC-4), DST has started on Mar 8
+    events_mar = store.list_events(
+        calendars_dir=cal_dir,
+        from_date=date(2026, 3, 13),
+        to_date=date(2026, 3, 14),
+    )
+    assert len(events_mar) == 1
+    mar_occ = events_mar[0]
+    assert isinstance(mar_occ.dtstart, datetime)
+    # 10:00 EDT = 14:00 UTC (NOT 15:00 which would be the bug)
+    mar_utc = mar_occ.dtstart.astimezone(UTC)
+    assert mar_utc.hour == 14, f"Expected 14:00 UTC for EDT occurrence, got {mar_utc}"


### PR DESCRIPTION
The SQLite cache serialized timezone-aware datetimes via isoformat(), which converts ZoneInfo('America/New_York') to a fixed UTC offset like -05:00. On deserialization, fromisoformat() produced a fixed-offset timezone that always returns the same offset regardless of date. This caused recurring events crossing a DST boundary to show the wrong time for all occurrences after the transition.

Append the Olson zone key in brackets during serialization (e.g. 2026-02-23T10:00:00-05:00[America/New_York]) and restore the proper ZoneInfo on deserialization so that DST-aware offset computation works correctly for each occurrence.

Bump the cache schema version to invalidate existing caches that stored fixed offsets.