### PR TITLE
README: add n8n-cli and calendar-cli to tool table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ A collection of CLI tools and skills designed to be useful for LLM agents.
 | Tool                              | Description                                                     | Skill                                      |
 | --------------------------------- | --------------------------------------------------------------- | ------------------------------------------ |
 | [browser-cli](browser-cli/)       | Control Firefox browser from the command line                   | [SKILL.md](skills/browser-cli/SKILL.md)    |
+| [calendar-cli](calendar-cli/)     | Manage calendar events and send meeting invitations             | [SKILL.md](skills/calendar-cli/SKILL.md)   |
 | [context7-cli](context7-cli/)     | Fetch up-to-date library documentation from Context7            | [SKILL.md](skills/context7-cli/SKILL.md)   |
 | [db-cli](db-cli/)                 | Search Deutsche Bahn train connections                          | [SKILL.md](skills/db-cli/SKILL.md)         |
 | [gmaps-cli](gmaps-cli/)           | Search for places and get directions using Google Maps          | [SKILL.md](skills/gmaps-cli/SKILL.md)      |
 | [kagi-search](kagi-search/)       | Search the web using Kagi with Quick Answer AI summaries        | [SKILL.md](skills/kagi-search/SKILL.md)    |
+| [n8n-cli](n8n-cli/)               | Manage n8n workflows, credentials, executions, tags, and data   | [SKILL.md](skills/n8n-cli/SKILL.md)        |
 | [pexpect-cli](pexpect-cli/)       | Persistent pexpect sessions for interactive terminal automation | [SKILL.md](skills/pexpect-cli/SKILL.md)    |
 | [screenshot-cli](screenshot-cli/) | Cross-platform screenshots for macOS and KDE Wayland            | [SKILL.md](skills/screenshot-cli/SKILL.md) |
 | [tasker-cli](tasker-cli/)         | Deploy and trigger Android Tasker tasks via WebUI and adb       | [SKILL.md](skills/tasker-cli/SKILL.md)     |
@@ -25,10 +27,12 @@ Each provides usage examples and references the package README for setup.
 
 ```bash
 nix run github:Mic92/mics-skills#browser-cli
+nix run github:Mic92/mics-skills#calendar-cli
 nix run github:Mic92/mics-skills#context7-cli
 nix run github:Mic92/mics-skills#db-cli
 nix run github:Mic92/mics-skills#gmaps-cli
 nix run github:Mic92/mics-skills#kagi-search
+nix run github:Mic92/mics-skills#n8n-cli
 nix run github:Mic92/mics-skills#pexpect-cli
 nix run github:Mic92/mics-skills#screenshot-cli
 nix run github:Mic92/mics-skills#tasker-cli


### PR DESCRIPTION

Both were missing from the top-level README despite having packages
and skill definitions already wired up.


