### PR TITLE
skills: drop README links

### DIFF
--- a/skills/db-cli/SKILL.md
+++ b/skills/db-cli/SKILL.md
@@ -3,7 +3,7 @@ name: db-cli
 description: Search Deutsche Bahn train connections. Use for train routes, schedules, and travel times in Germany.
 ---
 
-Station names are fuzzy-matched. No API key needed.
+Station names are fuzzy-matched.
 
 ```bash
 db-cli "Berlin Hbf" "München Hbf"                  # depart now


### PR DESCRIPTION

The skill file is the runtime context an agent loads to do a task.
"See README for setup" is dead weight there: if the tool is invokable
the setup already happened, and if it is not the agent will see the
exec error before it sees a markdown link it cannot follow anyway.
