### PR TITLE
n8n-cli: add Python CLI for n8n API gaps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
             db-cli = pkgs.callPackage ./db-cli { };
             gmaps-cli = pkgs.python3.pkgs.callPackage ./gmaps-cli { };
             kagi-search = pkgs.python3.pkgs.callPackage ./kagi-search { };
+            n8n-cli = pkgs.python3.pkgs.callPackage ./n8n-cli { };
             pexpect-cli = pkgs.callPackage ./pexpect-cli { };
             screenshot-cli = pkgs.python3.pkgs.callPackage ./screenshot-cli {
               spectacle = if pkgs.stdenv.hostPlatform.isLinux then pkgs.kdePackages.spectacle else null;
@@ -111,6 +112,11 @@
                 extraPythonPackages = with pkgs.python3.pkgs; [
                   beautifulsoup4
                   types-beautifulsoup4
+                ];
+              };
+              "n8n-cli" = {
+                extraPythonPackages = with pkgs.python3.pkgs; [
+                  pytest
                 ];
               };
               "weather-cli" = { };

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -14,6 +14,7 @@ let
     "db-cli"
     "gmaps-cli"
     "kagi-search"
+    "n8n-cli"
     "pexpect-cli"
     "screenshot-cli"
     "tasker-cli"

--- a/n8n-cli/README.md
+++ b/n8n-cli/README.md
@@ -1,0 +1,54 @@
+# n8n-cli
+
+Python CLI for n8n API operations — stdlib only, no dependencies.
+
+- Credential, workflow, execution, tag, data table CRUD
+- Webhook testing, bulk import/apply
+- Raw API escape hatch
+
+## Install
+
+```bash
+pip install n8n-cli
+```
+
+## Setup
+
+### Environment variables
+
+```bash
+export N8N_API_URL="https://your-n8n.example.com"
+export N8N_API_KEY="your-api-key"
+```
+
+### Config file (preferred)
+
+Create `~/.config/n8n-cli/config.json`:
+
+```json
+{
+  "api_url": "https://your-n8n.example.com",
+  "api_key_command": "rbw get n8n-api-key"
+}
+```
+
+| Field             | Description                                   |
+| ----------------- | --------------------------------------------- |
+| `api_url`         | n8n instance URL                              |
+| `api_key`         | API key (direct, less secure)                 |
+| `api_key_command` | Shell command to retrieve API key (preferred) |
+| `api_url_command` | Shell command to retrieve API URL             |
+| `timeout`         | Request timeout in seconds (default: 30)      |
+
+Priority: environment variables > `*_command` > direct values.
+
+## Usage
+
+See [SKILL.md](../skills/n8n-cli/SKILL.md) for full command reference.
+
+```bash
+n8n-cli --help
+n8n-cli <command> --help
+```
+
+Default output is LLM-friendly text. Add `-j`/`--json` for JSON.

--- a/n8n-cli/default.nix
+++ b/n8n-cli/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildPythonApplication,
+  hatchling,
+  pytestCheckHook,
+}:
+
+buildPythonApplication {
+  pname = "n8n-cli";
+  version = "0.1.0";
+
+  src = ./.;
+
+  pyproject = true;
+
+  build-system = [ hatchling ];
+
+  dependencies = [ ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Python CLI for n8n API: credentials, workflow JSON, execution data";
+    mainProgram = "n8n-cli";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/n8n-cli/n8n_cli/__init__.py
+++ b/n8n-cli/n8n_cli/__init__.py
@@ -1,0 +1,3 @@
+"""Python CLI for n8n API: credentials, workflow JSON, execution data."""
+
+__version__ = "0.1.0"

--- a/n8n-cli/n8n_cli/client.py
+++ b/n8n-cli/n8n_cli/client.py
@@ -1,0 +1,69 @@
+"""n8n REST API client."""
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from n8n_cli.errors import APIError, ConnectionError_
+
+
+class Client:
+    """Minimal n8n REST API client using only stdlib."""
+
+    def __init__(self, base_url: str, api_key: str, timeout: int = 30) -> None:
+        url = base_url.rstrip("/")
+        if not url.endswith("/api/v1"):
+            url += "/api/v1"
+        self.base_url = url
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def _request(self, method: str, path: str, body: Any = None) -> Any:
+        if not path.startswith("/"):
+            path = "/" + path
+        url = f"{self.base_url}{path}"
+        data = None
+        headers: dict[str, str] = {
+            "X-N8N-API-KEY": self.api_key,
+            "Accept": "application/json",
+        }
+        if body is not None:
+            data = json.dumps(body).encode()
+            headers["Content-Type"] = "application/json"
+
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read().decode()
+                if not raw:
+                    return None
+                return json.loads(raw)
+        except urllib.error.HTTPError as e:
+            body_text = e.read().decode() if e.fp else ""
+            msg = body_text
+            try:
+                parsed = json.loads(body_text)
+                if "message" in parsed:
+                    msg = parsed["message"]
+            except (json.JSONDecodeError, KeyError):
+                pass
+            raise APIError(e.code, msg) from e
+        except urllib.error.URLError as e:
+            raise ConnectionError_(str(e.reason)) from e
+
+    def get(self, path: str) -> Any:
+        return self._request("GET", path)
+
+    def post(self, path: str, body: Any = None) -> Any:
+        return self._request("POST", path, body)
+
+    def put(self, path: str, body: Any = None) -> Any:
+        return self._request("PUT", path, body)
+
+    def patch(self, path: str, body: Any = None) -> Any:
+        return self._request("PATCH", path, body)
+
+    def delete(self, path: str) -> Any:
+        return self._request("DELETE", path)

--- a/n8n-cli/n8n_cli/commands/__init__.py
+++ b/n8n-cli/n8n_cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CLI command modules."""

--- a/n8n-cli/n8n_cli/commands/apply.py
+++ b/n8n-cli/n8n_cli/commands/apply.py
@@ -1,0 +1,265 @@
+"""Apply command — push local workflow JSON files to n8n server."""
+
+import json
+import os
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.errors import APIError, CLIError
+from n8n_cli.output import atomic_write, enc
+
+
+class ApplyError(CLIError):
+    """Error during workflow apply."""
+
+
+def _scan_workflows(directory: str, ids: list[str] | None) -> list[tuple[str, dict[str, Any]]]:
+    """Scan directory for workflow JSON files. Returns list of (path, data).
+
+    Walks recursively, skipping _subfiles directories.
+    """
+    if not os.path.isdir(directory):
+        raise ApplyError(f"Directory not found: {directory}")
+
+    results: list[tuple[str, dict[str, Any]]] = []
+    seen_ids: dict[str, str] = {}
+
+    for root, dirs, files in os.walk(directory):
+        # Skip _subfiles directories
+        dirs[:] = [d for d in dirs if d != "_subfiles"]
+        for fname in sorted(files):
+            if not fname.endswith(".json"):
+                continue
+            path = os.path.join(root, fname)
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+            except json.JSONDecodeError as e:
+                print(f"  error: {path}: invalid JSON: {e}")
+                continue
+            except OSError as e:
+                print(f"  error: {path}: {e}")
+                continue
+
+            if not isinstance(data, dict):
+                print(f"  error: {path}: not a JSON object")
+                continue
+
+            # Validate minimum fields
+            if not data.get("name"):
+                print(f"  error: {path}: missing 'name' field")
+                continue
+            if data.get("nodes") is None:
+                print(f"  error: {path}: missing 'nodes' field")
+                continue
+            if data.get("connections") is None:
+                print(f"  error: {path}: missing 'connections' field")
+                continue
+
+            wf_id = data.get("id")
+
+            # Filter by IDs if specified
+            if ids:
+                if not wf_id or wf_id not in ids:
+                    continue
+
+            # Check for duplicate IDs
+            if wf_id and wf_id in seen_ids:
+                raise ApplyError(
+                    f"Duplicate workflow ID {wf_id}:\n  - {seen_ids[wf_id]}\n  - {path}"
+                )
+            if wf_id:
+                seen_ids[wf_id] = path
+
+            results.append((path, data))
+
+    return results
+
+
+def _strip_for_create(data: dict[str, Any]) -> dict[str, Any]:
+    """Strip fields not accepted by the create endpoint."""
+    body: dict[str, Any] = {
+        "name": data["name"],
+        "nodes": data["nodes"],
+        "connections": data["connections"],
+    }
+    if data.get("settings"):
+        body["settings"] = data["settings"]
+    if data.get("staticData"):
+        body["staticData"] = data["staticData"]
+    return body
+
+
+def _strip_for_update(data: dict[str, Any]) -> dict[str, Any]:
+    """Strip fields not accepted by the update endpoint."""
+    body = dict(data)
+    for key in ("id", "createdAt", "updatedAt", "tags", "shared", "pinData"):
+        body.pop(key, None)
+    return body
+
+
+def _update_local_file(path: str, created: dict[str, Any]) -> None:
+    """Update local JSON file with server-assigned id and timestamps."""
+    try:
+        with open(path) as f:
+            local = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return
+
+    if not isinstance(local, dict):
+        return
+
+    local["id"] = created.get("id")
+    if created.get("updatedAt"):
+        local["updatedAt"] = created["updatedAt"]
+    if created.get("createdAt"):
+        local["createdAt"] = created["createdAt"]
+
+    try:
+        atomic_write(path, json.dumps(local, indent=2) + "\n")
+    except OSError:
+        pass  # Best-effort; the server operation already succeeded
+
+
+def _workflows_differ(local: dict[str, Any], remote: dict[str, Any]) -> bool:
+    """Check if local and remote workflows differ in meaningful fields."""
+
+    def _normalize(v: Any) -> Any:
+        """Normalize for comparison: strip None, sort keys."""
+        if v is None:
+            return None
+        s = json.dumps(v, sort_keys=True, separators=(",", ":"))
+        return s
+
+    for field in ("name", "nodes", "connections", "settings"):
+        if _normalize(local.get(field)) != _normalize(remote.get(field)):
+            return True
+    # Compare active state
+    if local.get("active") != remote.get("active"):
+        return True
+    return False
+
+
+def cmd_apply(client: Client, ns: Namespace) -> None:
+    """Apply local workflow JSON files to n8n server."""
+    directory = ns.dir
+
+    # Parse IDs filter
+    ids: list[str] | None = None
+    if ns.ids:
+        ids = [s.strip() for s in ns.ids.split(",") if s.strip()]
+
+    files = _scan_workflows(directory, ids)
+    if not files:
+        print("No workflow files found.")
+        return
+
+    created = 0
+    updated = 0
+    skipped = 0
+    errors = 0
+    conflicts = 0
+
+    for path, data in files:
+        wf_name = data.get("name", "")
+        wf_id = data.get("id")
+        basename = os.path.basename(path)
+
+        if not wf_id:
+            # No ID = create
+            if ns.dry_run:
+                print(f"  create: {basename} ({wf_name})")
+                created += 1
+                continue
+
+            try:
+                body = _strip_for_create(data)
+                result = client.post("/workflows", body)
+                _update_local_file(path, result)
+                print(f"  create: {basename} → {result.get('id', '')} ({wf_name})")
+                created += 1
+            except (APIError, OSError) as e:
+                print(f"  error: {basename}: {e}")
+                errors += 1
+            continue
+
+        # Has ID — fetch remote to compare
+        try:
+            remote = client.get(f"/workflows/{enc(wf_id)}")
+        except APIError as e:
+            if e.status == 404:
+                # Not on server — create with ID preserved
+                if ns.dry_run:
+                    print(f"  create: {basename} ({wf_name}) [id: {wf_id}]")
+                    created += 1
+                    continue
+
+                try:
+                    body = _strip_for_create(data)
+                    result = client.post("/workflows", body)
+                    _update_local_file(path, result)
+                    print(f"  create: {basename} → {result.get('id', '')} ({wf_name})")
+                    created += 1
+                except (APIError, OSError) as e2:
+                    print(f"  error: {basename}: {e2}")
+                    errors += 1
+                continue
+            print(f"  error: {basename}: {e}")
+            errors += 1
+            continue
+
+        if not isinstance(remote, dict):
+            print(f"  error: {basename}: unexpected remote response")
+            errors += 1
+            continue
+
+        # Compare
+        if not _workflows_differ(data, remote):
+            print(f"  skip: {basename} (no changes)")
+            skipped += 1
+            continue
+
+        # Conflict detection: remote newer than local
+        local_updated = data.get("updatedAt")
+        remote_updated = remote.get("updatedAt")
+        if local_updated and remote_updated and remote_updated > local_updated:
+            if not ns.force:
+                print(
+                    f"  conflict: {basename} (remote is newer: {remote_updated} > {local_updated})"
+                )
+                conflicts += 1
+                continue
+
+        # Update
+        if ns.dry_run:
+            print(f"  update: {basename} ({wf_name})")
+            updated += 1
+            continue
+
+        try:
+            body = _strip_for_update(data)
+            result = client.put(f"/workflows/{enc(wf_id)}", body)
+            _update_local_file(path, result)
+            print(f"  update: {basename} ({wf_name})")
+            updated += 1
+        except (APIError, OSError) as e:
+            print(f"  error: {basename}: {e}")
+            errors += 1
+
+    prefix = "(dry-run) " if ns.dry_run else ""
+    parts = [
+        f"{created} created",
+        f"{updated} updated",
+        f"{skipped} skipped",
+    ]
+    if conflicts:
+        parts.append(f"{conflicts} conflicts")
+    if errors:
+        parts.append(f"{errors} errors")
+    print(f"\n{prefix}Summary: {', '.join(parts)}")
+
+    if errors > 0:
+        raise SystemExit(1)
+    if conflicts > 0:
+        raise SystemExit(2)

--- a/n8n-cli/n8n_cli/commands/credential.py
+++ b/n8n-cli/n8n_cli/commands/credential.py
@@ -1,0 +1,96 @@
+"""Credential management commands."""
+
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, read_json_input, ts
+
+
+def _text_get(c: dict[str, Any]) -> None:
+    emit_kv(
+        {
+            "ID": str(c.get("id", "")),
+            "Name": str(c.get("name", "")),
+            "Type": str(c.get("type", "")),
+            "Created": ts(c.get("createdAt")),
+            "Updated": ts(c.get("updatedAt")),
+        }
+    )
+
+
+def _text_mutate(action: str, c: dict[str, Any]) -> None:
+    print(f"{action} credential {c.get('name', '')} (id: {c.get('id', '')})")
+
+
+def cmd_credential_list(client: Client, ns: Namespace) -> None:
+    """List all credentials."""
+    result = client.get("/credentials")
+
+    def text(data: dict[str, object]) -> None:
+        items = data.get("data", data)
+        if not isinstance(items, list):
+            emit_json(data)
+            return
+        emit_table(
+            ["ID", "NAME", "TYPE", "UPDATED"],
+            [
+                [
+                    str(c.get("id", "")),
+                    str(c.get("name", "")),
+                    str(c.get("type", "")),
+                    ts(c.get("updatedAt")),
+                ]
+                for c in items
+                if isinstance(c, dict)
+            ],
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_credential_get(client: Client, ns: Namespace) -> None:
+    """Get a credential by ID (metadata only — secrets are not returned)."""
+    result = client.get(f"/credentials/{enc(ns.id)}")
+    emit(result, use_json=ns.use_json, text_fn=_text_get)
+
+
+def cmd_credential_create(client: Client, ns: Namespace) -> None:
+    """Create a credential from JSON."""
+    body = read_json_input(ns.file)
+    result = client.post("/credentials", body)
+    emit(result, use_json=ns.use_json, text_fn=lambda c: _text_mutate("Created", c))
+
+
+def cmd_credential_update(client: Client, ns: Namespace) -> None:
+    """Update a credential."""
+    body = read_json_input(ns.file)
+    result = client.patch(f"/credentials/{enc(ns.id)}", body)
+    emit(result, use_json=ns.use_json, text_fn=lambda c: _text_mutate("Updated", c))
+
+
+def cmd_credential_delete(client: Client, ns: Namespace) -> None:
+    """Delete a credential."""
+    result = client.delete(f"/credentials/{enc(ns.id)}")
+    if ns.use_json and result is not None:
+        emit_json(result)
+    else:
+        print(f"Deleted credential {ns.id}")
+
+
+def cmd_credential_test(client: Client, ns: Namespace) -> None:
+    """Test a credential by ID."""
+    result = client.post(f"/credentials/{enc(ns.id)}/test")
+
+    def text(data: dict[str, object]) -> None:
+        status = data.get("status", "unknown")
+        msg = data.get("message", "")
+        print(f"Test {status}" + (f": {msg}" if msg else ""))
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_credential_schema(client: Client, ns: Namespace) -> None:
+    """Get the JSON schema for a credential type."""
+    result = client.get(f"/credentials/schema/{enc(ns.type)}")
+    emit_json(result)

--- a/n8n-cli/n8n_cli/commands/datatable.py
+++ b/n8n-cli/n8n_cli/commands/datatable.py
@@ -1,0 +1,189 @@
+"""Data table management commands."""
+
+import json
+import urllib.parse
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.errors import InputError
+from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, read_json_input, ts
+
+
+# ---------------------------------------------------------------------------
+# Table-level commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_datatable_list(client: Client, ns: Namespace) -> None:
+    """List all data tables."""
+    params: dict[str, str] = {}
+    if ns.filter:
+        params["filter"] = ns.filter
+    if ns.sort:
+        params["sortBy"] = ns.sort
+    if ns.limit is not None:
+        params["limit"] = str(ns.limit)
+
+    qs = urllib.parse.urlencode(params)
+    path = f"/data-tables?{qs}" if qs else "/data-tables"
+    result = client.get(path)
+
+    def text(data: dict[str, Any]) -> None:
+        items = data.get("data", data)
+        if not isinstance(items, list):
+            emit_json(data)
+            return
+        emit_table(
+            ["ID", "NAME", "COLUMNS", "UPDATED"],
+            [
+                [
+                    str(t.get("id", "")),
+                    str(t.get("name", "")),
+                    str(len(t.get("columns", []))),
+                    ts(t.get("updatedAt")),
+                ]
+                for t in items
+                if isinstance(t, dict)
+            ],
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_datatable_get(client: Client, ns: Namespace) -> None:
+    """Get a data table by ID (includes column definitions)."""
+    result = client.get(f"/data-tables/{enc(ns.id)}")
+
+    def text(data: dict[str, Any]) -> None:
+        cols = data.get("columns", [])
+        col_strs = [f"{c.get('name', '')}:{c.get('type', '')}" for c in cols if isinstance(c, dict)]
+        emit_kv(
+            {
+                "ID": str(data.get("id", "")),
+                "Name": str(data.get("name", "")),
+                "Columns": ", ".join(col_strs) if col_strs else "-",
+                "Created": ts(data.get("createdAt")),
+                "Updated": ts(data.get("updatedAt")),
+            }
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_datatable_create(client: Client, ns: Namespace) -> None:
+    """Create a data table from JSON."""
+    body = read_json_input(ns.file)
+    result = client.post("/data-tables", body)
+
+    def text(data: dict[str, Any]) -> None:
+        print(f"Created table {data.get('name', '')} (id: {data.get('id', '')})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_datatable_update(client: Client, ns: Namespace) -> None:
+    """Rename a data table."""
+    result = client.patch(f"/data-tables/{enc(ns.id)}", {"name": ns.name})
+
+    def text(data: dict[str, Any]) -> None:
+        print(f"Renamed table to {data.get('name', '')} (id: {data.get('id', '')})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_datatable_delete(client: Client, ns: Namespace) -> None:
+    """Delete a data table (and all its rows)."""
+    client.delete(f"/data-tables/{enc(ns.id)}")
+
+    def text(_: dict[str, Any]) -> None:
+        print(f"Deleted table {ns.id}")
+
+    emit({"deleted": True, "id": ns.id}, use_json=ns.use_json, text_fn=text)
+
+
+# ---------------------------------------------------------------------------
+# Row-level commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_datatable_rows(client: Client, ns: Namespace) -> None:
+    """List rows from a data table."""
+    params: dict[str, str] = {}
+    if ns.filter:
+        params["filter"] = ns.filter
+    if ns.sort:
+        params["sortBy"] = ns.sort
+    if ns.search:
+        params["search"] = ns.search
+    if ns.limit is not None:
+        params["limit"] = str(ns.limit)
+
+    qs = urllib.parse.urlencode(params)
+    path = f"/data-tables/{enc(ns.id)}/rows"
+    if qs:
+        path += f"?{qs}"
+    result = client.get(path)
+
+    def text(data: dict[str, Any]) -> None:
+        items = data.get("data", data)
+        if not isinstance(items, list):
+            emit_json(data)
+            return
+        if not items:
+            print("(no rows)")
+            return
+        cols = list(items[0].keys())
+        emit_table(
+            [c.upper() for c in cols],
+            [[str(row.get(c, "")) for c in cols] for row in items if isinstance(row, dict)],
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_datatable_insert(client: Client, ns: Namespace) -> None:
+    """Insert rows into a data table."""
+    body = read_json_input(ns.file)
+
+    if isinstance(body, list):
+        body = {"data": body, "returnType": ns.return_type}
+    elif isinstance(body, dict):
+        body.setdefault("returnType", ns.return_type)
+    else:
+        raise InputError('Insert JSON must be an array of rows or {"data": [...]}')
+
+    result = client.post(f"/data-tables/{enc(ns.id)}/rows", body)
+    emit_json(result)
+
+
+def cmd_datatable_update_rows(client: Client, ns: Namespace) -> None:
+    """Update rows matching a filter."""
+    body = read_json_input(ns.file)
+    result = client.patch(f"/data-tables/{enc(ns.id)}/rows/update", body)
+    emit_json(result)
+
+
+def cmd_datatable_upsert(client: Client, ns: Namespace) -> None:
+    """Upsert a row (update if filter matches, insert otherwise)."""
+    body = read_json_input(ns.file)
+    result = client.post(f"/data-tables/{enc(ns.id)}/rows/upsert", body)
+    emit_json(result)
+
+
+def cmd_datatable_delete_rows(client: Client, ns: Namespace) -> None:
+    """Delete rows matching a filter."""
+    try:
+        json.loads(ns.filter)
+    except json.JSONDecodeError as e:
+        raise InputError(f"Invalid filter JSON: {e}") from None
+
+    params: dict[str, str] = {"filter": ns.filter}
+    if ns.return_data:
+        params["returnData"] = "true"
+    if ns.dry_run:
+        params["dryRun"] = "true"
+
+    qs = urllib.parse.urlencode(params)
+    result = client.delete(f"/data-tables/{enc(ns.id)}/rows/delete?{qs}")
+    emit_json(result)

--- a/n8n-cli/n8n_cli/commands/execution.py
+++ b/n8n-cli/n8n_cli/commands/execution.py
@@ -1,0 +1,165 @@
+"""Execution management commands."""
+
+import urllib.parse
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, ts
+
+
+def _text_summary(exc: dict[str, Any], *, show_data: bool = True) -> None:
+    """Print a compact execution summary with error/node details."""
+    emit_kv(
+        {
+            "ID": str(exc.get("id", "")),
+            "Workflow": str(exc.get("workflowId", "")),
+            "Status": str(exc.get("status", "")),
+            "Mode": str(exc.get("mode", "")),
+            "Started": ts(exc.get("startedAt")),
+            "Stopped": ts(exc.get("stoppedAt")),
+        }
+    )
+
+    data = exc.get("data")
+    if not isinstance(data, dict):
+        return
+    result_data = data.get("resultData")
+    if not isinstance(result_data, dict):
+        return
+
+    error = result_data.get("error")
+    if isinstance(error, dict):
+        print()
+        kv: dict[str, str] = {
+            "Error node": str(error.get("node", "-")),
+            "Error": str(error.get("message", "")),
+        }
+        desc = error.get("description")
+        if desc:
+            kv["Details"] = str(desc)
+        emit_kv(kv)
+
+    last = result_data.get("lastNodeExecuted")
+    if last:
+        print(f"\nLast node: {last}")
+
+    if not show_data:
+        return
+
+    run_data = result_data.get("runData")
+    if isinstance(run_data, dict) and run_data:
+        print()
+        rows: list[list[str]] = []
+        for node_name, runs in run_data.items():
+            if not isinstance(runs, list):
+                continue
+            for run in runs:
+                if not isinstance(run, dict):
+                    continue
+                ms = str(run.get("executionTime", 0))
+                err = run.get("error")
+                if isinstance(err, dict):
+                    status = f"✗ {err.get('message', 'error')}"
+                else:
+                    status = "✓"
+                rows.append([node_name, f"{ms}ms", status])
+        emit_table(["NODE", "TIME", "STATUS"], rows)
+
+
+def cmd_execution_get(client: Client, ns: Namespace) -> None:
+    """Get execution by ID, optionally with full runData."""
+    include = "true" if ns.show_data else "false"
+    result = client.get(f"/executions/{enc(ns.id)}?includeData={include}")
+
+    if ns.use_json:
+        emit_json(result)
+    elif isinstance(result, dict):
+        _text_summary(result, show_data=ns.show_data)
+    else:
+        emit_json(result)
+
+
+def cmd_execution_list(client: Client, ns: Namespace) -> None:
+    """List executions with optional filters."""
+    params: dict[str, str] = {"limit": str(ns.limit)}
+    if ns.workflow:
+        params["workflowId"] = ns.workflow
+    if ns.status:
+        params["status"] = ns.status
+
+    qs = urllib.parse.urlencode(params)
+    result = client.get(f"/executions?{qs}")
+
+    def text(data: dict[str, object]) -> None:
+        items = data.get("data", data)
+        if not isinstance(items, list):
+            emit_json(data)
+            return
+        emit_table(
+            ["ID", "WORKFLOW", "STATUS", "MODE", "STARTED", "STOPPED"],
+            [
+                [
+                    str(e.get("id", "")),
+                    str(e.get("workflowId", "")),
+                    str(e.get("status", "")),
+                    str(e.get("mode", "")),
+                    ts(e.get("startedAt")),
+                    ts(e.get("stoppedAt")),
+                ]
+                for e in items
+                if isinstance(e, dict)
+            ],
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_execution_delete(client: Client, ns: Namespace) -> None:
+    """Delete an execution by ID."""
+    result = client.delete(f"/executions/{enc(ns.id)}")
+
+    def text(data: dict[str, Any]) -> None:
+        wf = data.get("workflowId", "") if isinstance(data, dict) else ""
+        print(f"Deleted execution {ns.id} (workflow: {wf})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_execution_retry(client: Client, ns: Namespace) -> None:
+    """Retry a failed execution."""
+    body = None
+    if ns.load_workflow:
+        body = {"loadWorkflow": True}
+    result = client.post(f"/executions/{enc(ns.id)}/retry", body)
+
+    def text(data: dict[str, Any]) -> None:
+        emit_kv(
+            {
+                "Original ID": ns.id,
+                "New Execution ID": str(data.get("id", "")),
+                "Workflow": str(data.get("workflowId", "")),
+                "Status": str(data.get("status", "")),
+            }
+        )
+        print("\nExecution retry started.")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_execution_stop(client: Client, ns: Namespace) -> None:
+    """Stop a running execution."""
+    result = client.post(f"/executions/{enc(ns.id)}/stop")
+
+    def text(data: dict[str, Any]) -> None:
+        emit_kv(
+            {
+                "ID": str(data.get("id", ns.id)),
+                "Workflow": str(data.get("workflowId", "")),
+                "Status": str(data.get("status", "")),
+                "Stopped": ts(data.get("stoppedAt")),
+            }
+        )
+        print("\nExecution stopped.")
+
+    emit(result, use_json=ns.use_json, text_fn=text)

--- a/n8n-cli/n8n_cli/commands/import_wf.py
+++ b/n8n-cli/n8n_cli/commands/import_wf.py
@@ -1,0 +1,172 @@
+"""Import command — download workflows from n8n server to local JSON files."""
+
+import json
+import os
+import re
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.output import atomic_write, enc
+
+
+def _slugify(name: str) -> str:
+    """Convert a workflow name to a filesystem-safe slug."""
+    s = name.lower().strip()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"[\s_]+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-")[:80]
+
+
+def _generate_filename(wf_id: str, name: str) -> str:
+    """Generate a filename like 'daily-report_wf-1.json'."""
+    slug = _slugify(name)
+    if slug:
+        return f"{slug}_{wf_id}.json"
+    return f"{wf_id}.json"
+
+
+def _build_local_index(directory: str) -> dict[str, str]:
+    """Build a mapping of workflow ID → file path for all JSON files in directory."""
+    index: dict[str, str] = {}
+    if not os.path.isdir(directory):
+        return index
+    for name in os.listdir(directory):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(directory, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            if isinstance(data, dict) and data.get("id"):
+                index[data["id"]] = path
+        except (json.JSONDecodeError, OSError):
+            continue
+    return index
+
+
+def _should_update(local_updated: str | None, remote_updated: str | None) -> bool:
+    """Return True if remote is newer than local."""
+    if not local_updated:
+        return True
+    if not remote_updated:
+        return False
+    return remote_updated > local_updated
+
+
+def _fetch_all_workflows(client: Client, ids: list[str] | None) -> list[dict[str, Any]]:
+    """Fetch all workflows from server, with optional ID filter and pagination."""
+    all_wfs: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while True:
+        params = "limit=100"
+        if cursor:
+            params += f"&cursor={enc(cursor)}"
+        result = client.get(f"/workflows?{params}")
+        if not isinstance(result, dict):
+            break
+
+        items = result.get("data", [])
+        if not isinstance(items, list):
+            break
+
+        for wf in items:
+            if not isinstance(wf, dict):
+                continue
+            if ids and wf.get("id") not in ids:
+                continue
+            all_wfs.append(wf)
+
+        next_cursor = result.get("nextCursor")
+        if not next_cursor:
+            break
+        cursor = next_cursor
+
+    return all_wfs
+
+
+def cmd_import(client: Client, ns: Namespace) -> None:
+    """Import workflows from n8n server to local JSON files."""
+    directory = ns.dir
+
+    # Parse IDs filter
+    ids: list[str] | None = None
+    if ns.ids:
+        ids = [s.strip() for s in ns.ids.split(",") if s.strip()]
+
+    # Fetch workflows
+    workflows = _fetch_all_workflows(client, ids)
+    if not workflows:
+        print("No workflows found.")
+        return
+
+    os.makedirs(directory, exist_ok=True)
+    local_index = _build_local_index(directory)
+
+    created = 0
+    updated = 0
+    skipped = 0
+    errors = 0
+
+    for wf in workflows:
+        wf_id = wf.get("id", "")
+        wf_name = wf.get("name", "")
+        remote_updated = wf.get("updatedAt")
+
+        if not wf_id:
+            print(f"  skip: workflow with empty ID ({wf_name})")
+            skipped += 1
+            continue
+
+        # Find existing local file or generate new path
+        existing = local_index.get(wf_id)
+        if existing:
+            # Check if update needed
+            try:
+                with open(existing) as f:
+                    local_data = json.load(f)
+                local_updated = (
+                    local_data.get("updatedAt") if isinstance(local_data, dict) else None
+                )
+                if not _should_update(local_updated, remote_updated):
+                    if not ns.dry_run:
+                        print(f"  skip: {os.path.basename(existing)} (up to date)")
+                    skipped += 1
+                    continue
+            except (json.JSONDecodeError, OSError):
+                pass  # Treat as needs update
+
+            target_path = existing
+            op = "update"
+        else:
+            target_path = os.path.join(directory, _generate_filename(wf_id, wf_name))
+            op = "create"
+
+        if ns.dry_run:
+            print(f"  {op}: {os.path.basename(target_path)} ({wf_name})")
+            if op == "create":
+                created += 1
+            else:
+                updated += 1
+            continue
+
+        # Write file atomically
+        try:
+            content = json.dumps(wf, indent=2) + "\n"
+            atomic_write(target_path, content)
+            print(f"  {op}: {os.path.basename(target_path)} ({wf_name})")
+            if op == "create":
+                created += 1
+            else:
+                updated += 1
+        except OSError as e:
+            print(f"  error: {target_path}: {e}")
+            errors += 1
+
+    print(f"\nSummary: {created} created, {updated} updated, {skipped} skipped, {errors} errors")
+    if errors > 0:
+        raise SystemExit(1)

--- a/n8n-cli/n8n_cli/commands/raw.py
+++ b/n8n-cli/n8n_cli/commands/raw.py
@@ -1,0 +1,39 @@
+"""Raw API command — escape hatch for any endpoint."""
+
+import sys
+from argparse import Namespace
+
+from n8n_cli.client import Client
+from n8n_cli.errors import InputError
+from n8n_cli.output import emit_json, read_json_input
+
+
+def cmd_raw(client: Client, ns: Namespace) -> None:
+    """Make a raw API call."""
+    method = ns.method.upper()
+    path = ns.path
+    if not path.startswith("/"):
+        path = f"/{path}"
+
+    body = None
+    if ns.file:
+        if method in ("GET", "DELETE"):
+            print(f"Warning: request body ignored for {method}", file=sys.stderr)
+        else:
+            body = read_json_input(ns.file)
+
+    methods = {
+        "GET": lambda: client.get(path),
+        "POST": lambda: client.post(path, body),
+        "PUT": lambda: client.put(path, body),
+        "PATCH": lambda: client.patch(path, body),
+        "DELETE": lambda: client.delete(path),
+    }
+
+    fn = methods.get(method)
+    if fn is None:
+        raise InputError(f"Unsupported HTTP method: {method}")
+
+    result = fn()
+    if result is not None:
+        emit_json(result)

--- a/n8n-cli/n8n_cli/commands/tag.py
+++ b/n8n-cli/n8n_cli/commands/tag.py
@@ -1,0 +1,81 @@
+"""Tag management commands."""
+
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, ts
+
+
+def cmd_tag_list(client: Client, ns: Namespace) -> None:
+    """List all tags."""
+    result = client.get("/tags")
+
+    def text(data: dict[str, Any]) -> None:
+        items = data.get("data", data)
+        if not isinstance(items, list):
+            emit_json(data)
+            return
+        emit_table(
+            ["ID", "NAME", "CREATED", "UPDATED"],
+            [
+                [
+                    str(t.get("id", "")),
+                    str(t.get("name", "")),
+                    ts(t.get("createdAt")),
+                    ts(t.get("updatedAt")),
+                ]
+                for t in items
+                if isinstance(t, dict)
+            ],
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_tag_get(client: Client, ns: Namespace) -> None:
+    """Get a tag by ID."""
+    result = client.get(f"/tags/{enc(ns.id)}")
+
+    def text(data: dict[str, Any]) -> None:
+        emit_kv(
+            {
+                "ID": str(data.get("id", "")),
+                "Name": str(data.get("name", "")),
+                "Created": ts(data.get("createdAt")),
+                "Updated": ts(data.get("updatedAt")),
+            }
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_tag_create(client: Client, ns: Namespace) -> None:
+    """Create a tag."""
+    body = {"name": ns.name}
+    result = client.post("/tags", body)
+
+    def text(data: dict[str, Any]) -> None:
+        print(f"Created tag {data.get('name', '')} (id: {data.get('id', '')})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_tag_update(client: Client, ns: Namespace) -> None:
+    """Update a tag name."""
+    body = {"name": ns.name}
+    result = client.put(f"/tags/{enc(ns.id)}", body)
+
+    def text(data: dict[str, Any]) -> None:
+        print(f"Updated tag to {data.get('name', '')} (id: {data.get('id', '')})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_tag_delete(client: Client, ns: Namespace) -> None:
+    """Delete a tag by ID."""
+    client.delete(f"/tags/{enc(ns.id)}")
+    if ns.use_json:
+        emit_json({"deleted": True, "id": ns.id})
+    else:
+        print(f"Deleted tag {ns.id}")

--- a/n8n-cli/n8n_cli/commands/test_wf.py
+++ b/n8n-cli/n8n_cli/commands/test_wf.py
@@ -1,0 +1,237 @@
+"""Test command — trigger a workflow via its webhook and check results."""
+
+import json
+import time
+import urllib.error
+import urllib.request
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.errors import CLIError
+from n8n_cli.output import emit_json, emit_kv, enc
+
+
+class WebhookTestError(CLIError):
+    """Error during workflow test execution."""
+
+
+def _find_webhook_node(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Find the first webhook node in a workflow.
+
+    Prefers nodes named with '[CLI Test]' prefix, falls back to any webhook.
+    """
+    nodes = workflow.get("nodes", [])
+    cli_test_node = None
+    any_webhook = None
+
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        if node.get("type") != "n8n-nodes-base.webhook":
+            continue
+        name = node.get("name", "")
+        if name.startswith("[CLI Test]"):
+            cli_test_node = node
+            break
+        if any_webhook is None:
+            any_webhook = node
+
+    result = cli_test_node or any_webhook
+    if result is None:
+        wf_name = workflow.get("name", "")
+        wf_id = workflow.get("id", "")
+        raise WebhookTestError(f'No webhook node found in workflow "{wf_name}" ({wf_id})')
+    return result
+
+
+def _build_webhook_url(api_url: str, webhook_path: str) -> str:
+    """Build the production webhook URL from the API URL and webhook path."""
+    # Strip /api/v1 suffix to get the base n8n URL
+    base = api_url.rstrip("/")
+    if base.endswith("/api/v1"):
+        base = base[: -len("/api/v1")]
+    webhook_path = webhook_path.lstrip("/")
+    return f"{base}/webhook/{webhook_path}"
+
+
+def _call_webhook(
+    url: str,
+    method: str,
+    data: Any,
+    timeout: int,
+) -> tuple[int, str]:
+    """Send HTTP request to webhook, return (status, body)."""
+    body_bytes = None
+    headers: dict[str, str] = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    if data is not None:
+        body_bytes = json.dumps(data).encode()
+
+    req = urllib.request.Request(url, data=body_bytes, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode() if e.fp else ""
+        return e.code, body_text
+    except urllib.error.URLError as e:
+        raise WebhookTestError(f"Webhook request failed: {e.reason}") from e
+
+
+def _wait_for_execution(
+    client: Client,
+    workflow_id: str,
+    timeout_s: int,
+    poll_s: int = 1,
+) -> dict[str, Any]:
+    """Poll for the latest execution of a workflow to reach terminal status."""
+    # Brief delay for n8n to create the execution record
+    time.sleep(0.5)
+
+    # Get latest execution
+    result = client.get(f"/executions?workflowId={enc(workflow_id)}&limit=1&includeData=true")
+    items = result.get("data", []) if isinstance(result, dict) else []
+    if not items:
+        raise WebhookTestError(f"No execution found for workflow {workflow_id}")
+
+    execution: dict[str, Any] = items[0]
+    exec_id = execution.get("id", "")
+    terminal = {"success", "error", "crashed"}
+
+    if execution.get("status", "") in terminal:
+        return execution
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        time.sleep(poll_s)
+        resp = client.get(f"/executions/{enc(exec_id)}?includeData=true")
+        if isinstance(resp, dict) and resp.get("status", "") in terminal:
+            return resp
+
+    raise WebhookTestError(f"Timeout waiting for execution {exec_id} to complete")
+
+
+def cmd_test(client: Client, ns: Namespace) -> None:
+    """Test a workflow by triggering its webhook."""
+    workflow = client.get(f"/workflows/{enc(ns.id)}")
+    if not isinstance(workflow, dict):
+        raise WebhookTestError(f"Unexpected response for workflow {ns.id}")
+
+    wf_name = workflow.get("name", "")
+    wf_id = workflow.get("id", ns.id)
+
+    # Find webhook
+    webhook_node = _find_webhook_node(workflow)
+    params = webhook_node.get("parameters", {})
+    webhook_path = params.get("path", webhook_node.get("id", ""))
+    http_method = params.get("httpMethod", "POST")
+
+    webhook_url = _build_webhook_url(client.base_url, webhook_path)
+
+    # Dry run: just show the URL
+    if ns.dry_run:
+        if ns.use_json:
+            emit_json(
+                {
+                    "workflow": {"id": wf_id, "name": wf_name},
+                    "webhookURL": webhook_url,
+                    "httpMethod": http_method,
+                    "dryRun": True,
+                }
+            )
+        else:
+            emit_kv(
+                {
+                    "Workflow": f"{wf_name} ({wf_id})",
+                    "Webhook": webhook_node.get("name", ""),
+                    "URL": webhook_url,
+                    "Method": http_method,
+                }
+            )
+            print("\n(dry-run — no request sent)")
+        return
+
+    # Auto-activate if requested
+    if not workflow.get("active") and ns.activate:
+        client.post(f"/workflows/{enc(wf_id)}/activate")
+    elif not workflow.get("active"):
+        raise WebhookTestError(
+            f'Workflow "{wf_name}" ({wf_id}) is not active. Use --activate to auto-activate.'
+        )
+
+    # Parse data
+    data: Any = {}
+    if ns.data:
+        try:
+            data = json.loads(ns.data)
+        except json.JSONDecodeError as e:
+            raise WebhookTestError(f"Invalid JSON data: {e}") from None
+
+    # Call webhook
+    status_code, response_body = _call_webhook(webhook_url, http_method, data, ns.timeout)
+
+    # Optionally wait for execution
+    execution = None
+    if ns.wait_execution:
+        execution = _wait_for_execution(client, wf_id, ns.execution_timeout)
+
+    # Output
+    if ns.use_json:
+        out: dict[str, Any] = {
+            "workflow": {"id": wf_id, "name": wf_name},
+            "webhookURL": webhook_url,
+            "httpStatus": status_code,
+            "success": 200 <= status_code < 300,
+        }
+        try:
+            out["response"] = json.loads(response_body)
+        except (json.JSONDecodeError, ValueError):
+            out["response"] = response_body
+        if execution:
+            out["execution"] = {
+                "id": execution.get("id", ""),
+                "status": execution.get("status", ""),
+            }
+            out["success"] = out["success"] and execution.get("status") == "success"
+        emit_json(out)
+    else:
+        print(f"Testing workflow: {wf_name} ({wf_id})")
+        print(f"  Webhook: {webhook_node.get('name', '')}")
+        print(f"  URL: {webhook_url}")
+        print()
+        print(f"  Status: {status_code}")
+        if response_body:
+            try:
+                pretty = json.dumps(json.loads(response_body), indent=2)
+                print(f"  Response:\n  {pretty}")
+            except (json.JSONDecodeError, ValueError):
+                display = response_body[:500] + "..." if len(response_body) > 500 else response_body
+                print(f"  Response: {display}")
+
+        if execution:
+            print()
+            exec_status = execution.get("status", "")
+            print(f"Execution: {execution.get('id', '')}")
+            print(f"  Status: {exec_status}")
+            err_data = (
+                execution.get("data", {}).get("resultData", {}).get("error")
+                if isinstance(execution.get("data"), dict)
+                else None
+            )
+            if isinstance(err_data, dict):
+                print(f"  Error: {err_data.get('message', '')}")
+                if err_data.get("node"):
+                    print(f"  Failed node: {err_data['node']}")
+
+        success = 200 <= status_code < 300
+        if execution:
+            success = success and execution.get("status") == "success"
+        print()
+        if success:
+            print("✓ Test passed")
+        else:
+            print("✗ Test failed")
+            raise WebhookTestError("Test failed")

--- a/n8n-cli/n8n_cli/commands/workflow.py
+++ b/n8n-cli/n8n_cli/commands/workflow.py
@@ -1,0 +1,132 @@
+"""Workflow management commands."""
+
+import urllib.parse
+from argparse import Namespace
+from typing import Any
+
+from n8n_cli.client import Client
+from n8n_cli.errors import InputError
+from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, read_json_input, ts
+
+
+def _text_summary(wf: dict[str, Any]) -> None:
+    """Print a compact workflow summary."""
+    tags = wf.get("tags", [])
+    tag_str = ", ".join(t.get("name", "") for t in tags if isinstance(t, dict)) if tags else "-"
+    emit_kv(
+        {
+            "ID": str(wf.get("id", "")),
+            "Name": str(wf.get("name", "")),
+            "Active": "yes" if wf.get("active") else "no",
+            "Nodes": str(len(wf.get("nodes", []))),
+            "Tags": tag_str,
+            "Updated": ts(wf.get("updatedAt")),
+        }
+    )
+
+
+def cmd_workflow_list(client: Client, ns: Namespace) -> None:
+    """List all workflows with optional filters."""
+    params: dict[str, str] = {}
+    if ns.active is not None:
+        params["active"] = "true" if ns.active else "false"
+    if ns.tags:
+        params["tags"] = ns.tags
+    if ns.name:
+        params["name"] = ns.name
+    if ns.limit is not None:
+        params["limit"] = str(ns.limit)
+
+    qs = urllib.parse.urlencode(params)
+    path = f"/workflows?{qs}" if qs else "/workflows"
+    result = client.get(path)
+
+    def text(data: dict[str, Any]) -> None:
+        items = data.get("data", data)
+        if not isinstance(items, list):
+            emit_json(data)
+            return
+        emit_table(
+            ["ID", "NAME", "ACTIVE", "TAGS", "UPDATED"],
+            [
+                [
+                    str(w.get("id", "")),
+                    str(w.get("name", "")),
+                    "yes" if w.get("active") else "no",
+                    ", ".join(
+                        t.get("name", "") for t in (w.get("tags") or []) if isinstance(t, dict)
+                    )
+                    or "-",
+                    ts(w.get("updatedAt")),
+                ]
+                for w in items
+                if isinstance(w, dict)
+            ],
+        )
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_workflow_get(client: Client, ns: Namespace) -> None:
+    """Get a workflow by ID — always outputs full JSON for round-trip editing."""
+    result = client.get(f"/workflows/{enc(ns.id)}")
+    emit_json(result)
+
+
+def cmd_workflow_create(client: Client, ns: Namespace) -> None:
+    """Create a workflow from a JSON definition."""
+    body = read_json_input(ns.file)
+    if not isinstance(body, dict):
+        raise InputError("Workflow JSON must be an object, not an array or scalar")
+    result = client.post("/workflows", body)
+
+    def text(data: dict[str, Any]) -> None:
+        print(f"Created workflow {data.get('name', '')} (id: {data.get('id', '')})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_workflow_update(client: Client, ns: Namespace) -> None:
+    """Update a workflow from a full JSON definition.
+
+    Strips id, createdAt, updatedAt, tags, shared, pinData before PUT.
+    """
+    body = read_json_input(ns.file)
+    if not isinstance(body, dict):
+        raise InputError("Workflow JSON must be an object, not an array or scalar")
+    for key in ("id", "createdAt", "updatedAt", "tags", "shared", "pinData"):
+        body.pop(key, None)
+    result = client.put(f"/workflows/{enc(ns.id)}", body)
+    emit(result, use_json=ns.use_json, text_fn=_text_summary)
+
+
+def cmd_workflow_delete(client: Client, ns: Namespace) -> None:
+    """Delete a workflow by ID."""
+    result = client.delete(f"/workflows/{enc(ns.id)}")
+
+    def text(data: dict[str, Any]) -> None:
+        name = data.get("name", "") if isinstance(data, dict) else ""
+        print(f"Deleted workflow {name} (id: {ns.id})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def _cmd_toggle(client: Client, ns: Namespace, *, action: str, endpoint: str) -> None:
+    """Activate or deactivate a workflow via POST."""
+    result = client.post(f"/workflows/{enc(ns.id)}/{endpoint}")
+
+    def text(data: dict[str, object]) -> None:
+        past = f"{action}d" if action.endswith("e") else f"{action}ed"
+        print(f"{past.capitalize()} workflow {data.get('name', '')} (id: {data.get('id', ns.id)})")
+
+    emit(result, use_json=ns.use_json, text_fn=text)
+
+
+def cmd_workflow_activate(client: Client, ns: Namespace) -> None:
+    """Activate a workflow."""
+    _cmd_toggle(client, ns, action="activate", endpoint="activate")
+
+
+def cmd_workflow_deactivate(client: Client, ns: Namespace) -> None:
+    """Deactivate a workflow."""
+    _cmd_toggle(client, ns, action="deactivate", endpoint="deactivate")

--- a/n8n-cli/n8n_cli/config.py
+++ b/n8n-cli/n8n_cli/config.py
@@ -1,0 +1,118 @@
+"""Configuration loading and credential resolution."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CONFIG_DIR = Path.home() / ".config" / "n8n-cli"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+def load_config(config_path: str | None = None) -> dict[str, Any]:
+    """Load configuration from JSON file.
+
+    Config file (~/.config/n8n-cli/config.json):
+    {
+        "api_url": "https://your-n8n.example.com",
+        "api_key": "your-api-key",
+        "api_key_command": "rbw get n8n-api-key",
+        "api_url_command": "rbw get n8n-api-url",
+        "timeout": 30
+    }
+    """
+    path = Path(config_path) if config_path else CONFIG_FILE
+    if not path.exists():
+        return {}
+    try:
+        with path.open() as f:
+            result: dict[str, Any] = json.load(f)
+            return result
+    except json.JSONDecodeError as e:
+        print(f"Warning: invalid JSON in config file {path}: {e}", file=sys.stderr)
+        return {}
+
+
+def run_secret_command(command: str) -> str | None:
+    """Execute a shell command to retrieve a secret value."""
+    try:
+        result = subprocess.run(  # noqa: S602
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        return result.stdout.strip() or None
+    except subprocess.TimeoutExpired:
+        print(f"Warning: command timed out after 30s: {command}", file=sys.stderr)
+        return None
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: command failed: {command}: {e}", file=sys.stderr)
+        if e.stderr:
+            print(f"  stderr: {e.stderr.strip()}", file=sys.stderr)
+        return None
+
+
+def _resolve_value(
+    env_var: str,
+    cfg: dict[str, Any],
+    command_key: str,
+    direct_key: str,
+) -> str | None:
+    """Resolve a value from env var > config command > config direct."""
+    value = os.environ.get(env_var)
+    if value:
+        return value
+
+    cmd = cfg.get(command_key)
+    if isinstance(cmd, str) and cmd:
+        value = run_secret_command(cmd)
+        if value:
+            return value
+
+    direct = cfg.get(direct_key)
+    if isinstance(direct, str) and direct:
+        return direct
+
+    return None
+
+
+def _resolve_timeout(cfg: dict[str, Any]) -> int:
+    """Resolve timeout from env > config > default(30)."""
+    timeout = 30
+    timeout_str = os.environ.get("N8N_API_TIMEOUT")
+    if timeout_str:
+        try:
+            timeout = int(timeout_str)
+        except ValueError:
+            print(
+                f"Warning: invalid N8N_API_TIMEOUT={timeout_str!r}, using default",
+                file=sys.stderr,
+            )
+    elif cfg.get("timeout") is not None:
+        try:
+            timeout = int(cfg["timeout"])
+        except (ValueError, TypeError):
+            print(
+                f"Warning: invalid timeout in config: {cfg['timeout']!r}, using default",
+                file=sys.stderr,
+            )
+    return timeout
+
+
+def resolve_credentials(
+    config_path: str | None = None,
+) -> tuple[str | None, str | None, int]:
+    """Resolve API URL, key, and timeout.
+
+    Priority: env vars > config *_command > config direct values.
+    """
+    cfg = load_config(config_path)
+    api_url = _resolve_value("N8N_API_URL", cfg, "api_url_command", "api_url")
+    api_key = _resolve_value("N8N_API_KEY", cfg, "api_key_command", "api_key")
+    timeout = _resolve_timeout(cfg)
+    return api_url, api_key, timeout

--- a/n8n-cli/n8n_cli/errors.py
+++ b/n8n-cli/n8n_cli/errors.py
@@ -1,0 +1,42 @@
+"""Custom error types for user-facing messages."""
+
+from http import HTTPStatus
+
+# Extra hints for status codes where the standard phrase isn't enough.
+_HINTS: dict[int, str] = {
+    401: "check your API key",
+    403: "insufficient permissions",
+}
+
+
+class CLIError(Exception):
+    """Base for all errors that should be shown to the user and exit 1."""
+
+
+class InputError(CLIError):
+    """Bad user-supplied input (file not found, invalid JSON, bad option)."""
+
+
+class APIError(CLIError):
+    """Error returned by the n8n API."""
+
+    def __init__(self, status: int, message: str) -> None:
+        self.status = status
+        try:
+            phrase = HTTPStatus(status).phrase
+        except ValueError:
+            phrase = f"HTTP {status}"
+        hint = _HINTS.get(status)
+        label = f"{phrase} ({hint})" if hint else phrase
+        super().__init__(f"{label}: {message}" if message else label)
+
+
+class ConnectionError_(CLIError):
+    """Cannot reach the n8n instance."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"Cannot connect to n8n: {reason}")
+
+
+class ConfigError(CLIError):
+    """Missing or invalid configuration."""

--- a/n8n-cli/n8n_cli/main.py
+++ b/n8n-cli/n8n_cli/main.py
@@ -1,0 +1,308 @@
+"""CLI entry point and command dispatch."""
+
+import argparse
+import sys
+from collections.abc import Callable
+
+from n8n_cli.client import Client
+from n8n_cli.commands import (
+    apply,
+    credential,
+    datatable,
+    execution,
+    import_wf,
+    raw,
+    tag,
+    test_wf,
+    workflow,
+)
+from n8n_cli.config import CONFIG_FILE, resolve_credentials
+from n8n_cli.errors import CLIError, ConfigError
+
+Handler = Callable[[Client, argparse.Namespace], None]
+
+
+def _make_client() -> Client:
+    """Create a client from environment variables or config file."""
+    api_url, api_key, timeout = resolve_credentials()
+    if not api_url or not api_key:
+        missing = []
+        if not api_url:
+            missing.append("N8N_API_URL")
+        if not api_key:
+            missing.append("N8N_API_KEY")
+        raise ConfigError(f"{', '.join(missing)} not set. Set env vars or configure {CONFIG_FILE}")
+    return Client(api_url, api_key, timeout)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="n8n-cli", description="Python CLI for n8n API")
+    p.add_argument("-j", "--json", action="store_true", dest="use_json", help="Output JSON")
+    sub = p.add_subparsers(dest="command")
+
+    # -- credential ----------------------------------------------------------
+    cred = sub.add_parser("credential", help="Manage credentials")
+    cred_sub = cred.add_subparsers(dest="subcmd")
+
+    cred_sub.add_parser("list", help="List all credentials")
+
+    s = cred_sub.add_parser("get", help="Get credential metadata")
+    s.add_argument("id", help="Credential ID")
+
+    s = cred_sub.add_parser("create", help="Create credential from JSON")
+    s.add_argument("file", help="JSON file or - for stdin")
+
+    s = cred_sub.add_parser("update", help="Update credential")
+    s.add_argument("id", help="Credential ID")
+    s.add_argument("file", help="JSON file or - for stdin")
+
+    s = cred_sub.add_parser("delete", help="Delete credential")
+    s.add_argument("id", help="Credential ID")
+
+    s = cred_sub.add_parser("test", help="Test credential")
+    s.add_argument("id", help="Credential ID")
+
+    s = cred_sub.add_parser("schema", help="Get credential type schema")
+    s.add_argument("type", help="Credential type name")
+
+    # -- workflow -------------------------------------------------------------
+    wf = sub.add_parser("workflow", help="Manage workflows")
+    wf_sub = wf.add_subparsers(dest="subcmd")
+
+    s = wf_sub.add_parser("list", help="List all workflows")
+    active_grp = s.add_mutually_exclusive_group()
+    active_grp.add_argument("--active", dest="active", action="store_true", default=None)
+    active_grp.add_argument("--inactive", dest="active", action="store_false")
+    s.add_argument("--tags", help="Filter by tags (comma-separated)")
+    s.add_argument("--name", help="Filter by name (substring match)")
+    s.add_argument("--limit", type=int, help="Max results")
+
+    s = wf_sub.add_parser("get", help="Get full workflow JSON")
+    s.add_argument("id", help="Workflow ID")
+
+    s = wf_sub.add_parser("create", help="Create workflow from JSON")
+    s.add_argument("file", help="JSON file or - for stdin")
+
+    s = wf_sub.add_parser("update", help="Update workflow from JSON")
+    s.add_argument("id", help="Workflow ID")
+    s.add_argument("file", help="JSON file or - for stdin")
+
+    s = wf_sub.add_parser("delete", help="Delete workflow")
+    s.add_argument("id", help="Workflow ID")
+
+    s = wf_sub.add_parser("activate", help="Activate workflow")
+    s.add_argument("id", help="Workflow ID")
+
+    s = wf_sub.add_parser("deactivate", help="Deactivate workflow")
+    s.add_argument("id", help="Workflow ID")
+
+    # -- execution ------------------------------------------------------------
+    exc = sub.add_parser("execution", help="Manage executions")
+    exc_sub = exc.add_subparsers(dest="subcmd")
+
+    s = exc_sub.add_parser("get", help="Get execution details")
+    s.add_argument("id", help="Execution ID")
+    s.add_argument("--show-data", action="store_true", help="Include full execution data in output")
+
+    s = exc_sub.add_parser("list", help="List executions")
+    s.add_argument("--workflow", help="Filter by workflow ID")
+    s.add_argument("--status", help="Filter by status")
+    s.add_argument("--limit", type=int, default=20, help="Max results (default: 20)")
+
+    s = exc_sub.add_parser("delete", help="Delete execution")
+    s.add_argument("id", help="Execution ID")
+
+    s = exc_sub.add_parser("retry", help="Retry a failed execution")
+    s.add_argument("id", help="Execution ID")
+    s.add_argument(
+        "--load-workflow", action="store_true", help="Retry with latest workflow version"
+    )
+
+    s = exc_sub.add_parser("stop", help="Stop a running execution")
+    s.add_argument("id", help="Execution ID")
+
+    # -- datatable ------------------------------------------------------------
+    dt = sub.add_parser("datatable", help="Manage data tables")
+    dt_sub = dt.add_subparsers(dest="subcmd")
+
+    s = dt_sub.add_parser("list", help="List all data tables")
+    s.add_argument("--filter", help="Filter conditions (JSON)")
+    s.add_argument("--sort", help="Sort: field:asc or field:desc")
+    s.add_argument("--limit", type=int, help="Max results")
+
+    s = dt_sub.add_parser("get", help="Get data table by ID")
+    s.add_argument("id", help="Data table ID")
+
+    s = dt_sub.add_parser("create", help="Create data table from JSON")
+    s.add_argument("file", help="JSON file or - for stdin")
+
+    s = dt_sub.add_parser("update", help="Rename data table")
+    s.add_argument("id", help="Data table ID")
+    s.add_argument("name", help="New name")
+
+    s = dt_sub.add_parser("delete", help="Delete data table")
+    s.add_argument("id", help="Data table ID")
+
+    s = dt_sub.add_parser("rows", help="List rows")
+    s.add_argument("id", help="Data table ID")
+    s.add_argument("--filter", help="Filter conditions (JSON)")
+    s.add_argument("--sort", help="Sort: col:asc or col:desc")
+    s.add_argument("--search", help="Full-text search")
+    s.add_argument("--limit", type=int, help="Max results")
+
+    s = dt_sub.add_parser("insert", help="Insert rows from JSON")
+    s.add_argument("id", help="Data table ID")
+    s.add_argument("file", help="JSON file or - for stdin")
+    s.add_argument(
+        "--return",
+        dest="return_type",
+        default="count",
+        choices=["count", "id", "all"],
+        help="Return type (default: count)",
+    )
+
+    s = dt_sub.add_parser("update-rows", help="Update rows matching filter")
+    s.add_argument("id", help="Data table ID")
+    s.add_argument("file", help="JSON file or - for stdin")
+
+    s = dt_sub.add_parser("upsert", help="Upsert a row")
+    s.add_argument("id", help="Data table ID")
+    s.add_argument("file", help="JSON file or - for stdin")
+
+    s = dt_sub.add_parser("delete-rows", help="Delete rows matching filter")
+    s.add_argument("id", help="Data table ID")
+    s.add_argument("--filter", required=True, help="Filter conditions (JSON, required)")
+    s.add_argument("--return-data", action="store_true", help="Return deleted rows")
+    s.add_argument("--dry-run", action="store_true", help="Preview without deleting")
+
+    # -- tag ------------------------------------------------------------------
+    tg = sub.add_parser("tag", help="Manage tags")
+    tg_sub = tg.add_subparsers(dest="subcmd")
+
+    tg_sub.add_parser("list", help="List all tags")
+
+    s = tg_sub.add_parser("get", help="Get tag by ID")
+    s.add_argument("id", help="Tag ID")
+
+    s = tg_sub.add_parser("create", help="Create a tag")
+    s.add_argument("name", help="Tag name")
+
+    s = tg_sub.add_parser("update", help="Update a tag name")
+    s.add_argument("id", help="Tag ID")
+    s.add_argument("name", help="New tag name")
+
+    s = tg_sub.add_parser("delete", help="Delete a tag")
+    s.add_argument("id", help="Tag ID")
+
+    # -- raw ------------------------------------------------------------------
+    s = sub.add_parser("raw", help="Raw API call (escape hatch)")
+    s.add_argument("method", metavar="METHOD", help="HTTP method")
+    s.add_argument("path", metavar="PATH", help="API path")
+    s.add_argument("file", nargs="?", metavar="FILE", help="JSON body file or - for stdin")
+
+    # -- test -----------------------------------------------------------------
+    s = sub.add_parser("test", help="Test a workflow via its webhook")
+    s.add_argument("id", help="Workflow ID")
+    s.add_argument("-d", "--data", help="JSON data to send to the webhook")
+    s.add_argument("--timeout", type=int, default=30, help="HTTP timeout in seconds (default: 30)")
+    s.add_argument(
+        "--wait-execution",
+        action="store_true",
+        help="Wait for execution to complete and show results",
+    )
+    s.add_argument(
+        "--execution-timeout",
+        type=int,
+        default=300,
+        help="Max seconds to wait for execution (default: 300)",
+    )
+    s.add_argument("--activate", action="store_true", help="Auto-activate the workflow if inactive")
+    s.add_argument("--dry-run", action="store_true", help="Show webhook URL without executing")
+
+    # -- import ---------------------------------------------------------------
+    s = sub.add_parser("import", help="Import workflows from n8n to local files")
+    s.add_argument(
+        "-d", "--dir", default="./definitions", help="Target directory (default: ./definitions)"
+    )
+    s.add_argument("--ids", help="Comma-separated workflow IDs to import (empty = all)")
+    s.add_argument("--dry-run", action="store_true", help="Preview without writing files")
+
+    # -- apply ----------------------------------------------------------------
+    s = sub.add_parser("apply", help="Apply local workflow files to n8n server")
+    s.add_argument(
+        "-d",
+        "--dir",
+        default="./definitions",
+        help="Definitions directory (default: ./definitions)",
+    )
+    s.add_argument("--ids", help="Comma-separated workflow IDs to process")
+    s.add_argument("--dry-run", action="store_true", help="Preview changes without applying")
+    s.add_argument("--force", action="store_true", help="Override conflict detection")
+
+    return p
+
+
+_HANDLERS: dict[tuple[str, str | None], Handler] = {
+    ("credential", "list"): credential.cmd_credential_list,
+    ("credential", "get"): credential.cmd_credential_get,
+    ("credential", "create"): credential.cmd_credential_create,
+    ("credential", "update"): credential.cmd_credential_update,
+    ("credential", "delete"): credential.cmd_credential_delete,
+    ("credential", "test"): credential.cmd_credential_test,
+    ("credential", "schema"): credential.cmd_credential_schema,
+    ("workflow", "list"): workflow.cmd_workflow_list,
+    ("workflow", "get"): workflow.cmd_workflow_get,
+    ("workflow", "create"): workflow.cmd_workflow_create,
+    ("workflow", "update"): workflow.cmd_workflow_update,
+    ("workflow", "delete"): workflow.cmd_workflow_delete,
+    ("workflow", "activate"): workflow.cmd_workflow_activate,
+    ("workflow", "deactivate"): workflow.cmd_workflow_deactivate,
+    ("execution", "get"): execution.cmd_execution_get,
+    ("execution", "list"): execution.cmd_execution_list,
+    ("execution", "delete"): execution.cmd_execution_delete,
+    ("execution", "retry"): execution.cmd_execution_retry,
+    ("execution", "stop"): execution.cmd_execution_stop,
+    ("tag", "list"): tag.cmd_tag_list,
+    ("tag", "get"): tag.cmd_tag_get,
+    ("tag", "create"): tag.cmd_tag_create,
+    ("tag", "update"): tag.cmd_tag_update,
+    ("tag", "delete"): tag.cmd_tag_delete,
+    ("datatable", "list"): datatable.cmd_datatable_list,
+    ("datatable", "get"): datatable.cmd_datatable_get,
+    ("datatable", "create"): datatable.cmd_datatable_create,
+    ("datatable", "update"): datatable.cmd_datatable_update,
+    ("datatable", "delete"): datatable.cmd_datatable_delete,
+    ("datatable", "rows"): datatable.cmd_datatable_rows,
+    ("datatable", "insert"): datatable.cmd_datatable_insert,
+    ("datatable", "update-rows"): datatable.cmd_datatable_update_rows,
+    ("datatable", "upsert"): datatable.cmd_datatable_upsert,
+    ("datatable", "delete-rows"): datatable.cmd_datatable_delete_rows,
+    ("raw", None): raw.cmd_raw,
+    ("test", None): test_wf.cmd_test,
+    ("import", None): import_wf.cmd_import,
+    ("apply", None): apply.cmd_apply,
+}
+
+
+def main() -> None:
+    parser = _build_parser()
+    ns = parser.parse_args()
+
+    if not ns.command:
+        parser.print_help()
+        sys.exit(0)
+
+    # For grouped commands, check subcmd
+    key = (ns.command, getattr(ns, "subcmd", None))
+    handler = _HANDLERS.get(key)
+    if handler is None:
+        # subcmd missing — print subcommand help
+        parser.parse_args([ns.command, "--help"])
+        return
+
+    try:
+        client = _make_client()
+        handler(client, ns)
+    except CLIError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/n8n-cli/n8n_cli/output.py
+++ b/n8n-cli/n8n_cli/output.py
@@ -1,0 +1,101 @@
+"""Output formatting helpers."""
+
+import json
+import os
+import sys
+import tempfile
+import urllib.parse
+from typing import Any
+
+from n8n_cli.errors import InputError
+
+
+def emit_json(data: Any) -> None:
+    """Print JSON to stdout."""
+    json.dump(data, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def emit_kv(pairs: dict[str, str]) -> None:
+    """Print key-value pairs, aligned."""
+    if not pairs:
+        return
+    width = max(len(k) for k in pairs) + 1
+    for k, v in pairs.items():
+        print(f"{k + ':':<{width}} {v}")
+
+
+def emit_table(headers: list[str], rows: list[list[str]]) -> None:
+    """Print a compact text table."""
+    if not rows:
+        print("(none)")
+        return
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            if i < len(widths):
+                widths[i] = max(widths[i], len(cell))
+    fmt = "  ".join(f"{{:<{w}}}" for w in widths)
+    print(fmt.format(*headers))
+    print(fmt.format(*("-" * w for w in widths)))
+    for row in rows:
+        padded = row + [""] * (len(headers) - len(row))
+        print(fmt.format(*padded))
+
+
+def emit(data: Any, *, use_json: bool, text_fn: Any = None) -> None:
+    """Unified output: JSON if requested, else call text_fn, else fallback to JSON.
+
+    text_fn receives the data and should print text output.
+    If text_fn is None or data is not a dict, falls back to JSON.
+    """
+    if use_json or text_fn is None or not isinstance(data, dict):
+        emit_json(data)
+    else:
+        text_fn(data)
+
+
+def read_json_input(path: str) -> Any:
+    """Read JSON from a file path or '-' for stdin."""
+    try:
+        if path == "-":
+            return json.load(sys.stdin)
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        raise InputError(f"File not found: {path}") from None
+    except json.JSONDecodeError as e:
+        source = "stdin" if path == "-" else path
+        raise InputError(f"Invalid JSON in {source}: {e}") from None
+
+
+def ts(value: str | None) -> str:
+    """Format an ISO timestamp to short form, or '-' if missing."""
+    if not value:
+        return "-"
+    return value[:19].replace("T", " ")
+
+
+def enc(value: str) -> str:
+    """URL-encode a path component."""
+    return urllib.parse.quote(value, safe="")
+
+
+def atomic_write(path: str, content: str) -> None:
+    """Write content to a file atomically via temp file + rename.
+
+    Writes to a temp file in the same directory, then renames. This
+    ensures the target file is never left in a partial/corrupt state.
+    """
+    directory = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=directory, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/n8n-cli/pyproject.toml
+++ b/n8n-cli/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "n8n-cli"
+version = "0.1.0"
+description = "Python CLI for n8n API: credentials, full workflow JSON, execution data, raw API calls"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+n8n-cli = "n8n_cli.main:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["n8n_cli"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+
+[tool.mypy]
+python_version = "3.13"
+warn_return_any = true
+warn_unused_configs = true

--- a/n8n-cli/tests/conftest.py
+++ b/n8n-cli/tests/conftest.py
@@ -1,0 +1,311 @@
+"""Shared fixtures — fake n8n API server and CLI test helpers."""
+
+import json
+import threading
+from collections.abc import Generator
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from n8n_cli.main import main
+
+# ---------------------------------------------------------------------------
+# Realistic payloads modelled on actual n8n v1 API responses
+# ---------------------------------------------------------------------------
+
+CREDENTIAL_1 = {
+    "id": "42",
+    "name": "My Slack Token",
+    "type": "slackApi",
+    "createdAt": "2025-01-10T08:00:00.000Z",
+    "updatedAt": "2025-03-01T12:30:00.000Z",
+}
+
+CREDENTIAL_SCHEMA = {
+    "additionalProperties": False,
+    "properties": {
+        "accessToken": {"type": "string"},
+    },
+    "required": ["accessToken"],
+}
+
+WORKFLOW_1 = {
+    "id": "wf-1",
+    "name": "Daily Report",
+    "active": True,
+    "nodes": [
+        {"type": "n8n-nodes-base.start", "name": "Start"},
+        {"type": "n8n-nodes-base.httpRequest", "name": "Fetch"},
+    ],
+    "connections": {},
+    "tags": [{"name": "production"}],
+    "createdAt": "2025-02-01T09:00:00.000Z",
+    "updatedAt": "2025-03-10T16:45:00.000Z",
+}
+
+EXECUTION_1 = {
+    "id": "exec-100",
+    "workflowId": "wf-1",
+    "status": "success",
+    "mode": "trigger",
+    "startedAt": "2025-03-14T10:00:00.000Z",
+    "stoppedAt": "2025-03-14T10:00:05.000Z",
+    "data": {
+        "resultData": {
+            "lastNodeExecuted": "Fetch",
+            "runData": {
+                "Start": [{"executionTime": 2}],
+                "Fetch": [{"executionTime": 150}],
+            },
+        },
+    },
+}
+
+DATATABLE_1 = {
+    "id": "dt-1",
+    "name": "Contacts",
+    "columns": [
+        {"name": "name", "type": "string"},
+        {"name": "email", "type": "string"},
+    ],
+    "createdAt": "2025-03-01T10:00:00.000Z",
+    "updatedAt": "2025-03-14T08:00:00.000Z",
+}
+
+ROW_1 = {"id": "row-1", "name": "Alice", "email": "alice@example.com"}
+ROW_2 = {"id": "row-2", "name": "Bob", "email": "bob@example.com"}
+
+TAG_1 = {
+    "id": "tag-1",
+    "name": "production",
+    "createdAt": "2025-01-05T10:00:00.000Z",
+    "updatedAt": "2025-02-20T14:00:00.000Z",
+}
+
+WORKFLOW_WEBHOOK = {
+    "id": "wf-2",
+    "name": "Webhook Test",
+    "active": True,
+    "nodes": [
+        {
+            "id": "node-1",
+            "name": "[CLI Test] Entry",
+            "type": "n8n-nodes-base.webhook",
+            "typeVersion": 2.1,
+            "position": [0, 0],
+            "parameters": {"httpMethod": "POST", "path": "test-hook"},
+            "webhookId": "test-hook",
+        },
+    ],
+    "connections": {},
+    "tags": [],
+    "createdAt": "2025-02-01T09:00:00.000Z",
+    "updatedAt": "2025-03-10T16:45:00.000Z",
+}
+
+EXECUTION_RETRY_RESULT = {
+    "id": "exec-101",
+    "workflowId": "wf-1",
+    "status": "running",
+    "mode": "retry",
+    "startedAt": "2025-03-14T11:00:00.000Z",
+}
+
+EXECUTION_STOPPED = {
+    "id": "exec-100",
+    "workflowId": "wf-1",
+    "status": "canceled",
+    "mode": "trigger",
+    "startedAt": "2025-03-14T10:00:00.000Z",
+    "stoppedAt": "2025-03-14T10:00:02.000Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fake n8n API server
+# ---------------------------------------------------------------------------
+
+
+class FakeN8NHandler(BaseHTTPRequestHandler):
+    """Route requests to canned responses based on method + path."""
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        pass  # silence server logs during tests
+
+    def _send(self, code: int, body: Any) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", 0))
+        return self.rfile.read(length)
+
+    # -- routing -------------------------------------------------------------
+
+    def do_GET(self) -> None:  # noqa: N802
+        p = self.path.split("?")[0]  # strip query string for matching
+
+        routes: dict[str, Any] = {
+            "/api/v1/credentials": {"data": [CREDENTIAL_1]},
+            "/api/v1/credentials/42": CREDENTIAL_1,
+            "/api/v1/credentials/schema/slackApi": CREDENTIAL_SCHEMA,
+            "/api/v1/workflows": {"data": [WORKFLOW_1, WORKFLOW_WEBHOOK]},
+            "/api/v1/workflows/wf-1": WORKFLOW_1,
+            "/api/v1/workflows/wf-2": WORKFLOW_WEBHOOK,
+            "/api/v1/executions/exec-100": EXECUTION_1,
+            "/api/v1/executions": {"data": [EXECUTION_1]},
+            "/api/v1/tags": {"data": [TAG_1]},
+            "/api/v1/tags/tag-1": TAG_1,
+            "/api/v1/data-tables": {"data": [DATATABLE_1]},
+            "/api/v1/data-tables/dt-1": DATATABLE_1,
+            "/api/v1/data-tables/dt-1/rows": {"data": [ROW_1, ROW_2]},
+            # raw escape hatch
+            "/api/v1/custom/endpoint": {"ok": True},
+        }
+        body = routes.get(p)
+        if body is not None:
+            self._send(200, body)
+        else:
+            self._send(404, {"message": f"Not found: {p}"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._read_body()
+        p = self.path.split("?")[0]
+
+        # Webhook endpoint (outside /api/v1)
+        if p == "/webhook/test-hook":
+            self._send(200, {"success": True, "received": True})
+            return
+
+        routes: dict[str, Any] = {
+            "/api/v1/credentials": {**CREDENTIAL_1, "id": "43", "name": "New Cred"},
+            "/api/v1/credentials/42/test": {"status": "ok", "message": "Connection successful"},
+            "/api/v1/workflows": {**WORKFLOW_1, "id": "wf-2", "name": "New Workflow"},
+            "/api/v1/workflows/wf-1/activate": {**WORKFLOW_1, "active": True},
+            "/api/v1/workflows/wf-1/deactivate": {**WORKFLOW_1, "active": False},
+            "/api/v1/workflows/wf-2/activate": {**WORKFLOW_WEBHOOK, "active": True},
+            "/api/v1/executions/exec-100/retry": EXECUTION_RETRY_RESULT,
+            "/api/v1/executions/exec-100/stop": EXECUTION_STOPPED,
+            "/api/v1/tags": {**TAG_1, "id": "tag-2", "name": "staging"},
+            "/api/v1/data-tables": {**DATATABLE_1, "id": "dt-2", "name": "New Table"},
+            "/api/v1/data-tables/dt-1/rows": {"created": 2},
+            "/api/v1/data-tables/dt-1/rows/upsert": {"updated": 1},
+        }
+        body = routes.get(p)
+        if body is not None:
+            self._send(200, body)
+        else:
+            self._send(404, {"message": f"Not found: {p}"})
+
+    def do_PUT(self) -> None:  # noqa: N802
+        raw = self._read_body()
+        p = self.path.split("?")[0]
+
+        if p == "/api/v1/workflows/wf-1":
+            sent = json.loads(raw)
+            # Verify round-trip stripping: these keys must NOT be in the body
+            for forbidden in ("id", "createdAt", "updatedAt", "tags", "shared", "pinData"):
+                assert forbidden not in sent, f"workflow update should strip '{forbidden}'"
+            self._send(200, {**WORKFLOW_1, "name": sent.get("name", WORKFLOW_1["name"])})
+        elif p == "/api/v1/tags/tag-1":
+            sent = json.loads(raw)
+            self._send(200, {**TAG_1, "name": sent.get("name", TAG_1["name"])})
+        else:
+            self._send(404, {"message": f"Not found: {p}"})
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        self._read_body()
+        p = self.path.split("?")[0]
+
+        routes: dict[str, Any] = {
+            "/api/v1/credentials/42": {**CREDENTIAL_1, "name": "Updated Cred"},
+            "/api/v1/data-tables/dt-1": {**DATATABLE_1, "name": "Renamed"},
+            "/api/v1/data-tables/dt-1/rows/update": {"updated": 1},
+        }
+        body = routes.get(p)
+        if body is not None:
+            self._send(200, body)
+        else:
+            self._send(404, {"message": f"Not found: {p}"})
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        p = self.path.split("?")[0]
+
+        delete_routes: dict[str, Any] = {
+            "/api/v1/credentials/42": {},
+            "/api/v1/workflows/wf-1": WORKFLOW_1,
+            "/api/v1/executions/exec-100": {
+                "id": "exec-100",
+                "workflowId": "wf-1",
+                "status": "success",
+            },
+            "/api/v1/tags/tag-1": {},
+            "/api/v1/data-tables/dt-1": {},
+            "/api/v1/data-tables/dt-1/rows/delete": {},
+        }
+        body = delete_routes.get(p)
+        if body is not None:
+            self._send(200, body)
+        else:
+            self._send(404, {"message": f"Not found: {p}"})
+
+
+@pytest.fixture(scope="session")
+def server() -> Generator[tuple[str, int]]:
+    """Start a fake n8n server for the test session. Returns (host, port)."""
+    httpd = HTTPServer(("127.0.0.1", 0), FakeN8NHandler)
+    port = httpd.server_address[1]
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    yield "127.0.0.1", port
+    httpd.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# CLI test helpers
+# ---------------------------------------------------------------------------
+
+
+def run_ok(
+    server: tuple[str, int],
+    argv: list[str],
+    capsys: pytest.CaptureFixture[str],
+) -> str:
+    """Run a CLI command that should succeed, return stdout."""
+    host, port = server
+    env = {
+        "N8N_API_URL": f"http://{host}:{port}",
+        "N8N_API_KEY": "test-key-1234",
+    }
+    with patch.dict("os.environ", env, clear=False):
+        with patch("sys.argv", ["n8n-cli", *argv]):
+            try:
+                main()
+            except SystemExit as e:
+                assert e.code in (None, 0), f"Expected success but got exit {e.code}"
+    out: str = capsys.readouterr().out
+    return out
+
+
+def run_fail(
+    server: tuple[str, int],
+    argv: list[str],
+    capsys: pytest.CaptureFixture[str],
+) -> str:
+    """Run a CLI command that should fail, return stderr."""
+    host, port = server
+    env = {
+        "N8N_API_URL": f"http://{host}:{port}",
+        "N8N_API_KEY": "test-key-1234",
+    }
+    with patch.dict("os.environ", env, clear=False):
+        with patch("sys.argv", ["n8n-cli", *argv]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code != 0
+    err: str = capsys.readouterr().err
+    return err

--- a/n8n-cli/tests/test_apply.py
+++ b/n8n-cli/tests/test_apply.py
@@ -1,0 +1,71 @@
+"""Apply command tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import WORKFLOW_1, run_fail, run_ok
+
+
+class TestApplyCommand:
+    def test_create_new(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """apply creates workflow when local file has no ID."""
+        wf = {"name": "Brand New", "nodes": [], "connections": {}}
+        (tmp_path / "new.json").write_text(json.dumps(wf))
+        out = run_ok(server, ["apply", "-d", str(tmp_path)], capsys)
+        assert "create" in out.lower()
+        # File should be updated with server-assigned ID
+        data = json.loads((tmp_path / "new.json").read_text())
+        assert data.get("id") is not None
+
+    def test_dry_run(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """apply --dry-run previews without changes."""
+        wf = {"name": "Dry Run Test", "nodes": [], "connections": {}}
+        (tmp_path / "dry.json").write_text(json.dumps(wf))
+        out = run_ok(server, ["apply", "-d", str(tmp_path), "--dry-run"], capsys)
+        assert "create" in out.lower()
+        # File should NOT be updated
+        data = json.loads((tmp_path / "dry.json").read_text())
+        assert "id" not in data
+
+    def test_skip_unchanged(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """apply skips workflows that match remote."""
+        (tmp_path / "existing.json").write_text(json.dumps(WORKFLOW_1))
+        out = run_ok(server, ["apply", "-d", str(tmp_path)], capsys)
+        assert "skip" in out.lower()
+
+    def test_empty_dir(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """apply with empty directory prints message."""
+        out = run_ok(server, ["apply", "-d", str(tmp_path)], capsys)
+        assert "No workflow files found" in out
+
+    def test_missing_dir(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """apply with nonexistent directory shows error."""
+        err = run_fail(server, ["apply", "-d", str(tmp_path / "nope")], capsys)
+        assert "not found" in err.lower() or "Directory" in err

--- a/n8n-cli/tests/test_credential.py
+++ b/n8n-cli/tests/test_credential.py
@@ -1,0 +1,95 @@
+"""Credential command tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_fail, run_ok
+
+
+class TestCredential:
+    def test_list_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["credential", "list"], capsys)
+        assert "42" in out
+        assert "My Slack Token" in out
+        assert "slackApi" in out
+
+    def test_list_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "credential", "list"], capsys)
+        data = json.loads(out)
+        assert data["data"][0]["id"] == "42"
+
+    def test_get_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["credential", "get", "42"], capsys)
+        assert "My Slack Token" in out
+        assert "slackApi" in out
+
+    def test_get_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "credential", "get", "42"], capsys)
+        data = json.loads(out)
+        assert data["id"] == "42"
+
+    def test_create(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "cred.json"
+        f.write_text(json.dumps({"name": "New", "type": "slackApi", "data": {"accessToken": "x"}}))
+        out = run_ok(server, ["credential", "create", str(f)], capsys)
+        assert "Created" in out
+        assert "New Cred" in out
+
+    def test_update(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "cred.json"
+        f.write_text(json.dumps({"name": "Updated Cred"}))
+        out = run_ok(server, ["credential", "update", "42", str(f)], capsys)
+        assert "Updated" in out
+
+    def test_delete(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["credential", "delete", "42"], capsys)
+        assert "Deleted" in out
+        assert "42" in out
+
+    def test_test(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["credential", "test", "42"], capsys)
+        assert "ok" in out
+        assert "Connection successful" in out
+
+    def test_schema(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["credential", "schema", "slackApi"], capsys)
+        data = json.loads(out)
+        assert "accessToken" in data["properties"]
+
+    def test_bad_json_file(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """Invalid JSON input shows InputError, not a raw traceback."""
+        f = tmp_path / "bad.json"
+        f.write_text("not json{{{")
+        err = run_fail(server, ["credential", "create", str(f)], capsys)
+        assert "Invalid JSON" in err
+
+    def test_missing_file(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Non-existent file shows InputError."""
+        err = run_fail(server, ["credential", "create", "/no/such/file.json"], capsys)
+        assert "File not found" in err
+
+    def test_api_404(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        """Requesting a non-existent resource shows a friendly error."""
+        err = run_fail(server, ["credential", "get", "nonexistent"], capsys)
+        assert "Not Found" in err

--- a/n8n-cli/tests/test_datatable.py
+++ b/n8n-cli/tests/test_datatable.py
@@ -1,0 +1,117 @@
+"""Data table command tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_fail, run_ok
+
+
+class TestDatatable:
+    def test_list_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["datatable", "list"], capsys)
+        assert "dt-1" in out
+        assert "Contacts" in out
+
+    def test_list_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "datatable", "list"], capsys)
+        data = json.loads(out)
+        assert data["data"][0]["name"] == "Contacts"
+
+    def test_get_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["datatable", "get", "dt-1"], capsys)
+        assert "Contacts" in out
+        assert "name:string" in out
+        assert "email:string" in out
+
+    def test_create(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "dt.json"
+        f.write_text(
+            json.dumps({"name": "New Table", "columns": [{"name": "x", "type": "string"}]})
+        )
+        out = run_ok(server, ["datatable", "create", str(f)], capsys)
+        assert "Created" in out
+        assert "New Table" in out
+
+    def test_update(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["datatable", "update", "dt-1", "Renamed"], capsys)
+        assert "Renamed" in out
+
+    def test_delete(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["datatable", "delete", "dt-1"], capsys)
+        assert "Deleted" in out
+        assert "dt-1" in out
+
+    def test_rows_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["datatable", "rows", "dt-1"], capsys)
+        assert "Alice" in out
+        assert "Bob" in out
+
+    def test_rows_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "datatable", "rows", "dt-1"], capsys)
+        data = json.loads(out)
+        assert len(data["data"]) == 2
+
+    def test_insert(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "rows.json"
+        f.write_text(json.dumps([{"name": "Charlie", "email": "c@x.com"}]))
+        out = run_ok(server, ["datatable", "insert", "dt-1", str(f)], capsys)
+        data = json.loads(out)
+        assert data["created"] == 2
+
+    def test_update_rows(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "upd.json"
+        f.write_text(json.dumps({"filter": {}, "data": {"name": "Updated"}}))
+        out = run_ok(server, ["datatable", "update-rows", "dt-1", str(f)], capsys)
+        data = json.loads(out)
+        assert data["updated"] == 1
+
+    def test_upsert(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "ups.json"
+        f.write_text(json.dumps({"filter": {}, "data": {"name": "Upserted"}}))
+        out = run_ok(server, ["datatable", "upsert", "dt-1", str(f)], capsys)
+        data = json.loads(out)
+        assert data["updated"] == 1
+
+    def test_delete_rows(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(
+            server,
+            ["datatable", "delete-rows", "dt-1", "--filter", '{"id": "row-1"}'],
+            capsys,
+        )
+        data = json.loads(out)
+        assert isinstance(data, dict)
+
+    def test_delete_rows_bad_filter(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """delete-rows with invalid filter JSON shows InputError."""
+        err = run_fail(
+            server,
+            ["datatable", "delete-rows", "dt-1", "--filter", "not-json"],
+            capsys,
+        )
+        assert "Invalid filter JSON" in err

--- a/n8n-cli/tests/test_errors.py
+++ b/n8n-cli/tests/test_errors.py
@@ -1,0 +1,28 @@
+"""Error handling tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from n8n_cli.main import main
+
+
+class TestErrors:
+    def test_missing_credentials(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Missing API URL/key produces a ConfigError, not a traceback."""
+        env = {"N8N_API_URL": "", "N8N_API_KEY": ""}
+        with patch.dict("os.environ", env, clear=False):
+            with patch("sys.argv", ["n8n-cli", "credential", "list"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "N8N_API_URL" in err
+
+    def test_unknown_command(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Unknown top-level command exits with code 2 (argparse error)."""
+        with patch.dict("os.environ", {"N8N_API_URL": "x", "N8N_API_KEY": "x"}):
+            with patch("sys.argv", ["n8n-cli", "bogus"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 2

--- a/n8n-cli/tests/test_execution.py
+++ b/n8n-cli/tests/test_execution.py
@@ -1,0 +1,76 @@
+"""Execution command tests."""
+
+import json
+
+import pytest
+
+from tests.conftest import run_ok
+
+
+class TestExecution:
+    def test_get_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        """Without --show-data, shows summary but not node run table."""
+        out = run_ok(server, ["execution", "get", "exec-100"], capsys)
+        assert "exec-100" in out
+        assert "success" in out
+
+    def test_get_show_data(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """With --show-data, shows full node execution table."""
+        out = run_ok(server, ["execution", "get", "exec-100", "--show-data"], capsys)
+        assert "exec-100" in out
+        assert "success" in out
+        assert "Fetch" in out
+        assert "150ms" in out
+        assert "✓" in out
+
+    def test_get_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "execution", "get", "exec-100", "--show-data"], capsys)
+        data = json.loads(out)
+        assert data["id"] == "exec-100"
+        assert "runData" in data["data"]["resultData"]
+
+    def test_list_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["execution", "list"], capsys)
+        assert "exec-100" in out
+        assert "wf-1" in out
+
+    def test_list_with_filters(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = run_ok(
+            server,
+            ["execution", "list", "--workflow", "wf-1", "--status", "success", "--limit", "5"],
+            capsys,
+        )
+        assert "exec-100" in out
+
+    def test_delete(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["execution", "delete", "exec-100"], capsys)
+        assert "Deleted" in out
+        assert "exec-100" in out
+
+    def test_delete_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "execution", "delete", "exec-100"], capsys)
+        data = json.loads(out)
+        assert data["id"] == "exec-100"
+
+    def test_retry(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["execution", "retry", "exec-100"], capsys)
+        assert "exec-101" in out
+        assert "retry started" in out.lower()
+
+    def test_retry_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "execution", "retry", "exec-100"], capsys)
+        data = json.loads(out)
+        assert data["id"] == "exec-101"
+
+    def test_stop(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["execution", "stop", "exec-100"], capsys)
+        assert "stopped" in out.lower()
+
+    def test_stop_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "execution", "stop", "exec-100"], capsys)
+        data = json.loads(out)
+        assert data["status"] == "canceled"

--- a/n8n-cli/tests/test_help.py
+++ b/n8n-cli/tests/test_help.py
@@ -1,0 +1,35 @@
+"""Help output tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from n8n_cli.main import main
+
+
+class TestHelp:
+    def test_top_level_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("sys.argv", ["n8n-cli", "--help"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "credential" in out
+        assert "workflow" in out
+        assert "execution" in out
+        assert "tag" in out
+        assert "datatable" in out
+        assert "raw" in out
+        assert "test" in out
+        assert "import" in out
+        assert "apply" in out
+
+    def test_subcommand_help(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("sys.argv", ["n8n-cli", "credential", "--help"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "list" in out
+        assert "get" in out
+        assert "schema" in out

--- a/n8n-cli/tests/test_import.py
+++ b/n8n-cli/tests/test_import.py
@@ -1,0 +1,66 @@
+"""Import command tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_ok
+
+
+class TestImportCommand:
+    def test_dry_run(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """import --dry-run shows what would be written."""
+        out = run_ok(server, ["import", "-d", str(tmp_path), "--dry-run"], capsys)
+        assert "create" in out
+        assert "Daily Report" in out
+        # No files should be written
+        assert not list(tmp_path.glob("*.json"))
+
+    def test_create_files(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """import creates JSON files for each workflow."""
+        out = run_ok(server, ["import", "-d", str(tmp_path)], capsys)
+        assert "created" in out.lower()
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) >= 1
+        # Verify file content
+        data = json.loads(files[0].read_text())
+        assert "id" in data
+        assert "nodes" in data
+
+    def test_skip_up_to_date(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """import skips files that are already up to date."""
+        # First import
+        run_ok(server, ["import", "-d", str(tmp_path)], capsys)
+        # Second import should skip
+        out = run_ok(server, ["import", "-d", str(tmp_path)], capsys)
+        assert "skip" in out.lower()
+
+    def test_filter_by_ids(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """import --ids filters to specific workflows."""
+        out = run_ok(server, ["import", "-d", str(tmp_path), "--ids", "wf-1"], capsys)
+        assert "Daily Report" in out
+        files = list(tmp_path.glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert data["id"] == "wf-1"

--- a/n8n-cli/tests/test_raw.py
+++ b/n8n-cli/tests/test_raw.py
@@ -1,0 +1,44 @@
+"""Raw command tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import run_fail, run_ok
+
+
+class TestRaw:
+    def test_get(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["raw", "GET", "/custom/endpoint"], capsys)
+        data = json.loads(out)
+        assert data["ok"] is True
+
+    def test_post(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "body.json"
+        f.write_text(json.dumps({"key": "val"}))
+        out = run_ok(
+            server,
+            ["raw", "POST", "/credentials", str(f)],
+            capsys,
+        )
+        data = json.loads(out)
+        assert data["id"] == "43"
+
+    def test_delete(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["raw", "DELETE", "/credentials/42"], capsys)
+        data = json.loads(out)
+        assert isinstance(data, dict)
+
+    def test_unsupported_method(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        err = run_fail(server, ["raw", "TRACE", "/foo"], capsys)
+        assert "Unsupported HTTP method" in err

--- a/n8n-cli/tests/test_tag.py
+++ b/n8n-cli/tests/test_tag.py
@@ -1,0 +1,54 @@
+"""Tag command tests."""
+
+import json
+
+import pytest
+
+from tests.conftest import run_ok
+
+
+class TestTag:
+    def test_list_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["tag", "list"], capsys)
+        assert "tag-1" in out
+        assert "production" in out
+
+    def test_list_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "tag", "list"], capsys)
+        data = json.loads(out)
+        assert data["data"][0]["name"] == "production"
+
+    def test_get_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["tag", "get", "tag-1"], capsys)
+        assert "production" in out
+        assert "tag-1" in out
+
+    def test_get_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "tag", "get", "tag-1"], capsys)
+        data = json.loads(out)
+        assert data["id"] == "tag-1"
+
+    def test_create(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["tag", "create", "staging"], capsys)
+        assert "Created" in out
+        assert "staging" in out
+
+    def test_create_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "tag", "create", "staging"], capsys)
+        data = json.loads(out)
+        assert data["name"] == "staging"
+
+    def test_update(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["tag", "update", "tag-1", "renamed-tag"], capsys)
+        assert "Updated" in out
+        assert "renamed-tag" in out
+
+    def test_delete(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["tag", "delete", "tag-1"], capsys)
+        assert "Deleted" in out
+        assert "tag-1" in out
+
+    def test_delete_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "tag", "delete", "tag-1"], capsys)
+        data = json.loads(out)
+        assert data["deleted"] is True

--- a/n8n-cli/tests/test_test_command.py
+++ b/n8n-cli/tests/test_test_command.py
@@ -1,0 +1,46 @@
+"""Test (webhook trigger) command tests."""
+
+import json
+
+import pytest
+
+from tests.conftest import run_fail, run_ok
+
+
+class TestTestCommand:
+    def test_dry_run(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        """test --dry-run shows webhook URL without calling it."""
+        out = run_ok(server, ["test", "wf-2", "--dry-run"], capsys)
+        assert "webhook/test-hook" in out
+        assert "[CLI Test] Entry" in out
+
+    def test_dry_run_json(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = run_ok(server, ["-j", "test", "wf-2", "--dry-run"], capsys)
+        data = json.loads(out)
+        assert "webhook/test-hook" in data["webhookURL"]
+        assert data["dryRun"] is True
+
+    def test_execute_webhook(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """test sends request to webhook and reports result."""
+        out = run_ok(server, ["test", "wf-2", "-d", '{"key": "val"}'], capsys)
+        assert "200" in out
+        assert "Test passed" in out
+
+    def test_execute_json(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = run_ok(server, ["-j", "test", "wf-2", "-d", "{}"], capsys)
+        data = json.loads(out)
+        assert data["httpStatus"] == 200
+        assert data["success"] is True
+
+    def test_no_webhook_node(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """test against workflow without webhook shows friendly error."""
+        err = run_fail(server, ["test", "wf-1"], capsys)
+        assert "No webhook node" in err

--- a/n8n-cli/tests/test_workflow.py
+++ b/n8n-cli/tests/test_workflow.py
@@ -1,0 +1,139 @@
+"""Workflow command tests."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import WORKFLOW_1, run_fail, run_ok
+
+
+class TestWorkflow:
+    def test_list_text(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["workflow", "list"], capsys)
+        assert "wf-1" in out
+        assert "Daily Report" in out
+        assert "production" in out
+
+    def test_list_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "workflow", "list"], capsys)
+        data = json.loads(out)
+        assert data["data"][0]["id"] == "wf-1"
+
+    def test_list_active_filter(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = run_ok(server, ["workflow", "list", "--active"], capsys)
+        assert "wf-1" in out
+
+    def test_list_with_tags(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = run_ok(server, ["workflow", "list", "--tags", "production"], capsys)
+        assert "wf-1" in out
+
+    def test_get_always_json(
+        self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """workflow get always outputs full JSON for round-trip editing."""
+        out = run_ok(server, ["workflow", "get", "wf-1"], capsys)
+        data = json.loads(out)
+        assert data["id"] == "wf-1"
+        assert data["name"] == "Daily Report"
+        assert len(data["nodes"]) == 2
+
+    def test_create(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "wf.json"
+        f.write_text(json.dumps({"name": "New Workflow", "nodes": [], "connections": {}}))
+        out = run_ok(server, ["workflow", "create", str(f)], capsys)
+        assert "Created" in out
+        assert "New Workflow" in out
+
+    def test_create_json(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "wf.json"
+        f.write_text(json.dumps({"name": "New Workflow", "nodes": [], "connections": {}}))
+        out = run_ok(server, ["-j", "workflow", "create", str(f)], capsys)
+        data = json.loads(out)
+        assert data["id"] == "wf-2"
+
+    def test_create_rejects_non_object(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "arr.json"
+        f.write_text("[1, 2, 3]")
+        err = run_fail(server, ["workflow", "create", str(f)], capsys)
+        assert "object" in err.lower()
+
+    def test_update_strips_metadata(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """workflow update strips id/createdAt/updatedAt/tags/shared/pinData."""
+        wf = {
+            **WORKFLOW_1,
+            "pinData": {"Start": [{}]},
+            "shared": [{"userId": "1"}],
+        }
+        f = tmp_path / "wf.json"
+        f.write_text(json.dumps(wf))
+        # The fake server asserts these keys are NOT present
+        out = run_ok(server, ["workflow", "update", "wf-1", str(f)], capsys)
+        assert "Daily Report" in out
+
+    def test_update_json(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        f = tmp_path / "wf.json"
+        f.write_text(json.dumps(WORKFLOW_1))
+        out = run_ok(server, ["-j", "workflow", "update", "wf-1", str(f)], capsys)
+        data = json.loads(out)
+        assert data["id"] == "wf-1"
+
+    def test_update_rejects_non_object(
+        self,
+        server: tuple[str, int],
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """workflow update rejects non-object JSON."""
+        f = tmp_path / "arr.json"
+        f.write_text("[1, 2, 3]")
+        err = run_fail(server, ["workflow", "update", "wf-1", str(f)], capsys)
+        assert "object" in err.lower()
+
+    def test_delete(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["workflow", "delete", "wf-1"], capsys)
+        assert "Deleted" in out
+        assert "wf-1" in out
+
+    def test_delete_json(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["-j", "workflow", "delete", "wf-1"], capsys)
+        data = json.loads(out)
+        assert data["id"] == "wf-1"
+
+    def test_activate(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["workflow", "activate", "wf-1"], capsys)
+        assert "Activated" in out
+        assert "Daily Report" in out
+
+    def test_deactivate(self, server: tuple[str, int], capsys: pytest.CaptureFixture[str]) -> None:
+        out = run_ok(server, ["workflow", "deactivate", "wf-1"], capsys)
+        assert "Deactivated" in out

--- a/skills/n8n-cli/SKILL.md
+++ b/skills/n8n-cli/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: n8n-cli
+description: Manage n8n workflows, credentials, executions, tags, and data tables via the n8n REST API.
+---
+
+Default output is LLM-friendly text. `-j`/`--json` for JSON. Pipe with `- ` for stdin.
+
+```bash
+# Credentials — list|get|create|update|delete|test|schema
+n8n-cli credential list
+n8n-cli credential get|delete|test <id>
+n8n-cli credential create|update <id> cred.json
+n8n-cli credential schema httpBasicAuth
+
+# Workflows — list|get|create|update|delete|activate|deactivate
+n8n-cli workflow list [--active|--inactive] [--tags t1,t2] [--name text] [--limit N]
+n8n-cli workflow get <id>              # full JSON for round-trip editing
+n8n-cli workflow create wf.json
+n8n-cli workflow update <id> wf.json   # auto-strips id/tags/shared/pinData
+n8n-cli workflow delete|activate|deactivate <id>
+
+# Executions — list|get|delete|retry|stop
+n8n-cli execution list [--workflow <id>] [--status error] [--limit 5]
+n8n-cli execution get <id> [--show-data]
+n8n-cli execution delete|stop <id>
+n8n-cli execution retry <id> [--load-workflow]
+
+# Tags — list|get|create|update|delete
+n8n-cli tag list
+n8n-cli tag create <name>
+n8n-cli tag update <id> <new-name>
+n8n-cli tag get|delete <id>
+
+# Data tables
+n8n-cli datatable list|get|create|update|delete <id> [...]
+n8n-cli datatable rows <id> [--filter '<json>' --sort col:asc --limit 20]
+n8n-cli datatable insert <id> rows.json [--return count|id|all]
+n8n-cli datatable update-rows|upsert <id> body.json  # {"filter":{...},"data":{...}}
+n8n-cli datatable delete-rows <id> --filter '<json>' [--dry-run]
+# filter: {"type":"and","filters":[{"columnName":"c","condition":"eq","value":"v"}]}
+
+# Test webhook
+n8n-cli test <id> [-d '{"key":"val"}'] [--wait-execution] [--activate] [--dry-run]
+
+# Bulk sync
+n8n-cli import -d ./definitions [--ids a,b] [--dry-run]   # server → local JSON
+n8n-cli apply -d ./definitions [--ids a,b] [--dry-run] [--force]  # local → server
+
+# Raw API
+n8n-cli raw GET|POST|PUT|DELETE /path [body.json]
+```


### PR DESCRIPTION

The TypeScript n8n-cli (ubie-oss) covers workflow and execution basics
but lacks credential CRUD, data table management, and a raw API escape
hatch. This stdlib-only Python CLI fills those gaps so agents can
manage n8n instances without resorting to curl.

Uses argparse for argument parsing and a custom error hierarchy
(CLIError/APIError/InputError/ConfigError) so every failure path
produces a clear, actionable message. API status codes get
human-readable labels via http.HTTPStatus.

Credential resolution supports env vars, config file values, and
password-manager commands (api_key_command) to avoid storing secrets
in plain text.


