### PR TITLE
flake: drop homeManagerModules deprecation stub

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,13 +53,5 @@
       homeModules = import ./nix/home-modules.nix { inherit self lib; } // {
         default = import ./nix/home-manager.nix;
       };
-
-      homeManagerModules = {
-        default = throw ''
-          mics-skills: `homeManagerModules` has been removed.
-          Use `homeModules.default` (legacy programs.mics-skills option module)
-          or the per-skill modules `homeModules.<skill>` instead.
-        '';
-      };
     };
 }


### PR DESCRIPTION
Even wrapped in an attrset the throw trips downstream tooling that
deep-inspects flake outputs (srvos telegraf metric). The rename has
been in place long enough; consumers that still reference the old
attribute now get the standard "attribute missing" error instead.
