### PR TITLE
n8n-cli: allowlist writable fields for update requests

### DIFF
--- a/n8n-cli/n8n_cli/commands/apply.py
+++ b/n8n-cli/n8n_cli/commands/apply.py
@@ -8,7 +8,7 @@ from typing import Any
 from n8n_cli.client import Client
 from n8n_cli.errors import APIError, CLIError
 from n8n_cli.output import atomic_write, enc
-from n8n_cli.strip import WORKFLOW_READONLY, strip_readonly
+from n8n_cli.strip import WORKFLOW_WRITABLE, keep_writable
 
 
 class ApplyError(CLIError):
@@ -93,8 +93,8 @@ def _strip_for_create(data: dict[str, Any]) -> dict[str, Any]:
 
 
 def _strip_for_update(data: dict[str, Any]) -> dict[str, Any]:
-    """Strip read-only fields not accepted by the update endpoint."""
-    return strip_readonly(data, WORKFLOW_READONLY)
+    """Keep only fields the public API PUT endpoint accepts."""
+    return keep_writable(data, WORKFLOW_WRITABLE)
 
 
 def _update_local_file(path: str, created: dict[str, Any]) -> None:

--- a/n8n-cli/n8n_cli/commands/credential.py
+++ b/n8n-cli/n8n_cli/commands/credential.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from n8n_cli.client import Client
 from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, read_json_input, ts
-from n8n_cli.strip import CREDENTIAL_READONLY, strip_readonly
+from n8n_cli.strip import CREDENTIAL_WRITABLE, keep_writable
 
 
 def _text_get(c: dict[str, Any]) -> None:
@@ -66,11 +66,12 @@ def cmd_credential_create(client: Client, ns: Namespace) -> None:
 def cmd_credential_update(client: Client, ns: Namespace) -> None:
     """Update a credential.
 
-    Strips read-only fields returned by GET that the PATCH endpoint rejects.
+    Keeps only fields the public API PATCH endpoint accepts so a
+    round-trip get→edit→update works cleanly.
     """
     body = read_json_input(ns.file)
     if isinstance(body, dict):
-        body = strip_readonly(body, CREDENTIAL_READONLY)
+        body = keep_writable(body, CREDENTIAL_WRITABLE)
     result = client.patch(f"/credentials/{enc(ns.id)}", body)
     emit(result, use_json=ns.use_json, text_fn=lambda c: _text_mutate("Updated", c))
 

--- a/n8n-cli/n8n_cli/commands/workflow.py
+++ b/n8n-cli/n8n_cli/commands/workflow.py
@@ -7,7 +7,7 @@ from typing import Any
 from n8n_cli.client import Client
 from n8n_cli.errors import InputError
 from n8n_cli.output import emit, emit_json, emit_kv, emit_table, enc, read_json_input, ts
-from n8n_cli.strip import WORKFLOW_READONLY, strip_readonly
+from n8n_cli.strip import WORKFLOW_WRITABLE, keep_writable
 
 
 def _text_summary(wf: dict[str, Any]) -> None:
@@ -90,13 +90,13 @@ def cmd_workflow_create(client: Client, ns: Namespace) -> None:
 def cmd_workflow_update(client: Client, ns: Namespace) -> None:
     """Update a workflow from a full JSON definition.
 
-    Strips read-only fields (id, timestamps, tags, shared, pinData,
-    isArchived, etc.) before PUT so round-trip get→edit→update works.
+    Keeps only fields the public API PUT endpoint accepts so a
+    round-trip get→edit→update works without "additional properties" errors.
     """
     body = read_json_input(ns.file)
     if not isinstance(body, dict):
         raise InputError("Workflow JSON must be an object, not an array or scalar")
-    body = strip_readonly(body, WORKFLOW_READONLY)
+    body = keep_writable(body, WORKFLOW_WRITABLE)
     result = client.put(f"/workflows/{enc(ns.id)}", body)
     emit(result, use_json=ns.use_json, text_fn=_text_summary)
 

--- a/n8n-cli/n8n_cli/strip.py
+++ b/n8n-cli/n8n_cli/strip.py
@@ -1,46 +1,52 @@
-"""Strip read-only fields before sending to n8n API.
+"""Filter request bodies to only include fields the n8n public API accepts.
 
-The n8n REST API returns metadata fields (timestamps, ownership, etc.)
-in GET responses that its PUT/PATCH endpoints reject.  These helpers
-remove them so a get→edit→update round-trip works cleanly.
+The n8n public API validates requests against its OpenAPI spec using
+express-openapi-validator.  The workflow schema sets
+``additionalProperties: false``, so any field not in the spec is
+rejected with "request/body must NOT have additional properties".
+
+Rather than maintaining a denylist of read-only fields, we allowlist
+exactly the fields each endpoint accepts — derived from the OpenAPI
+YAML definitions in the n8n source tree:
+
+  packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflow.yml
+  packages/cli/src/public-api/v1/handlers/credentials/spec/schemas/update-credential-request.yml
 """
 
 from typing import Any
 
-# Fields common to every resource type.
-_COMMON_READONLY: frozenset[str] = frozenset(
+# PUT /workflows/{id}  — workflow.yml, additionalProperties: false
+# Read-only fields (id, active, createdAt, updatedAt, tags) are in the
+# schema but marked readOnly; we exclude them.  All other fields the
+# spec defines are writable.
+WORKFLOW_WRITABLE: frozenset[str] = frozenset(
     {
-        "id",
-        "createdAt",
-        "updatedAt",
-        "homeProject",
-        "sharedWithProjects",
-        "scopes",
-    }
-)
-
-# Extra read-only fields per resource kind.
-_WORKFLOW_EXTRA: frozenset[str] = frozenset(
-    {
-        "tags",
+        "name",
+        "nodes",
+        "connections",
+        "settings",
+        "staticData",
         "shared",
-        "pinData",
-        "isArchived",
-        "usedCredentials",
+        "activeVersion",
     }
 )
 
-_CREDENTIAL_EXTRA: frozenset[str] = frozenset(
+# PATCH /credentials/{id}  — update-credential-request.yml
+# No additionalProperties constraint, but we filter anyway to avoid
+# sending back metadata (timestamps, ownership, scopes, etc.) that
+# the endpoint ignores or that could break in future API versions.
+CREDENTIAL_WRITABLE: frozenset[str] = frozenset(
     {
-        "isManaged",
-        "ownedBy",
+        "name",
+        "type",
+        "data",
+        "isGlobal",
+        "isResolvable",
+        "isPartialData",
     }
 )
 
-WORKFLOW_READONLY: frozenset[str] = _COMMON_READONLY | _WORKFLOW_EXTRA
-CREDENTIAL_READONLY: frozenset[str] = _COMMON_READONLY | _CREDENTIAL_EXTRA
 
-
-def strip_readonly(data: dict[str, Any], keys: frozenset[str]) -> dict[str, Any]:
-    """Return a shallow copy of *data* with *keys* removed."""
-    return {k: v for k, v in data.items() if k not in keys}
+def keep_writable(data: dict[str, Any], keys: frozenset[str]) -> dict[str, Any]:
+    """Return a shallow copy of *data* keeping only *keys*."""
+    return {k: v for k, v in data.items() if k in keys}

--- a/n8n-cli/tests/conftest.py
+++ b/n8n-cli/tests/conftest.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from n8n_cli.main import main
-from n8n_cli.strip import CREDENTIAL_READONLY, WORKFLOW_READONLY
+from n8n_cli.strip import CREDENTIAL_WRITABLE, WORKFLOW_WRITABLE
 
 # ---------------------------------------------------------------------------
 # Realistic payloads modelled on actual n8n v1 API responses
@@ -208,9 +208,9 @@ class FakeN8NHandler(BaseHTTPRequestHandler):
 
         if p == "/api/v1/workflows/wf-1":
             sent = json.loads(raw)
-            # Verify round-trip stripping: read-only keys must NOT be in the body
-            for forbidden in WORKFLOW_READONLY:
-                assert forbidden not in sent, f"workflow update should strip '{forbidden}'"
+            # Verify only writable fields are sent (mirroring additionalProperties: false)
+            for key in sent:
+                assert key in WORKFLOW_WRITABLE, f"workflow update sent non-writable field '{key}'"
             self._send(200, {**WORKFLOW_1, "name": sent.get("name", WORKFLOW_1["name"])})
         elif p == "/api/v1/tags/tag-1":
             sent = json.loads(raw)
@@ -224,9 +224,11 @@ class FakeN8NHandler(BaseHTTPRequestHandler):
 
         if p == "/api/v1/credentials/42":
             sent = json.loads(raw)
-            # Verify round-trip stripping: read-only keys must NOT be in the body
-            for forbidden in CREDENTIAL_READONLY:
-                assert forbidden not in sent, f"credential update should strip '{forbidden}'"
+            # Verify only writable fields are sent
+            for key in sent:
+                assert key in CREDENTIAL_WRITABLE, (
+                    f"credential update sent non-writable field '{key}'"
+                )
             self._send(200, {**CREDENTIAL_1, "name": sent.get("name", CREDENTIAL_1["name"])})
             return
 

--- a/n8n-cli/tests/test_workflow.py
+++ b/n8n-cli/tests/test_workflow.py
@@ -87,6 +87,8 @@ class TestWorkflow:
         wf = {
             **WORKFLOW_1,
             "pinData": {"Start": [{}]},
+            "staticData": {"lastId": 5},
+            "meta": {"instanceId": "abc123"},
             "shared": [{"userId": "1"}],
             "isArchived": False,
             "homeProject": {"id": "proj-1"},

--- a/skills/n8n-cli/SKILL.md
+++ b/skills/n8n-cli/SKILL.md
@@ -16,7 +16,7 @@ n8n-cli credential schema httpBasicAuth
 n8n-cli workflow list [--active|--inactive] [--tags t1,t2] [--name text] [--limit N]
 n8n-cli workflow get <id>              # full JSON for round-trip editing
 n8n-cli workflow create wf.json
-n8n-cli workflow update <id> wf.json   # auto-strips id/tags/shared/pinData
+n8n-cli workflow update <id> wf.json   # auto-filters to writable fields only
 n8n-cli workflow delete|activate|deactivate <id>
 
 # Executions — list|get|delete|retry|stop


### PR DESCRIPTION

The n8n public API validates requests against its OpenAPI spec using
express-openapi-validator.  The workflow schema sets
additionalProperties: false, so any field not in the spec is rejected
with "request/body must NOT have additional properties".

Instead of maintaining a fragile denylist of read-only fields, derive
allowlists from the actual OpenAPI YAML definitions in the n8n source
tree (workflow.yml, update-credential-request.yml).  This way new
read-only fields the API adds in future versions are automatically
excluded.

The credential update endpoint does not enforce additionalProperties
but we filter anyway to avoid sending metadata the endpoint ignores.


