### PR TITLE
✨ introduce homeModules for every client with speical configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ programs.mics-skills = {
 
 Only the selected CLI tools and their skill definitions will be installed.
 
+### Per-skill modules
+
+Each skill is also available as an individual Home Manager module. Importing a
+module installs its CLI tool and skill definition — no extra options needed:
+
+```nix
+# home-manager configuration
+{ inputs, ... }:
+{
+  imports = [
+    inputs.mics-skills.homeModules.kagi-search
+    inputs.mics-skills.homeModules.pexpect-cli
+    inputs.mics-skills.homeModules.screenshot-cli
+  ];
+}
+```
+
+> Run `nix flake show github:mic92/mics-skills` to see all available `homeModules`.
+
 ## Development
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
 
       imports = [
         inputs.treefmt-nix.flakeModule
+        ./home-manager-new.nix
       ];
 
       flake.homeManagerModules.default = import ./home-manager.nix;

--- a/home-manager-new.nix
+++ b/home-manager-new.nix
@@ -1,0 +1,48 @@
+{ self, ... }:
+let
+  mkSkillModule =
+    name:
+    {
+      packages ? null,
+      extra ? { },
+      ...
+    }:
+    { pkgs, ... }:
+    let
+      system = pkgs.stdenv.hostPlatform.system;
+      packageNames = if packages != null then packages else [ name ];
+    in
+    {
+      home.packages = map (p: self.packages.${system}.${p}) packageNames;
+      home.file.".claude/skills/${name}".source = "${self}/skills/${name}";
+      home.file.".opencode/skills/${name}".source = "${self}/skills/${name}";
+      imports = [ extra ];
+    };
+
+in
+{
+
+  flake.homeModules = builtins.mapAttrs mkSkillModule {
+    "browser-cli" = { };
+    "browser-cli-with-extension" = {
+      packages = [ "browser-cli" ];
+      extra =
+        { system, ... }:
+        {
+          programs.firefox.profiles.default.extensions.packages =
+            self.packages.${system}.browser-cli-extension;
+        };
+    };
+    "buildbot-pr-check" = { };
+    "calendar-cli" = { };
+    "context7-cli" = { };
+    "db-cli" = { };
+    "gmaps-cli" = { };
+    "kagi-search" = { };
+    "n8n-cli" = { };
+    "pexpect-cli" = { };
+    "screenshot-cli" = { };
+    "tasker-cli" = { };
+    "weather-cli" = { };
+  };
+}


### PR DESCRIPTION
Here an alternative way to import your skills. This way imports = [ module ] automatically enables it, and we can add customization of other tools (like firefox plugins) in that module without replicating it everywhere we use these skills.