### PR TITLE
flake: make homeManagerModules removal throw lazy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,10 +54,12 @@
         default = import ./nix/home-manager.nix;
       };
 
-      homeManagerModules = throw ''
-        mics-skills: `homeManagerModules` has been removed.
-        Use `homeModules.default` (legacy programs.mics-skills option module)
-        or the per-skill modules `homeModules.<skill>` instead.
-      '';
+      homeManagerModules = {
+        default = throw ''
+          mics-skills: `homeManagerModules` has been removed.
+          Use `homeModules.default` (legacy programs.mics-skills option module)
+          or the per-skill modules `homeModules.<skill>` instead.
+        '';
+      };
     };
 }


### PR DESCRIPTION
A bare `throw` at the top-level output breaks any tooling that
enumerates flake output attrs (e.g. srvos telegraf flake-input
metric calling `typeOf` on every attr). Wrap the throw in an
attrset so the migration error only fires when the attribute is
actually dereferenced.
