### PR TITLE
packages: make screenshot-cli spectacle backend overridable

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -8,6 +8,9 @@
   android-tools,
   makeWrapper,
   kdePackages,
+  # screenshot-cli backends, hoisted here so downstream users can drop one via
+  # `.override`, e.g. `.override { spectacle = null; }` on non-KDE systems.
+  spectacle ? if stdenv.hostPlatform.isLinux then kdePackages.spectacle else null,
 }:
 let
   pyCall = python3.pkgs.callPackage;
@@ -24,7 +27,7 @@ in
   n8n-cli = pyCall ../n8n-cli { };
   pexpect-cli = callPackage ../pexpect-cli { };
   screenshot-cli = pyCall ../screenshot-cli {
-    spectacle = if stdenv.hostPlatform.isLinux then kdePackages.spectacle else null;
+    inherit spectacle;
   };
   tasker-cli = pyCall ../tasker-cli { inherit android-tools makeWrapper; };
   weather-cli = pyCall ../weather-cli { };


### PR DESCRIPTION
Hoist the screenshot-cli spectacle backend to a top-level argument of nix/packages.nix.

screenshot-cli bundles spectacle as a runtime backend, which pulls qtbase-6, kio, kservice and kwidgetsaddons into the closure. Non-KDE users (grim on niri/sway) never invoke it.

The package set is exposed via callPackages, so .override only reaches packages.nix top-level args. That meant spectacle could not be dropped without overriding all of kdePackages.

Downstream can now drop it directly:

    screenshot-cli = mics-skills.packages.${system}.screenshot-cli.override {
      spectacle = null;
    };

With spectacle = null the wrapper keeps grim, drops spectacle, and no qtbase/kio/kservice remain in the closure. Default build unchanged.