### PR TITLE
n8n-cli: strip read-only fields before update requests

### DIFF
--- a/n8n-cli/n8n_cli/commands/apply.py
+++ b/n8n-cli/n8n_cli/commands/apply.py
@@ -8,6 +8,7 @@ from typing import Any
 from n8n_cli.client import Client
 from n8n_cli.errors import APIError, CLIError
 from n8n_cli.output import atomic_write, enc
+from n8n_cli.strip import WORKFLOW_READONLY, strip_readonly
 
 
 class ApplyError(CLIError):
@@ -92,11 +93,8 @@ def _strip_for_create(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _strip_for_update(data: dict[str, Any]) -> dict[str, Any]:
-    """Strip fields not accepted by the update endpoint."""
-    body = dict(data)
-    for key in ("id", "createdAt", "updatedAt", "tags", "shared", "pinData"):
-        body.pop(key, None)
-    return body
+    """Strip read-only fields not accepted by the update endpoint."""
+    return strip_readonly(data, WORKFLOW_READONLY)
 
 
 def _update_local_file(path: str, created: dict[str, Any]) -> None:

--- a/n8n-cli/n8n_cli/commands/credential.py
+++ b/n8n-cli/n8n_cli/commands/credential.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from n8n_cli.client import Client
 from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, read_json_input, ts
+from n8n_cli.strip import CREDENTIAL_READONLY, strip_readonly
 
 
 def _text_get(c: dict[str, Any]) -> None:
@@ -63,8 +64,13 @@ def cmd_credential_create(client: Client, ns: Namespace) -> None:
 
 
 def cmd_credential_update(client: Client, ns: Namespace) -> None:
-    """Update a credential."""
+    """Update a credential.
+
+    Strips read-only fields returned by GET that the PATCH endpoint rejects.
+    """
     body = read_json_input(ns.file)
+    if isinstance(body, dict):
+        body = strip_readonly(body, CREDENTIAL_READONLY)
     result = client.patch(f"/credentials/{enc(ns.id)}", body)
     emit(result, use_json=ns.use_json, text_fn=lambda c: _text_mutate("Updated", c))
 

--- a/n8n-cli/n8n_cli/commands/workflow.py
+++ b/n8n-cli/n8n_cli/commands/workflow.py
@@ -7,6 +7,7 @@ from typing import Any
 from n8n_cli.client import Client
 from n8n_cli.errors import InputError
 from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, read_json_input, ts
+from n8n_cli.strip import WORKFLOW_READONLY, strip_readonly
 
 
 def _text_summary(wf: dict[str, Any]) -> None:
@@ -89,13 +90,13 @@ def cmd_workflow_create(client: Client, ns: Namespace) -> None:
 def cmd_workflow_update(client: Client, ns: Namespace) -> None:
     """Update a workflow from a full JSON definition.
 
-    Strips id, createdAt, updatedAt, tags, shared, pinData before PUT.
+    Strips read-only fields (id, timestamps, tags, shared, pinData,
+    isArchived, etc.) before PUT so round-trip get→edit→update works.
     """
     body = read_json_input(ns.file)
     if not isinstance(body, dict):
         raise InputError("Workflow JSON must be an object, not an array or scalar")
-    for key in ("id", "createdAt", "updatedAt", "tags", "shared", "pinData"):
-        body.pop(key, None)
+    body = strip_readonly(body, WORKFLOW_READONLY)
     result = client.put(f"/workflows/{enc(ns.id)}", body)
     emit(result, use_json=ns.use_json, text_fn=_text_summary)
 

--- a/n8n-cli/n8n_cli/strip.py
+++ b/n8n-cli/n8n_cli/strip.py
@@ -1,0 +1,46 @@
+"""Strip read-only fields before sending to n8n API.
+
+The n8n REST API returns metadata fields (timestamps, ownership, etc.)
+in GET responses that its PUT/PATCH endpoints reject.  These helpers
+remove them so a get→edit→update round-trip works cleanly.
+"""
+
+from typing import Any
+
+# Fields common to every resource type.
+_COMMON_READONLY: frozenset[str] = frozenset(
+    {
+        "id",
+        "createdAt",
+        "updatedAt",
+        "homeProject",
+        "sharedWithProjects",
+        "scopes",
+    }
+)
+
+# Extra read-only fields per resource kind.
+_WORKFLOW_EXTRA: frozenset[str] = frozenset(
+    {
+        "tags",
+        "shared",
+        "pinData",
+        "isArchived",
+        "usedCredentials",
+    }
+)
+
+_CREDENTIAL_EXTRA: frozenset[str] = frozenset(
+    {
+        "isManaged",
+        "ownedBy",
+    }
+)
+
+WORKFLOW_READONLY: frozenset[str] = _COMMON_READONLY | _WORKFLOW_EXTRA
+CREDENTIAL_READONLY: frozenset[str] = _COMMON_READONLY | _CREDENTIAL_EXTRA
+
+
+def strip_readonly(data: dict[str, Any], keys: frozenset[str]) -> dict[str, Any]:
+    """Return a shallow copy of *data* with *keys* removed."""
+    return {k: v for k, v in data.items() if k not in keys}

--- a/n8n-cli/tests/conftest.py
+++ b/n8n-cli/tests/conftest.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from n8n_cli.main import main
+from n8n_cli.strip import CREDENTIAL_READONLY, WORKFLOW_READONLY
 
 # ---------------------------------------------------------------------------
 # Realistic payloads modelled on actual n8n v1 API responses
@@ -207,8 +208,8 @@ class FakeN8NHandler(BaseHTTPRequestHandler):
 
         if p == "/api/v1/workflows/wf-1":
             sent = json.loads(raw)
-            # Verify round-trip stripping: these keys must NOT be in the body
-            for forbidden in ("id", "createdAt", "updatedAt", "tags", "shared", "pinData"):
+            # Verify round-trip stripping: read-only keys must NOT be in the body
+            for forbidden in WORKFLOW_READONLY:
                 assert forbidden not in sent, f"workflow update should strip '{forbidden}'"
             self._send(200, {**WORKFLOW_1, "name": sent.get("name", WORKFLOW_1["name"])})
         elif p == "/api/v1/tags/tag-1":
@@ -218,11 +219,18 @@ class FakeN8NHandler(BaseHTTPRequestHandler):
             self._send(404, {"message": f"Not found: {p}"})
 
     def do_PATCH(self) -> None:  # noqa: N802
-        self._read_body()
+        raw = self._read_body()
         p = self.path.split("?")[0]
 
+        if p == "/api/v1/credentials/42":
+            sent = json.loads(raw)
+            # Verify round-trip stripping: read-only keys must NOT be in the body
+            for forbidden in CREDENTIAL_READONLY:
+                assert forbidden not in sent, f"credential update should strip '{forbidden}'"
+            self._send(200, {**CREDENTIAL_1, "name": sent.get("name", CREDENTIAL_1["name"])})
+            return
+
         routes: dict[str, Any] = {
-            "/api/v1/credentials/42": {**CREDENTIAL_1, "name": "Updated Cred"},
             "/api/v1/data-tables/dt-1": {**DATATABLE_1, "name": "Renamed"},
             "/api/v1/data-tables/dt-1/rows/update": {"updated": 1},
         }

--- a/n8n-cli/tests/test_credential.py
+++ b/n8n-cli/tests/test_credential.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.conftest import run_fail, run_ok
+from tests.conftest import CREDENTIAL_1, run_fail, run_ok
 
 
 class TestCredential:
@@ -42,14 +42,26 @@ class TestCredential:
         assert "Created" in out
         assert "New Cred" in out
 
-    def test_update(
+    def test_update_strips_readonly(
         self,
         server: tuple[str, int],
         capsys: pytest.CaptureFixture[str],
         tmp_path: Path,
     ) -> None:
+        """credential update strips read-only fields from round-trip JSON."""
+        cred = {
+            **CREDENTIAL_1,
+            "name": "Updated Cred",
+            "data": {"accessToken": "new-token"},
+            "isManaged": False,
+            "ownedBy": {"id": "user-1"},
+            "homeProject": {"id": "proj-1"},
+            "sharedWithProjects": [],
+            "scopes": ["credential:read"],
+        }
         f = tmp_path / "cred.json"
-        f.write_text(json.dumps({"name": "Updated Cred"}))
+        f.write_text(json.dumps(cred))
+        # The fake server asserts these read-only keys are NOT present
         out = run_ok(server, ["credential", "update", "42", str(f)], capsys)
         assert "Updated" in out
 

--- a/n8n-cli/tests/test_workflow.py
+++ b/n8n-cli/tests/test_workflow.py
@@ -83,11 +83,16 @@ class TestWorkflow:
         capsys: pytest.CaptureFixture[str],
         tmp_path: Path,
     ) -> None:
-        """workflow update strips id/createdAt/updatedAt/tags/shared/pinData."""
+        """workflow update strips all read-only fields from round-trip JSON."""
         wf = {
             **WORKFLOW_1,
             "pinData": {"Start": [{}]},
             "shared": [{"userId": "1"}],
+            "isArchived": False,
+            "homeProject": {"id": "proj-1"},
+            "sharedWithProjects": [],
+            "scopes": ["workflow:read"],
+            "usedCredentials": [{"id": "42"}],
         }
         f = tmp_path / "wf.json"
         f.write_text(json.dumps(wf))


### PR DESCRIPTION

The n8n API returns metadata fields (timestamps, ownership, scopes,
etc.) in GET responses that its PUT/PATCH endpoints reject. This broke
the get→edit→update round-trip for credentials entirely (no stripping
at all) and for workflows partially (missing isArchived, homeProject,
sharedWithProjects, scopes, usedCredentials).

Extract the read-only field sets into a shared strip module so the
forbidden lists stay in sync across workflow update, credential update,
apply, and the test fixtures that assert on them.


