### PR TITLE
browser-cli: remove remote-tab proxy and bridge tab tracking

### DIFF
--- a/browser-cli/README.md
+++ b/browser-cli/README.md
@@ -163,17 +163,6 @@ nix build .#browser-cli
 Refs are reset on each snapshot. If you get "Element [N] not found", call
 `snap()` to get fresh refs.
 
-## Known Issues
-
-### Extra `example.com` tab when no managed tabs exist
-
-When no managed tabs exist and the first command uses `tab("url")`, the bridge
-auto-creates a throwaway `example.com` tab to bootstrap content script
-execution. Firefox blocks content script injection on `about:blank` and `data:`
-URIs, so a real HTTP page is required. The `tab()` call then creates the
-intended tab and subsequent API calls (`snap()`, `click()`, etc.) are correctly
-proxied to it. The leftover `example.com` tab can be ignored or closed manually.
-
 ## License
 
 MIT

--- a/browser-cli/browser_cli/bridge.py
+++ b/browser-cli/browser_cli/bridge.py
@@ -22,7 +22,9 @@ class NativeMessagingBridge:
         self.message_counter = 0
         self.stdin_reader: asyncio.StreamReader | None = None
         self.stdout_writer: asyncio.StreamWriter | None = None
-        self.latest_tab_id: str | None = None  # Track the most recently created tab
+        # No tab-ID tracking here. The bridge is a dumb pipe; the
+        # extension is the single source of truth for tab state. Caching
+        # a tab ID here caused stale-reference bugs after browser restart.
 
     async def setup_native_messaging(self) -> None:
         """Set up stdin/stdout for native messaging."""
@@ -141,10 +143,6 @@ class NativeMessagingBridge:
             # This is a response to a CLI request
             future = self.pending_responses.pop(msg_id)
 
-            # Track the latest tab ID if this was a new-tab command
-            if message.get("success") and "tabId" in message.get("result", {}):
-                self.latest_tab_id = message["result"]["tabId"]
-
             future.set_result(message)
         else:
             # This is a command from the extension - shouldn't happen in our architecture
@@ -231,58 +229,6 @@ class NativeMessagingBridge:
             writer.close()
             await writer.wait_closed()
 
-    async def _ensure_tab_exists(
-        self,
-        data: dict[str, Any],
-        msg_id: str,
-        writer: asyncio.StreamWriter,
-    ) -> bool:
-        """Ensure a tab exists for commands that need one.
-
-        Returns True if tab exists or was created, False if failed.
-        """
-        command = data.get("command", "")
-        if command in ["list-tabs", "new-tab"] or "tabId" in data:
-            return True
-
-        if self.latest_tab_id:
-            data["tabId"] = self.latest_tab_id
-            return True
-
-        # No tabs exist, create a minimal one for content script injection.
-        # Uses a data: URI since about:blank blocks content scripts.
-        logger.info("No managed tabs exist, creating a new tab")
-        new_tab_id = f"auto_{msg_id}"
-        new_tab_msg = {
-            "command": "new-tab",
-            "params": {"url": "https://example.com"},
-            "id": new_tab_id,
-        }
-        new_tab_future: asyncio.Future[Any] = asyncio.Future()
-        self.pending_responses[new_tab_id] = new_tab_future
-        await self.write_native_message(new_tab_msg)
-
-        try:
-            new_tab_response = await asyncio.wait_for(new_tab_future, timeout=5.0)
-            result = new_tab_response.get("result", {})
-            if new_tab_response.get("success") and "tabId" in result:
-                self.latest_tab_id = new_tab_response["result"]["tabId"]
-                data["tabId"] = self.latest_tab_id
-                logger.info("Created new tab: %s", self.latest_tab_id)
-                return True
-            logger.error("Failed to create new tab - no tabId in response")
-            self.latest_tab_id = None
-        except TimeoutError:
-            logger.exception("Timeout creating new tab")
-            await self._send_error_response(
-                writer,
-                msg_id,
-                "No managed tabs exist. Use 'browser-cli new-tab'",
-            )
-            return False
-        else:
-            return False
-
     async def _send_error_response(
         self,
         writer: asyncio.StreamWriter,
@@ -314,10 +260,6 @@ class NativeMessagingBridge:
                 msg_id = f"cli_{self.message_counter}"
                 self.message_counter += 1
                 data["id"] = msg_id
-
-            # Ensure tab exists for commands that need it
-            if not await self._ensure_tab_exists(data, msg_id, writer):
-                return
 
             # Create future for response
             future: asyncio.Future[Any] = asyncio.Future()

--- a/browser-cli/browser_cli/cli.py
+++ b/browser-cli/browser_cli/cli.py
@@ -241,10 +241,19 @@ async def navigate_tab(
     socket: str | None,
     firefox_path: str | None = None,
 ) -> None:
-    """Navigate a tab to a URL and wait for load."""
+    """Navigate a tab to a URL and wait for load.
+
+    If no tab_id is given and no managed tab exists, the extension
+    creates a new tab. We print its ID so the user can target it in
+    subsequent commands.
+    """
     client = BrowserClient(socket, firefox_path=firefox_path)
-    await client.send_command("go", {"url": url}, tab_id)
-    print(f"Navigated to {url}")
+    result = await client.send_command("go", {"url": url}, tab_id)
+    new_id = result.get("tabId")
+    if new_id and new_id != tab_id:
+        print(f"Opened {url} in new tab {new_id}")
+    else:
+        print(f"Navigated to {url}")
 
 
 async def list_tabs(socket: str | None, firefox_path: str | None = None) -> None:
@@ -273,21 +282,22 @@ Examples:
   # List managed tabs
   browser-cli --list
 
-  # Open page and get snapshot
-  browser-cli <<'EOF'
-  await tab("https://example.com")
-  snap()
-  EOF
+  # Open a page (creates tab, prints its ID)
+  browser-cli --go "https://example.com"
+  # -> Opened https://example.com in new tab abc123
+
+  # Get snapshot of that tab
+  browser-cli abc123 <<< 'snap()'
 
   # Form filling with refs
-  browser-cli <<'EOF'
+  browser-cli abc123 <<'EOF'
   await type(1, "user@test.com")
   await type(2, "secret123")
   await click(3)
   EOF
 
   # Wait for dynamic content
-  browser-cli <<'EOF'
+  browser-cli abc123 <<'EOF'
   await click(5)
   await wait("text", "Success")
   snap()
@@ -324,10 +334,9 @@ Available JS API:
     download(url)        - Download file to ~/Downloads
     download(url, name)  - Download with custom filename
 
-  Tabs:
-    tab()                - New tab
-    tab(url)             - New tab with URL
-    tabs()               - List tabs
+Tab management is done via CLI flags, not JS:
+  browser-cli --go URL   - Open/navigate tab, prints tab ID
+  browser-cli --list     - List managed tabs
         """,
     )
 

--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -129,18 +129,24 @@ async function getTargetTab(targetTabId) {
   if (targetTabId) {
     const managedTab = managedTabs.get(targetTabId);
     if (!managedTab) {
-      throw new Error(`Tab ${targetTabId} not found`);
+      throw new Error(
+        `Tab ${targetTabId} not found. Use 'browser-cli --list' to see managed tabs.`,
+      );
     }
     return managedTab.tabId;
-  } else if (activeTabId) {
-    const managedTab = managedTabs.get(activeTabId);
-    if (!managedTab) {
-      throw new Error(`Active tab ${activeTabId} no longer exists`);
-    }
-    return managedTab.tabId;
-  } else {
-    throw new Error("No active tab. Create a tab first with newTab()");
   }
+  // Fall back to active tab, but validate it still exists — activeTabId
+  // can go stale after browser restart or when onRemoved didn't fire.
+  if (activeTabId) {
+    const managedTab = managedTabs.get(activeTabId);
+    if (managedTab) {
+      return managedTab.tabId;
+    }
+    activeTabId = undefined;
+  }
+  throw new Error(
+    "No managed tab. Open one with 'browser-cli --go URL' or click the extension icon.",
+  );
 }
 
 /**
@@ -179,14 +185,25 @@ async function sendToContentScript(command, params = {}, targetTabId) {
  * @returns {Promise<{url: string}>}
  */
 async function navigate(url, tabId) {
-  const targetId = tabId || activeTabId;
+  let targetId = tabId;
   if (!targetId) {
-    throw new Error("No tab to navigate");
+    // Validate activeTabId before using it — it can go stale.
+    if (activeTabId && managedTabs.has(activeTabId)) {
+      targetId = activeTabId;
+    } else {
+      activeTabId = undefined;
+      // No usable tab: create one. This makes `browser-cli --go URL`
+      // work without requiring the user to first open a tab manually.
+      const created = await createNewTab(url);
+      return { url: created.url, tabId: created.tabId };
+    }
   }
 
   const managedTab = managedTabs.get(targetId);
   if (!managedTab) {
-    throw new Error(`Tab ${targetId} not found`);
+    throw new Error(
+      `Tab ${targetId} not found. Use 'browser-cli --list' to see managed tabs.`,
+    );
   }
 
   const browserTabId = managedTab.tabId;
@@ -487,10 +504,6 @@ async function handleCommand(message) {
         result = await listTabs();
         break;
       }
-      case "new-tab": {
-        result = await createNewTab(params.url);
-        break;
-      }
       case "go": {
         if (!params.url) {
           throw new Error("go requires a URL");
@@ -511,19 +524,6 @@ async function handleCommand(message) {
       // Execute JavaScript in content script
       case "exec": {
         result = await sendToContentScript("exec", params, tabId);
-        break;
-      }
-
-      // Execute JavaScript on a specific tab (used for remote tab proxying)
-      case "exec-on-tab": {
-        if (!params.tabId) {
-          throw new Error("exec-on-tab requires tabId parameter");
-        }
-        result = await sendToContentScript(
-          "exec",
-          { code: params.code },
-          params.tabId,
-        );
         break;
       }
 
@@ -729,35 +729,8 @@ browser.runtime.onMessage.addListener((message, sender, _sendResponse) => {
             }
             break;
           }
-          case "new-tab": {
-            result = await createNewTab(params.url);
-            break;
-          }
-          case "go": {
-            result = await navigate(params.url, senderTabShortId);
-            break;
-          }
-          case "close-tab": {
-            result = await closeTab(params.tabId || senderTabShortId);
-            break;
-          }
-          case "list-tabs": {
-            result = await listTabs();
-            break;
-          }
           case "download": {
             result = await downloadFile(params.url, params.filename);
-            break;
-          }
-          case "exec-on-tab": {
-            if (!params.tabId) {
-              throw new Error("exec-on-tab requires tabId parameter");
-            }
-            result = await sendToContentScript(
-              "exec",
-              { code: params.code },
-              params.tabId,
-            );
             break;
           }
           default: {

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -31,14 +31,6 @@ if (!window.__browserCliInjected) {
   /** @type {number} */
   const MAX_CONSOLE_LOGS = 1000;
 
-  /**
-   * Track the remote tab ID when tab() switches context.
-   * When set, API functions like snap(), click(), etc. delegate to this tab.
-   * @type {string|null}
-   */
-  // eslint-disable-next-line unicorn/no-null
-  let _remoteTabId = null;
-
   /** @type {HTMLDivElement|undefined} Virtual cursor element */
   let virtualCursor;
 
@@ -1872,18 +1864,6 @@ if (!window.__browserCliInjected) {
   }
 
   /**
-   * Execute JavaScript code on a remote tab via background script.
-   * Used to delegate API calls when tab() has switched context.
-   * @param {string} code - JavaScript code to execute
-   * @param {string} tabId - Target tab short ID
-   * @returns {Promise<any>} Result from the remote tab
-   */
-  async function execOnRemoteTab(code, tabId) {
-    const result = await sendToBackground("exec-on-tab", { code, tabId });
-    return result?.result;
-  }
-
-  /**
    * Take a screenshot
    * @param {string} [path] - Output file path
    * @returns {Promise<string>} Path to saved screenshot
@@ -1891,29 +1871,6 @@ if (!window.__browserCliInjected) {
   async function shot(path) {
     const result = await sendToBackground("screenshot", { output_path: path });
     return result.screenshot_path || result.screenshot;
-  }
-
-  /**
-   * Create a new tab and switch execution context to it.
-   * After calling tab(), subsequent API calls (snap, click, etc.)
-   * will execute on the new tab.
-   * @param {string} [url] - URL to open
-   * @returns {Promise<{tabId: string, url: string}>} Tab info
-   */
-  async function tab(url) {
-    const result = await sendToBackground("new-tab", { url });
-    // Switch execution context: subsequent API calls target the new tab
-    _remoteTabId = result.tabId;
-    return { tabId: result.tabId, url: result.url };
-  }
-
-  /**
-   * List all managed tabs
-   * @returns {Promise<Array<{id: string, url: string, title: string, active: boolean}>>}
-   */
-  async function tabs() {
-    const result = await sendToBackground("list-tabs");
-    return result.tabs;
   }
 
   /**
@@ -2253,45 +2210,9 @@ if (!window.__browserCliInjected) {
       }
     }
 
-    // Reset remote tab context at start of each exec
-    // eslint-disable-next-line unicorn/no-null
-    _remoteTabId = null;
-
-    /**
-     * Create a proxy for a content-script function that delegates to the
-     * remote tab when _remoteTabId is set (i.e., after tab() was called).
-     * @param {string} fnName - Function name as it appears in the API
-     * @param {Function} localFn - The local implementation
-     * @returns {Function} Proxied function
-     */
-    function proxyFn(fnName, localFn) {
-      return async function (...args) {
-        if (_remoteTabId) {
-          // Serialize the call and execute on the remote tab
-          const serializedArgs = JSON.stringify(args);
-          const remoteCode = `return ${fnName}(...${serializedArgs})`;
-          return execOnRemoteTab(remoteCode, _remoteTabId);
-        }
-        return localFn(...args);
-      };
-    }
-
-    // Create proxied versions of content-script functions
-    const pClick = proxyFn("click", click);
-    const pType = proxyFn("type", type);
-    const pHover = proxyFn("hover", hover);
-    const pDrag = proxyFn("drag", drag);
-    const pSelect = proxyFn("select", select);
-    const pKey = proxyFn("key", key);
-    const pSnap = proxyFn("snap", snap);
-    const pLogs = proxyFn("logs", logs);
-    const pFind = proxyFn("find", find);
-    const pWait = proxyFn("wait", wait);
-    const pRead = proxyFn("read", read);
-
     // Make API functions available in the execution context
     const fn = new AsyncFunction(
-      // Content script functions (proxied)
+      // Content script functions
       "click",
       "type",
       "hover",
@@ -2305,29 +2226,25 @@ if (!window.__browserCliInjected) {
       "read",
       // Background script functions
       "shot",
-      "tab",
-      "tabs",
       "download",
       wrappedCode,
     );
 
     const result = await fn(
-      // Content script functions (proxied)
-      pClick,
-      pType,
-      pHover,
-      pDrag,
-      pSelect,
-      pKey,
-      pSnap,
-      pLogs,
-      pFind,
-      pWait,
-      pRead,
+      // Content script functions
+      click,
+      type,
+      hover,
+      drag,
+      select,
+      key,
+      snap,
+      logs,
+      find,
+      wait,
+      read,
       // Background script functions
       shot,
-      tab,
-      tabs,
       download,
     );
 

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.0.39",
+  "version": "1.1.0",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768127708,
-        "narHash": "sha256-1Sm77VfZh3mU0F5OqKABNLWxOuDeHIlcFjsXeeiPazs=",
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffbc9f8cbaacfb331b6017d5a5abb21a492c9a38",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768158989,
-        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
+        "lastModified": 1773297127,
+        "narHash": "sha256-6E/yhXP7Oy/NbXtf1ktzmU8SdVqJQ09HC/48ebEGBpk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
+        "rev": "71b125cd05fbfd78cab3e070b73544abe24c5016",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,6 @@
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
-        "x86_64-darwin"
       ];
 
       imports = [

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -9,13 +9,11 @@ description: Control Firefox browser from the command line. Use for web automati
 # List managed tabs
 browser-cli --list
 
-# Open a page and get snapshot
-browser-cli <<'EOF'
-await tab("https://example.com")
-snap()
-EOF
+# Open a page (creates a managed tab, prints its ID)
+browser-cli --go "https://example.com"
+# -> Opened https://example.com in new tab abc123
 
-# Execute in a specific tab
+# Execute in that tab
 browser-cli abc123 <<'EOF'
 snap()
 EOF
@@ -119,13 +117,8 @@ browser-cli TABID --go "https://example.com"
 # Then run commands on the loaded page
 browser-cli TABID <<< "read()"
 
-# Open new tab (note: switches execution context)
-browser-cli <<'EOF'
-await tab("https://example.com")
-EOF
-
 # List all tabs
-browser-cli <<< "await tabs()"
+browser-cli --list
 ```
 
 ## Screenshots
@@ -159,26 +152,26 @@ URL: https://example.com
 
 ```bash
 # Search on Google
-browser-cli <<'EOF'
-await tab("https://google.com")
-snap()
-EOF
+browser-cli --go "https://google.com"
+# -> Opened https://google.com in new tab gX7k2a
+
+browser-cli gX7k2a <<< 'snap()'
 # Output shows [12] combobox "Suche"
 
-browser-cli <<'EOF'
+browser-cli gX7k2a <<'EOF'
 await type(12, "hello world")
 diff()
 EOF
 # Shows: Added (autocomplete options), Changed (input value)
 
 # Form filling
-browser-cli <<'EOF'
-await tab("https://example.com/login")
-snap()
-EOF
+browser-cli --go "https://example.com/login"
+# -> Opened ... in new tab h9Jk3b
+
+browser-cli h9Jk3b <<< 'snap()'
 # Output: [1] input "Email", [2] input "Password", [3] button "Sign In"
 
-browser-cli <<'EOF'
+browser-cli h9Jk3b <<'EOF'
 await type(1, "user@test.com")
 await type(2, "secret123")
 await click(3)
@@ -186,7 +179,7 @@ diff()
 EOF
 
 # Wait for dynamic content
-browser-cli <<'EOF'
+browser-cli h9Jk3b <<'EOF'
 await click(5)
 await wait("text", "Success")
 snap()


### PR DESCRIPTION

The tab()/tabs() JS API and the remote-tab-proxy layer that backed it
were fundamentally broken:

  - tab() + snap() in one script needed a proxy that serialized every
    API call via JSON.stringify and re-executed it as a string on the
    remote tab. This lost non-JSON args, broke diff() state, and added
    a two-hop round-trip per call.
  - tabs() required a content-script context just to list tabs, so it
    could not bootstrap from zero tabs.
  - The bridge cached latest_tab_id and injected it into every request
    lacking an explicit tabId. This cache went stale after browser
    restart, yielding cryptic "Tab Xyz not found" for every command.
  - The bridge also auto-created an example.com tab to bootstrap, which
    was documented as a "known issue" rather than fixed.

All of this existed to make `tab(url); snap()` work in one script, but
the real answer is: do not do that. Tab management belongs on the CLI
side where it is stateless and composable:

  browser-cli --go URL    -> opens/navigates, prints tab ID
  browser-cli --list      -> lists tabs
  browser-cli TABID <<< . -> runs on that tab

Changes:
  - Drop tab(), tabs(), _remoteTabId, proxyFn, exec-on-tab
  - Drop bridge._ensure_tab_exists and latest_tab_id; bridge is now a
    dumb pipe with the extension as single source of truth
  - navigate() auto-creates a tab when none exists, so --go URL works
    from a cold start and prints the new tab ID
  - getTargetTab() clears stale activeTabId instead of erroring on it
  - Update SKILL.md, README, --help to the --go/--list/TABID workflow
  - Bump extension to 1.1.0

Net: -177 lines, one less stateful cache, one fewer "known issue".
