### PR TITLE
skills: drop README links

### DIFF
--- a/db-cli/README.md
+++ b/db-cli/README.md
@@ -1,0 +1,45 @@
+# db-cli
+
+CLI for Deutsche Bahn train connections. Wraps
+[db-vendo-client](https://github.com/public-transport/db-vendo-client), which
+talks to the same backend as the bahn.de app — so unlike most transit tooling,
+**there is no API key, registration, or rate limit setup**. It just works.
+
+## Features
+
+- Fuzzy station name matching — `Köln` resolves to `KÖLN (8096022)` before the
+  journey query runs, so you don't need to know IBNR station IDs
+- Relative time parsing — `"in 30 minutes"`, `"by 18:00"` (rolls to tomorrow if
+  already past), or full ISO 8601
+- Deutschlandticket filter (`-t`) — drops ICE/IC/EC and shows only what the €58
+  ticket actually covers
+- Booking link — every search ends with a pre-filled `bahn.de/buchung` URL with
+  your stations, time, and ticket filter encoded, so you can click through to
+  pay without re-entering anything
+
+## Install
+
+```bash
+nix run github:Mic92/mics-skills#db-cli -- "Berlin Hbf" "München Hbf"
+```
+
+Or add `mics-skills.packages.${system}.db-cli` to your home-manager packages.
+
+## Usage
+
+See [skills/db-cli/SKILL.md](../skills/db-cli/SKILL.md) for command examples.
+
+## Development
+
+```bash
+npm install
+npm run lint
+```
+
+The journey display logic lives in `lib/journey-display.mjs`; the bahn.de URL
+encoding (which is undocumented and was reverse-engineered from browser
+traffic) is in `lib/bahn-url-builder.mjs`.
+
+## License
+
+ISC

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -76,5 +76,3 @@ await wait("text", "Welcome")
 snap()
 EOF
 ```
-
-See [README.md](../../browser-cli/README.md) for installation and full API reference.

--- a/skills/db-cli/SKILL.md
+++ b/skills/db-cli/SKILL.md
@@ -1,29 +1,17 @@
 ---
 name: db-cli
-description: Search Deutsche Bahn train connections. Use for finding train routes, schedules, and travel times in Germany.
+description: Search Deutsche Bahn train connections. Use for train routes, schedules, and travel times in Germany.
 ---
 
-# Usage
+Station names are fuzzy-matched. No API key needed.
 
 ```bash
-# Basic search (uses current time)
-db-cli "Berlin Hbf" "München Hbf"
-
-# Search with specific departure time
-db-cli -d "2025-01-15T14:30" "Frankfurt" "Hamburg"
-
-# Search with arrival time
-db-cli -a "2025-01-15T18:00" "Köln" "Stuttgart"
+db-cli "Berlin Hbf" "München Hbf"                  # depart now
+db-cli -d "2026-04-10T14:30" Frankfurt Hamburg     # ISO departure
+db-cli -d "in 30 minutes" Hamburg Frankfurt        # relative
+db-cli -a "by 18:00" Köln Stuttgart                # arrive by (rolls to tomorrow if past)
+db-cli -t Berlin München                           # Deutschlandticket only (no ICE/IC/EC)
+db-cli -r 5 Berlin München                         # show 5 results (default 3)
 ```
 
-# Output Format
-
-Results show connections with:
-
-- Departure/arrival times
-- Duration
-- Number of transfers
-- Train types (ICE, IC, RE, etc.)
-- Platform information
-
-See [README.md](../../db-cli/README.md) for full documentation.
+Output: per-journey departure → arrival, duration, transfer count, per-leg train type and platforms. Ends with a pre-filled bahn.de booking URL.

--- a/skills/gmaps-cli/SKILL.md
+++ b/skills/gmaps-cli/SKILL.md
@@ -45,5 +45,3 @@ Route from Los Angeles, CA, USA to San Francisco, CA, USA
 Distance: 382 mi
 Duration: 5 hours 48 mins
 ```
-
-See [README.md](../../gmaps-cli/README.md) for setup and full documentation.

--- a/skills/kagi-search/SKILL.md
+++ b/skills/kagi-search/SKILL.md
@@ -18,5 +18,3 @@ kagi-search -l -n 10 "search query"
 # JSON output for parsing
 kagi-search -j "search query" | jq '.results[0].url'
 ```
-
-See [README.md](../../kagi-search/README.md) for setup and configuration.


### PR DESCRIPTION

The skill file is the runtime context an agent loads to do a task.
"See README for setup" is dead weight there: if the tool is invokable
the setup already happened, and if it is not the agent will see the
exec error before it sees a markdown link it cannot follow anyway.


