### PR TITLE
browser-cli: surgical inspection API + scriptable CLI

### DIFF
--- a/browser-cli/BUGS.md
+++ b/browser-cli/BUGS.md
@@ -1,3 +1,11 @@
 # Browser CLI Bugs
 
 No known bugs.
+
+## Known gotchas
+
+- **Policy installs are version-gated.** `force_installed` compares
+  `manifest.version` against the profile's installed copy and skips if
+  equal. Editing extension code without bumping the version means the
+  profile xpi never updates, even after a fresh nix build + browser
+  restart. Bump `manifest.json` `version` on every shipped change.

--- a/browser-cli/browser_cli/bridge.py
+++ b/browser-cli/browser_cli/bridge.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import logging
+import mimetypes
 import struct
 import sys
 from pathlib import Path
@@ -138,6 +139,9 @@ class NativeMessagingBridge:
         if command == "save-screenshot":
             await self._handle_save_screenshot(message)
             return
+        if command == "read-files":
+            await self._handle_read_files(message)
+            return
 
         if msg_id and msg_id in self.pending_responses:
             # This is a response to a CLI request
@@ -201,6 +205,53 @@ class NativeMessagingBridge:
                     "error": f"Failed to save screenshot: {e!s}",
                 },
             )
+
+    async def _handle_read_files(self, message: dict[str, Any]) -> None:
+        """Read files from disk for upload(). Ships content as base64.
+
+        Native messaging caps a single message at 1 MB, so this rejects
+        anything that would push the response past that. Uploading a 50 MB
+        video is out of scope; uploading a CSV/PNG/PDF is the use case.
+        """
+        msg_id = message.get("id")
+        paths = message.get("params", {}).get("paths", [])
+        result, error = self._read_files_for_upload(paths)
+        if error is None:
+            await self.write_native_message(
+                {"id": msg_id, "success": True, "result": result},
+            )
+        else:
+            await self.write_native_message(
+                {"id": msg_id, "success": False, "error": error},
+            )
+
+    @staticmethod
+    def _read_files_for_upload(
+        paths: list[str],
+    ) -> tuple[list[dict[str, str]], str | None]:
+        """Load and base64-encode files within the native-messaging size budget."""
+        # Leave headroom for the JSON envelope around the base64 payload.
+        budget = 900_000
+        files: list[dict[str, str]] = []
+        for raw in paths:
+            p = Path(raw).expanduser()
+            try:
+                data = p.read_bytes()
+            except OSError as e:
+                return [], f"{raw}: {e}"
+            b64 = base64.b64encode(data).decode("ascii")
+            budget -= len(b64)
+            if budget < 0:
+                return [], (f"File(s) too large for native messaging (~1MB limit): {raw}")
+            mime, _ = mimetypes.guess_type(p.name)
+            files.append(
+                {
+                    "name": p.name,
+                    "mime": mime or "application/octet-stream",
+                    "data": b64,
+                },
+            )
+        return files, None
 
     async def handle_cli_client(
         self,

--- a/browser-cli/browser_cli/bridge.py
+++ b/browser-cli/browser_cli/bridge.py
@@ -7,10 +7,17 @@ import logging
 import mimetypes
 import struct
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Native messaging caps app→extension messages at 1 MiB (Firefox
+# NativeMessaging.sys.mjs MAX_READ, Chrome kMaximumNativeMessageSize).
+# We chunk file payloads under that, leaving headroom for the JSON
+# envelope around each chunk.
+FILE_CHUNK_BYTES = 700_000
 
 
 class NativeMessagingBridge:
@@ -207,51 +214,53 @@ class NativeMessagingBridge:
             )
 
     async def _handle_read_files(self, message: dict[str, Any]) -> None:
-        """Read files from disk for upload(). Ships content as base64.
+        """Stream local files to the extension as base64 chunks.
 
-        Native messaging caps a single message at 1 MB, so this rejects
-        anything that would push the response past that. Uploading a 50 MB
-        video is out of scope; uploading a CSV/PNG/PDF is the use case.
+        The 1 MiB native-messaging cap is per-message, not per-connection,
+        so we side-step it by sending N chunk messages followed by a final
+        completion. The extension reassembles by file index.
         """
         msg_id = message.get("id")
         paths = message.get("params", {}).get("paths", [])
-        result, error = self._read_files_for_upload(paths)
-        if error is None:
+        try:
+            for chunk in self._iter_file_chunks(paths):
+                await self.write_native_message({"id": msg_id, "chunk": chunk})
+            await self.write_native_message({"id": msg_id, "success": True})
+        except OSError as e:
             await self.write_native_message(
-                {"id": msg_id, "success": True, "result": result},
-            )
-        else:
-            await self.write_native_message(
-                {"id": msg_id, "success": False, "error": error},
+                {"id": msg_id, "success": False, "error": str(e)},
             )
 
     @staticmethod
-    def _read_files_for_upload(
+    def _iter_file_chunks(
         paths: list[str],
-    ) -> tuple[list[dict[str, str]], str | None]:
-        """Load and base64-encode files within the native-messaging size budget."""
-        # Leave headroom for the JSON envelope around the base64 payload.
-        budget = 900_000
-        files: list[dict[str, str]] = []
-        for raw in paths:
+    ) -> Iterator[dict[str, str | int]]:
+        """Yield base64 chunks per file, sized for the native-messaging cap.
+
+        Reads in raw-byte blocks aligned to 3 so each chunk's base64 is
+        self-contained (no '=' padding mid-stream) and the receiver can
+        simply concatenate before decoding.
+        """
+        # 3 raw bytes -> 4 base64 chars; align so chunks join cleanly.
+        raw_block = (FILE_CHUNK_BYTES // 4 * 3) // 3 * 3
+        for idx, raw in enumerate(paths):
             p = Path(raw).expanduser()
-            try:
-                data = p.read_bytes()
-            except OSError as e:
-                return [], f"{raw}: {e}"
-            b64 = base64.b64encode(data).decode("ascii")
-            budget -= len(b64)
-            if budget < 0:
-                return [], (f"File(s) too large for native messaging (~1MB limit): {raw}")
             mime, _ = mimetypes.guess_type(p.name)
-            files.append(
-                {
-                    "name": p.name,
-                    "mime": mime or "application/octet-stream",
-                    "data": b64,
-                },
-            )
-        return files, None
+            mime = mime or "application/octet-stream"
+            sent = False
+            with p.open("rb") as fh:
+                while data := fh.read(raw_block):
+                    sent = True
+                    yield {
+                        "file": idx,
+                        "name": p.name,
+                        "mime": mime,
+                        "data": base64.b64encode(data).decode("ascii"),
+                    }
+            if not sent:
+                # Zero-byte file: still emit one chunk so the extension
+                # learns the name/mime.
+                yield {"file": idx, "name": p.name, "mime": mime, "data": ""}
 
     async def handle_cli_client(
         self,

--- a/browser-cli/browser_cli/cli.py
+++ b/browser-cli/browser_cli/cli.py
@@ -252,27 +252,40 @@ async def navigate_tab(
     """
     client = BrowserClient(socket, firefox_path=firefox_path)
     result = await client.send_command("go", {"url": url}, tab_id)
-    new_id = result.get("tabId")
-    if new_id and new_id != tab_id:
-        print(f"Opened {url} in new tab {new_id}")
+    # The extension always returns the tab ID it acted on. Print exactly
+    # that to stdout so `TAB=$(browser-cli --go ...)` works regardless of
+    # whether a tab was created or reused; prose goes to stderr.
+    final_id = result.get("tabId") or tab_id
+    if final_id and final_id != tab_id:
+        print(f"Opened {url} in new tab {final_id}", file=sys.stderr)
     else:
-        print(f"Navigated to {url}")
+        print(f"Navigated to {url}", file=sys.stderr)
+    if final_id:
+        print(final_id)
 
 
-async def list_tabs(socket: str | None, firefox_path: str | None = None) -> None:
+async def list_tabs(
+    socket: str | None,
+    firefox_path: str | None = None,
+    *,
+    as_json: bool = False,
+) -> None:
     """List all managed tabs."""
     client = BrowserClient(socket, firefox_path=firefox_path)
     tabs = await client.list_tabs()
+    if as_json:
+        print(json.dumps(tabs))
+        return
     if not tabs:
-        print("No managed tabs")
+        print("No managed tabs", file=sys.stderr)
         return
     for tab in tabs:
         tab_id = tab.get("id", "unknown")
         url = tab.get("url", "about:blank")
         title = tab.get("title", "Untitled")
-        active = " (active)" if tab.get("active") else ""
-        print(f"{tab_id}: {title}{active}")
-        print(f"       {url}")
+        active = "*" if tab.get("active") else " "
+        # ID first, fixed-width, tab-separated: parseable with `cut -f1`.
+        print(f"{tab_id}\t{active}\t{url}\t{title}")
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -285,12 +298,11 @@ Examples:
   # List managed tabs
   browser-cli --list
 
-  # Open a page (creates tab, prints its ID)
-  browser-cli --go "https://example.com"
-  # -> Opened https://example.com in new tab abc123
+  # Open a page; tab ID on stdout, prose on stderr
+  TAB=$(browser-cli --go "https://example.com")
 
   # Get snapshot of that tab
-  browser-cli abc123 <<< 'snap()'
+  browser-cli $TAB <<< 'snap()'
 
   # Form filling with refs
   browser-cli abc123 <<'EOF'
@@ -351,7 +363,12 @@ Tab management is done via CLI flags, not JS:
     parser.add_argument(
         "--list",
         action="store_true",
-        help="List all managed tabs",
+        help="List all managed tabs (TSV: id<TAB>active<TAB>url<TAB>title)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output --list as JSON",
     )
     parser.add_argument(
         "--install-host",
@@ -402,7 +419,7 @@ def main() -> None:
             install_native_host()
         elif args.list:
             firefox_path = _resolve_firefox_path(args)
-            asyncio.run(list_tabs(args.socket, firefox_path=firefox_path))
+            asyncio.run(list_tabs(args.socket, firefox_path=firefox_path, as_json=args.json))
         elif args.go:
             firefox_path = _resolve_firefox_path(args)
             asyncio.run(navigate_tab(args.tab_id, args.go, args.socket, firefox_path=firefox_path))

--- a/browser-cli/default.nix
+++ b/browser-cli/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonApplication {
   pname = "browser-cli";
-  version = "0.3.0";
+  version = "0.4.0";
   src = ./.;
   pyproject = true;
 

--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -342,6 +342,57 @@ async function saveScreenshotToFile(dataUrl, outputPath) {
 }
 
 /**
+ * Read local files via the native bridge so content scripts can populate
+ * <input type=file> without a user gesture. The extension itself has no
+ * filesystem access; the Python bridge does the actual disk I/O.
+ *
+ * @param {string[]} paths - Absolute paths on the local filesystem
+ * @returns {Promise<{name: string, mime: string, data: string}[]>}
+ */
+async function readLocalFiles(paths) {
+  if (!nativePort) {
+    throw new Error("Native messaging not connected - cannot read files");
+  }
+
+  const messageId = `read_files_${Date.now()}`;
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      delete messageHandlers[messageId];
+      reject(new Error("File read timeout"));
+    }, 30_000);
+
+    messageHandlers[messageId] = {
+      /** @param {{success?: boolean, result?: {name: string, mime: string, data: string}[], error?: string}} response */
+      resolve: (response) => {
+        clearTimeout(timeout);
+        if (response.success && response.result) {
+          resolve(response.result);
+        } else {
+          reject(new Error(response.error || "Failed to read files"));
+        }
+      },
+      /** @param {Error} error */
+      reject: (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    };
+
+    if (!nativePort) {
+      reject(new Error("Native messaging disconnected"));
+      return;
+    }
+
+    nativePort.postMessage({
+      command: "read-files",
+      params: { paths },
+      id: messageId,
+    });
+  });
+}
+
+/**
  * List all managed tabs
  * @returns {Promise<{tabs: Array<{id: string, tabId: number, url: string, title: string, active: boolean}>}>}
  */
@@ -739,6 +790,10 @@ browser.runtime.onMessage.addListener((message, sender, _sendResponse) => {
           }
           case "download": {
             result = await downloadFile(params.url, params.filename);
+            break;
+          }
+          case "read-files": {
+            result = await readLocalFiles(params.paths);
             break;
           }
           default: {

--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -11,6 +11,13 @@
  * @property {CommandParams} [params] - Command parameters
  * @property {string} [id] - Unique message ID
  * @property {string} [tabId] - Target tab ID for the command
+ * @property {FileChunk} [chunk] - One slice of a streamed file (read-files)
+ *
+ * @typedef {object} FileChunk
+ * @property {number} file - Index into the requested paths array
+ * @property {string} name - Basename of the file
+ * @property {string} mime - Best-guess content type
+ * @property {string} data - Base64 slice (3-byte-aligned, joinable)
  *
  * @typedef {object} Message
  * @property {string} command - The command to execute
@@ -29,7 +36,7 @@
 /** @type {browser.runtime.Port|undefined} Native messaging port */
 let nativePort;
 
-/** @type {Record<string, {resolve: Function, reject: Function}>} Message handlers from content scripts */
+/** @type {Record<string, {resolve: Function, reject: Function, chunk?: (c: FileChunk) => void}>} Message handlers from content scripts */
 const messageHandlers = {};
 
 /** @type {Map<string, {tabId: number, url: string, title: string}>} Map of managed tabs with short IDs */
@@ -84,9 +91,16 @@ function connectNativeHost() {
         return;
       }
 
-      // Handle responses to our requests (e.g., save-screenshot)
+      // Handle responses to our requests (e.g., save-screenshot, read-files)
       if (message.id && messageHandlers[message.id]) {
         const handler = messageHandlers[message.id];
+        // Chunked transfers (read-files) send N chunk messages followed
+        // by a final non-chunk completion. Keep the handler alive until
+        // that final message arrives.
+        if (message.chunk && handler.chunk) {
+          handler.chunk(message.chunk);
+          return;
+        }
         delete messageHandlers[message.id];
         handler.resolve(message);
         return;
@@ -346,6 +360,9 @@ async function saveScreenshotToFile(dataUrl, outputPath) {
  * <input type=file> without a user gesture. The extension itself has no
  * filesystem access; the Python bridge does the actual disk I/O.
  *
+ * Native messaging caps app→extension messages at 1MB, so the bridge
+ * streams files in chunks. We reassemble here per file index.
+ *
  * @param {string[]} paths - Absolute paths on the local filesystem
  * @returns {Promise<{name: string, mime: string, data: string}[]>}
  */
@@ -355,19 +372,43 @@ async function readLocalFiles(paths) {
   }
 
   const messageId = `read_files_${Date.now()}`;
+  /** @type {{name: string, mime: string, parts: string[]}[]} */
+  const buffers = paths.map(() => ({ name: "", mime: "", parts: [] }));
 
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      delete messageHandlers[messageId];
-      reject(new Error("File read timeout"));
-    }, 30_000);
+    // Timeout is sliding: any chunk arrival resets it. A 100MB file at
+    // 700KB/chunk is ~150 messages; we don't want a fixed deadline.
+    /** @type {ReturnType<typeof setTimeout>} */
+    let timeout;
+    const arm = () => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        delete messageHandlers[messageId];
+        reject(new Error("File read timeout (no data for 30s)"));
+      }, 30_000);
+    };
+    arm();
 
     messageHandlers[messageId] = {
-      /** @param {{success?: boolean, result?: {name: string, mime: string, data: string}[], error?: string}} response */
+      /** @param {{file: number, name: string, mime: string, data: string}} c */
+      chunk: (c) => {
+        arm();
+        const buf = buffers[c.file];
+        buf.name = c.name;
+        buf.mime = c.mime;
+        buf.parts.push(c.data);
+      },
+      /** @param {{success?: boolean, error?: string}} response */
       resolve: (response) => {
         clearTimeout(timeout);
-        if (response.success && response.result) {
-          resolve(response.result);
+        if (response.success) {
+          resolve(
+            buffers.map((b) => ({
+              name: b.name,
+              mime: b.mime,
+              data: b.parts.join(""),
+            })),
+          );
         } else {
           reject(new Error(response.error || "Failed to read files"));
         }

--- a/browser-cli/extension/background.js
+++ b/browser-cli/extension/background.js
@@ -81,7 +81,11 @@ function connectNativeHost() {
 
     nativePort.onMessage.addListener(async (msg) => {
       const message = /** @type {NativeMessage} */ (msg);
-      console.log("Received from native host:", message);
+      // Chunks can be 700KB each; logging them floods devtools and
+      // pins memory until the console is cleared.
+      if (!message.chunk) {
+        console.log("Received from native host:", message);
+      }
 
       if (message.ready && message.socket_path) {
         console.log(
@@ -200,13 +204,33 @@ async function sendToContentScript(command, params = {}, targetTabId) {
 // Browser-level commands (require background script)
 // ============================================================================
 
+/** URL schemes that content scripts cannot be injected into.
+ *  executeScript() throws "Missing host permission" on these even with
+ *  <all_urls> — they're hard-excluded by the WebExtension security model. */
+const PRIVILEGED_URL_PREFIXES = [
+  "about:",
+  "moz-extension:",
+  "chrome:",
+  "resource:",
+  "javascript:",
+  "data:",
+  "view-source:",
+];
+
 /**
  * Navigate a managed tab to a new URL and wait for load
  * @param {string} url - URL to navigate to
  * @param {string} [tabId] - Tab ID (defaults to active tab)
- * @returns {Promise<{url: string}>}
+ * @returns {Promise<{url: string, tabId: string}>}
  */
 async function navigate(url, tabId) {
+  const blocked = PRIVILEGED_URL_PREFIXES.find((p) => url.startsWith(p));
+  if (blocked) {
+    throw new Error(
+      `Cannot inject into ${blocked} URLs (browser security policy). Use http(s):// or file://`,
+    );
+  }
+
   let targetId = tabId;
   if (!targetId) {
     // Validate activeTabId before using it — it can go stale.
@@ -263,7 +287,9 @@ async function navigate(url, tabId) {
   // Re-inject content script
   await enableOnTab(browserTabId, targetId);
 
-  return { url };
+  // Always include tabId so the CLI can print it even on the
+  // existing-tab path (TAB=$(browser-cli --go ...) must always work).
+  return { url, tabId: targetId };
 }
 
 /**
@@ -474,7 +500,6 @@ async function listTabs() {
 async function createNewTab(url) {
   const shortId = generateTabId();
   const tabUrl = url || "about:blank";
-
   const tab = await browser.tabs.create({ url: tabUrl, active: true });
 
   if (tab.id === undefined) {

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -1890,11 +1890,13 @@ if (!window.__browserCliInjected) {
       browser.runtime.onMessage.addListener(handleResponse);
       browser.runtime.sendMessage({ command, params, bgMessageId: messageId });
 
-      // Timeout after 30 seconds
+      // Timeout after 30 seconds (5 min for file reads — chunked transfers
+      // of large uploads can legitimately take longer than 30s).
+      const ms = command === "read-files" ? 300_000 : 30_000;
       setTimeout(() => {
         browser.runtime.onMessage.removeListener(handleResponse);
         reject(new Error("Background script timeout"));
-      }, 30_000);
+      }, ms);
     });
   }
 

--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -1078,9 +1078,26 @@ if (!window.__browserCliInjected) {
    * @property {boolean} [forms] - Only form elements
    * @property {boolean} [links] - Only links
    * @property {boolean} [buttons] - Only buttons
+   * @property {boolean} [interactive] - Only interactive elements (links, buttons, inputs, clickables)
    * @property {string} [text] - Filter by text content
    * @property {number} [near] - Elements near ref
    */
+
+  /** Roles considered interactive for snap({interactive: true}) */
+  const INTERACTIVE_ROLES = new Set([
+    "link",
+    "button",
+    "input",
+    "textarea",
+    "select",
+    "checkbox",
+    "radio",
+    "tab",
+    "menuitem",
+    "combobox",
+    "slider",
+    "switch",
+  ]);
 
   /**
    * Generate snapshot with optional filtering
@@ -1120,6 +1137,15 @@ if (!window.__browserCliInjected) {
         continue;
       }
       if (options.buttons && role !== "button") {
+        continue;
+      }
+
+      if (
+        options.interactive &&
+        !INTERACTIVE_ROLES.has(role) &&
+        !role.startsWith("input[") &&
+        !attrs.includes("clickable")
+      ) {
         continue;
       }
 
@@ -1893,6 +1919,207 @@ if (!window.__browserCliInjected) {
   }
 
   // ============================================================================
+  // Surgical inspection (token-cheap alternatives to full snap())
+  // ============================================================================
+
+  /**
+   * Extract one piece of information from one element. Prefer this over
+   * snap() when you already have a ref and just need a value/attribute —
+   * a full snapshot can cost thousands of tokens, this costs ~nothing.
+   *
+   * @param {string|number} selector - Ref number or CSS selector
+   * @param {string} [what='text'] - text | html | value | count | attr:<name>
+   * @param {SelectorType} [selectorType='css']
+   * @returns {string|number|null}
+   */
+  function get(selector, what = "text", selectorType = "css") {
+    if (what === "count") {
+      // count only makes sense for CSS selectors (refs are unique)
+      if (typeof selector !== "string") {
+        throw new TypeError("get(..., 'count') requires a CSS selector string");
+      }
+      return document.querySelectorAll(selector).length;
+    }
+
+    const element = find(selector, selectorType);
+
+    if (what === "text") {
+      // innerText for layout-aware text (skips hidden/script), fall back
+      // to textContent for elements where innerText is empty (e.g. <option>).
+      // eslint-disable-next-line unicorn/prefer-dom-node-text-content -- innerText is layout-aware on purpose
+      const inner = element instanceof HTMLElement ? element.innerText : "";
+      return (inner || element.textContent || "").trim();
+    }
+    if (what === "html") {
+      return element.outerHTML;
+    }
+    if (what === "value") {
+      return /** @type {HTMLInputElement} */ (element).value ?? null; // eslint-disable-line unicorn/no-null
+    }
+    if (what.startsWith("attr:")) {
+      return element.getAttribute(what.slice(5));
+    }
+    throw new Error(
+      `Unknown 'what': ${what}. Use text|html|value|count|attr:<name>`,
+    );
+  }
+
+  /**
+   * Check element state. Returns a boolean instead of making you parse
+   * "[disabled]" / "[checked]" out of snapshot output.
+   *
+   * @param {string|number} selector - Ref number or CSS selector
+   * @param {'visible'|'enabled'|'checked'} what
+   * @param {SelectorType} [selectorType='css']
+   * @returns {boolean}
+   */
+  function is(selector, what, selectorType = "css") {
+    const element = find(selector, selectorType);
+
+    switch (what) {
+      case "visible": {
+        // offsetParent is null for display:none and ancestors with it.
+        // Also catch zero-size and visibility:hidden.
+        if (!(element instanceof HTMLElement)) {
+          return false;
+        }
+        // position:fixed elements have null offsetParent but are visible
+        if (
+          element.offsetParent === null &&
+          window.getComputedStyle(element).position !== "fixed"
+        ) {
+          return false;
+        }
+        const rect = element.getBoundingClientRect();
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          window.getComputedStyle(element).visibility !== "hidden"
+        );
+      }
+      case "enabled": {
+        const inputLike = /** @type {HTMLInputElement} */ (element);
+        return !inputLike.disabled && !element.hasAttribute("aria-disabled");
+      }
+      case "checked": {
+        const inputLike = /** @type {HTMLInputElement} */ (element);
+        return (
+          inputLike.checked === true ||
+          element.getAttribute("aria-checked") === "true"
+        );
+      }
+      default: {
+        throw new Error(`Unknown 'what': ${what}. Use visible|enabled|checked`);
+      }
+    }
+  }
+
+  /**
+   * Scroll the viewport, or scroll an element into view. Snapshots only
+   * see what's in the viewport, so this is the unlock for infinite-scroll
+   * pages and lazy-loaded content.
+   *
+   * @param {number|string} target - Ref/selector to scroll into view,
+   *   or a direction: 'up' | 'down' | 'left' | 'right' | 'top' | 'bottom'
+   * @param {number} [amount] - Pixels (for directions). Default: one viewport.
+   * @param {SelectorType} [selectorType='css']
+   * @returns {{scrolled: string|number, x: number, y: number}}
+   */
+  function scroll(target, amount, selectorType = "css") {
+    if (typeof target === "string") {
+      const dy = amount ?? window.innerHeight;
+      const dx = amount ?? window.innerWidth;
+      switch (target) {
+        case "down": {
+          window.scrollBy({ top: dy, behavior: "instant" });
+          break;
+        }
+        case "up": {
+          window.scrollBy({ top: -dy, behavior: "instant" });
+          break;
+        }
+        case "right": {
+          window.scrollBy({ left: dx, behavior: "instant" });
+          break;
+        }
+        case "left": {
+          window.scrollBy({ left: -dx, behavior: "instant" });
+          break;
+        }
+        case "top": {
+          window.scrollTo({ top: 0, behavior: "instant" });
+          break;
+        }
+        case "bottom": {
+          window.scrollTo({
+            top: document.body.scrollHeight,
+            behavior: "instant",
+          });
+          break;
+        }
+        default: {
+          // Not a direction keyword — treat as CSS selector
+          find(target, selectorType).scrollIntoView({
+            block: "center",
+            behavior: "instant",
+          });
+        }
+      }
+    } else {
+      // Numeric ref
+      find(target).scrollIntoView({ block: "center", behavior: "instant" });
+    }
+    return { scrolled: target, x: window.scrollX, y: window.scrollY };
+  }
+
+  /**
+   * Set files on a file input. The bridge reads the file from disk and
+   * ships it over as base64; we reconstruct a real File object here so
+   * the page's change handlers see exactly what they'd see from a
+   * native file picker.
+   *
+   * @param {string|number} selector - Ref or selector for <input type=file>
+   * @param {string|string[]} paths - Absolute path(s) on the local filesystem
+   * @param {SelectorType} [selectorType='css']
+   * @returns {Promise<{uploaded: string[], to: string|number}>}
+   */
+  async function upload(selector, paths, selectorType = "css") {
+    const element = /** @type {HTMLInputElement} */ (
+      find(selector, selectorType)
+    );
+    if (element.tagName !== "INPUT" || element.type !== "file") {
+      throw new Error(
+        `Element is not a file input. Found: <${element.tagName.toLowerCase()}${element.type ? ` type=${element.type}` : ""}>`,
+      );
+    }
+
+    const pathList = Array.isArray(paths) ? paths : [paths];
+    if (pathList.length > 1 && !element.multiple) {
+      throw new Error(
+        `Input does not accept multiple files (${pathList.length} given)`,
+      );
+    }
+
+    /** @type {{name: string, mime: string, data: string}[]} */
+    const fileData = await sendToBackground("read-files", { paths: pathList });
+
+    // DataTransfer is the only way to populate the otherwise read-only
+    // .files property without a trusted user gesture.
+    const dt = new DataTransfer();
+    for (const f of fileData) {
+      const bytes = Uint8Array.from(atob(f.data), (c) => c.codePointAt(0) ?? 0);
+      dt.items.add(new File([bytes], f.name, { type: f.mime }));
+    }
+
+    moveCursorToElement(element);
+    element.files = dt.files;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+
+    return { uploaded: pathList, to: selector };
+  }
+
+  // ============================================================================
   // Message handling for background script commands
   // ============================================================================
   // Reader Mode (Mozilla Readability)
@@ -2212,6 +2439,10 @@ if (!window.__browserCliInjected) {
     read,
     shot,
     download,
+    get,
+    is,
+    scroll,
+    upload,
   };
   const execApiNames = Object.keys(execApi);
   const execApiValues = Object.values(execApi);

--- a/browser-cli/extension/eslint.config.js
+++ b/browser-cli/extension/eslint.config.js
@@ -32,6 +32,8 @@ export default [
         HTMLSelectElement: "readonly",
         HTMLImageElement: "readonly",
         DataTransfer: "readonly",
+        File: "readonly",
+        atob: "readonly",
         DragEvent: "readonly",
         Node: "readonly",
         NodeList: "readonly",

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/extension/manifest.json
+++ b/browser-cli/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Browser CLI Controller",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Control your browser from the command line",
 
   "applications": {

--- a/browser-cli/pyproject.toml
+++ b/browser-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-cli"
-version = "0.3.0"
+version = "0.4.0"
 description = "Control Firefox browser from the command line"
 requires-python = ">=3.13"
 license = {text = "MIT"}

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -6,9 +6,10 @@ description: Control Firefox browser from the command line. Use for web automati
 # Usage
 
 ```bash
-browser-cli --list                       # List managed tabs
-browser-cli --go "https://example.com"   # Open page, prints tab ID (e.g. abc123)
-browser-cli abc123 <<< 'snap()'          # Execute JS in that tab
+TAB=$(browser-cli --go "https://example.com")  # tab ID on stdout
+browser-cli $TAB <<< 'snap()'                  # execute JS in that tab
+browser-cli --list                             # TSV: id⇥*⇥url⇥title
+browser-cli --list --json                      # machine-readable
 ```
 
 # JavaScript API
@@ -69,11 +70,11 @@ markdown without a browser tab — prefer for public static articles/docs.
 # Example: Login Flow
 
 ```bash
-browser-cli --go "https://example.com/login"   # -> tab h9Jk3b
-browser-cli h9Jk3b <<< 'snap()'
+TAB=$(browser-cli --go "https://example.com/login")
+browser-cli $TAB <<< 'snap()'
 # [1] input "Email"  [2] input "Password"  [3] button "Sign In"
 
-browser-cli h9Jk3b <<'EOF'
+browser-cli $TAB <<'EOF'
 await type(1, "user@test.com")
 await type(2, "secret123")
 await click(3)

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -30,8 +30,11 @@ key("Enter")
 snap()                               // full snapshot first call,
                                      // diff vs previous on later calls
 snap({full: true})                   // force full snapshot
+snap({interactive: true})            // only buttons/links/inputs (cheap)
 snap({forms|links|buttons: true})    // filter by type (always full)
 snap({text: "login"})                // filter by text (always full)
+get(1, "text")                       // text|html|value|attr:name|count
+is(2, "visible")                     // visible|enabled|checked -> bool
 logs()                               // console logs
 
 // Waiting
@@ -41,6 +44,8 @@ await wait("text", "Success")        // text appears
 await wait("gone", "Loading")        // text disappears
 
 // Other
+scroll("down")                       // also: up|top|bottom, or scroll(ref)
+await upload(3, "/path/to/file.pdf") // <input type=file>, ~1MB limit
 await download(url, "file.pdf")      // -> ~/Downloads/
 await shot("/tmp/page.png")          // screenshot (omit path for data URL)
 read()                               // article text via Readability

--- a/skills/browser-cli/SKILL.md
+++ b/skills/browser-cli/SKILL.md
@@ -45,7 +45,7 @@ await wait("gone", "Loading")        // text disappears
 
 // Other
 scroll("down")                       // also: up|top|bottom, or scroll(ref)
-await upload(3, "/path/to/file.pdf") // <input type=file>, ~1MB limit
+await upload(3, "/path/to/file.pdf") // <input type=file> (chunked, any size)
 await download(url, "file.pdf")      // -> ~/Downloads/
 await shot("/tmp/page.png")          // screenshot (omit path for data URL)
 read()                               // article text via Readability


### PR DESCRIPTION
Ports the highest-value-per-token primitives from agent-browser so an LLM with a ref in hand can ask one cheap question instead of paying for a full snapshot: `get(ref, …)`, `is(ref, …)`, `scroll(…)`, `snap({interactive: true})`, and `upload(ref, path)`. The upload path threads filesystem reads through the Python bridge and reconstructs a real `File` via `DataTransfer`, with the 1 MiB native-messaging cap side-stepped by chunking (3-byte-aligned base64, sliding timeout, reassembled per file index). Along the way fixed the things that broke while testing: `--go` now prints just the tab ID to stdout (always, including the existing-tab path) so `TAB=$(browser-cli --go …)` actually works, `--list` is TSV/`--json`, privileged URL schemes are rejected up front instead of dying inside `executeScript`, and 700KB chunks are no longer dumped into the devtools console. Verified end-to-end against a live LibreWolf: 5 MB file uploaded in 141 ms with matching sha256 across the disk→bridge→extension→`File` round trip.
