### PR TITLE
extension: capture page console via wrappedJSObject at document_start

### DIFF
--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -154,6 +154,9 @@ async function getTargetTab(targetTabId) {
   );
 }
 
+/** @type {number} Monotonic counter to disambiguate messages sent in the same millisecond. */
+let contentMessageCounter = 0;
+
 /**
  * Send command to content script
  * @param {string} command
@@ -161,9 +164,6 @@ async function getTargetTab(targetTabId) {
  * @param {string} [targetTabId]
  * @returns {Promise<object>}
  */
-/** @type {number} Monotonic counter to disambiguate messages sent in the same millisecond. */
-let contentMessageCounter = 0;
-
 async function sendToContentScript(command, params = {}, targetTabId) {
   const tabId = await getTargetTab(targetTabId);
 

--- a/browser-cli/extension/console-capture.js
+++ b/browser-cli/extension/console-capture.js
@@ -1,0 +1,131 @@
+/// <reference types="firefox-webext-browser" />
+
+/**
+ * Early console capture — runs at document_start on every page.
+ *
+ * Patches the PAGE's console (not the content-script isolated world's)
+ * via wrappedJSObject + exportFunction. This bypasses CSP because no
+ * DOM <script> is injected, and catches logs emitted during page load
+ * because it runs before any page script.
+ *
+ * Logs are buffered on the isolated-world window so that content.js
+ * (injected later via tabs.executeScript) can read them. Both scripts
+ * share the same isolated world for a given page.
+ */
+
+// Guard against double-injection (bfcache restore, SPA soft navigation)
+// @ts-ignore - custom property
+if (!window.__browserCliConsoleCapture) {
+  /**
+   * @typedef {object} ConsoleLog
+   * @property {string} type
+   * @property {string} message
+   * @property {string} timestamp
+   */
+
+  /** @type {ConsoleLog[]} */
+  const buffer = [];
+  const MAX_LOGS = 1000;
+
+  // Expose buffer to later-injected content.js via the shared isolated world.
+  // @ts-ignore - custom property
+  window.__browserCliConsoleCapture = buffer;
+
+  /**
+   * Serialize an argument the way DevTools would show it. Runs with
+   * page-world values, so wrap in try/catch — hostile getters, proxies
+   * and cyclic structures are all possible.
+   * @param {unknown} arg
+   * @returns {string}
+   */
+  function serialize(arg) {
+    try {
+      if (arg === null) {
+        return "null";
+      }
+      if (arg === undefined) {
+        return "undefined";
+      }
+      if (typeof arg === "object") {
+        return JSON.stringify(arg);
+      }
+      return String(arg);
+    } catch {
+      try {
+        return String(arg);
+      } catch {
+        return "[unserializable]";
+      }
+    }
+  }
+
+  /**
+   * @param {string} method
+   * @param {unknown[]} args
+   */
+  function record(method, args) {
+    buffer.push({
+      type: method,
+      message: args.map((a) => serialize(a)).join(" "),
+      timestamp: new Date().toISOString(),
+    });
+    if (buffer.length > MAX_LOGS) {
+      buffer.shift();
+    }
+  }
+
+  // wrappedJSObject gives us the page-world globals without injecting
+  // a <script>, so CSP never sees us. exportFunction is required to
+  // hand a content-script function to page-world code without Xray
+  // wrappers getting in the way.
+  //
+  // Both are Firefox-only. If we ever port to Chrome this whole file
+  // needs the MAIN-world injection approach instead.
+  const pageWindow = /** @type {any} */ (window).wrappedJSObject;
+  if (pageWindow && typeof exportFunction === "function") {
+    const pageConsole = pageWindow.console;
+
+    for (const method of ["log", "error", "warn", "info", "debug"]) {
+      const original = pageConsole[method];
+      if (typeof original !== "function") {
+        continue;
+      }
+
+      exportFunction(
+        function (/** @type {unknown[]} */ ...args) {
+          record(method, args);
+          return original.apply(pageConsole, args);
+        },
+        pageConsole,
+        { defineAs: method },
+      );
+    }
+
+    // Uncaught errors and promise rejections are the things you most
+    // want when debugging, and they never go through console.* at all.
+    pageWindow.addEventListener(
+      "error",
+      exportFunction(
+        /** @param {ErrorEvent} e */
+        function (e) {
+          record("error", [
+            `Uncaught ${e.message} (${e.filename}:${e.lineno}:${e.colno})`,
+          ]);
+        },
+        pageWindow,
+      ),
+      true,
+    );
+
+    pageWindow.addEventListener(
+      "unhandledrejection",
+      exportFunction(
+        /** @param {PromiseRejectionEvent} e */
+        function (e) {
+          record("error", [`Unhandled rejection: ${serialize(e.reason)}`]);
+        },
+        pageWindow,
+      ),
+    );
+  }
+}

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -703,7 +703,9 @@ if (!window.__browserCliInjected) {
    * @returns {string}
    */
   function cssAttrQuote(s) {
-    return `"${s.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+    // eslint-disable-next-line unicorn/prefer-string-raw -- nested in template literal
+    const escaped = s.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+    return `"${escaped}"`;
   }
 
   /**
@@ -2273,12 +2275,15 @@ if (!window.__browserCliInjected) {
   function compileExec(code) {
     const trimmed = code.trim();
 
-    /** @param {string} body */
+    /**
+     * @param {string} body
+     * @returns {Function|undefined}
+     */
     const tryCompile = (body) => {
       try {
         return new AsyncFunction(...execApiNames, body);
       } catch {
-        return undefined;
+        return undefined; // eslint-disable-line unicorn/no-useless-undefined
       }
     };
 

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -26,8 +26,17 @@ if (!window.__browserCliInjected) {
    * @property {Element} domElement - Reference to DOM element
    */
 
-  /** @type {ConsoleLog[]} Store console logs */
-  const consoleLogs = [];
+  /**
+   * Page console logs. The buffer itself lives in console-capture.js,
+   * a document_start content script that patches the page-world console
+   * via wrappedJSObject (so CSP never blocks it and early logs are not
+   * missed). Both scripts share the same isolated world, hence the
+   * window-scoped handoff.
+   *
+   * @type {ConsoleLog[]}
+   */
+  // @ts-ignore - custom property populated by console-capture.js
+  const consoleLogs = window.__browserCliConsoleCapture || [];
   /** @type {number} */
   const MAX_CONSOLE_LOGS = 1000;
 
@@ -501,94 +510,38 @@ if (!window.__browserCliInjected) {
   }
 
   // ============================================================================
-  // Console Override
+  // Console capture (content-script world)
   // ============================================================================
+  //
+  // Page-world capture is handled by console-capture.js. Here we only
+  // patch the isolated-world console so that console.log() inside user
+  // exec() code also lands in the same buffer.
 
-  /**
-   * Inject console override into page context to capture all logs
-   */
-  function injectConsoleOverride() {
-    const script = document.createElement("script");
-    script.textContent = `
-    (function() {
-      const consoleMethods = ['log', 'error', 'warn', 'info', 'debug'];
-      consoleMethods.forEach(method => {
-        const original = console[method];
-        console[method] = function(...args) {
-          window.postMessage({
-            type: 'browser-cli-console',
-            method: method,
-            args: args.map(arg => {
-              try {
-                return typeof arg === 'object' ? JSON.stringify(arg) : String(arg);
-              } catch {
-                return '[Circular reference]';
-              }
-            }),
-            timestamp: new Date().toISOString()
-          }, '*');
-          original.apply(console, args);
-        };
-      });
-    })();
-  `;
-    (document.head || document.documentElement).append(script);
-    script.remove();
-  }
-
-  window.addEventListener("message", (event) => {
-    if (event.source !== window) {
-      return;
-    }
-
-    if (event.data && event.data.type === "browser-cli-console") {
-      consoleLogs.push({
-        type: event.data.method,
-        message: event.data.args.join(" "),
-        timestamp: event.data.timestamp,
-      });
-
-      if (consoleLogs.length > MAX_CONSOLE_LOGS) {
-        consoleLogs.shift();
-      }
-    }
-  });
-
-  injectConsoleOverride();
-
-  /** @type {Array<keyof Console>} */
-  const consoleMethods = /** @type {any} */ ([
+  for (const method of /** @type {const} */ ([
     "log",
     "error",
     "warn",
     "info",
     "debug",
-  ]);
-  for (const method of consoleMethods) {
-    // @ts-ignore
+  ])) {
     const original = console[method];
-    // @ts-ignore
-    console[method] = function (.../** @type {any[]} */ args) {
+    console[method] = function (.../** @type {unknown[]} */ args) {
       consoleLogs.push({
         type: method,
         message: args
-          .map((arg) => {
+          .map((a) => {
             try {
-              return typeof arg === "object"
-                ? JSON.stringify(arg)
-                : String(arg);
+              return typeof a === "object" ? JSON.stringify(a) : String(a);
             } catch {
-              return String(arg);
+              return String(a);
             }
           })
           .join(" "),
         timestamp: new Date().toISOString(),
       });
-
       if (consoleLogs.length > MAX_CONSOLE_LOGS) {
         consoleLogs.shift();
       }
-
       original.apply(console, args);
     };
   }

--- a/browser-cli/extension/eslint.config.js
+++ b/browser-cli/extension/eslint.config.js
@@ -53,6 +53,9 @@ export default [
         SubmitEvent: "readonly",
         MutationObserver: "readonly",
         Readability: "readonly",
+        // Firefox content-script APIs for page-world interop
+        exportFunction: "readonly",
+        cloneInto: "readonly",
       },
     },
     plugins: {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Control your browser from the command line",
 
   "applications": {
@@ -26,6 +26,15 @@
     "scripts": ["background.js"],
     "persistent": true
   },
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["console-capture.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ],
 
   "browser_action": {
     "default_title": "Browser CLI Controller",


### PR DESCRIPTION

The old approach injected an inline <script> to override the page's
console. That fails on any site with a CSP script-src directive
(GitHub, Google, essentially every modern app), and even where it ran
it was injected after onUpdated fires "complete" — long after the
page's own startup logging.

The content-script-world console override, meanwhile, only ever saw
logs from exec()'d user code because Firefox gives content scripts
their own isolated-world console distinct from the page's.

Replace both with a document_start content script that reaches into the
page world via window.wrappedJSObject and patches console.* with
exportFunction. No DOM script is injected so CSP never applies, and
document_start runs before any page script so early logs are captured.
Logs are stored on the isolated-world window where the later-injected
content.js reads them — both scripts share the same isolated world per
page, so a simple array handoff suffices.

While here, also capture uncaught errors and unhandled promise
rejections, which are usually what you actually want when debugging
and which never pass through console.* at all.

Firefox-only (wrappedJSObject/exportFunction). A Chrome port would
need the MAIN-world injection approach.


