### PR TITLE
screenshot-cli: stop bundling spectacle and jq

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   callPackage,
   callPackages,
   python3,
@@ -7,10 +6,6 @@
   msmtp,
   android-tools,
   makeWrapper,
-  kdePackages,
-  # screenshot-cli backends, hoisted here so downstream users can drop one via
-  # `.override`, e.g. `.override { spectacle = null; }` on non-KDE systems.
-  spectacle ? if stdenv.hostPlatform.isLinux then kdePackages.spectacle else null,
 }:
 let
   pyCall = python3.pkgs.callPackage;
@@ -26,9 +21,7 @@ in
   kagi-search = pyCall ../kagi-search { };
   n8n-cli = pyCall ../n8n-cli { };
   pexpect-cli = callPackage ../pexpect-cli { };
-  screenshot-cli = pyCall ../screenshot-cli {
-    inherit spectacle;
-  };
+  screenshot-cli = pyCall ../screenshot-cli { };
   tasker-cli = pyCall ../tasker-cli { inherit android-tools makeWrapper; };
   weather-cli = pyCall ../weather-cli { };
 }

--- a/screenshot-cli/default.nix
+++ b/screenshot-cli/default.nix
@@ -4,29 +4,13 @@
   hatchling,
   makeWrapper,
   pytestCheckHook,
-  # Linux-only screenshot backends, null on non-Linux
-  grim ? null,
-  spectacle ? null,
-  sway ? null,
-  jq,
+  grim,
   stdenv,
 }:
 
-let
-  isLinux = stdenv.hostPlatform.isLinux;
-  runtimeDeps = lib.optionals isLinux (
-    lib.filter (p: p != null) [
-      grim
-      spectacle
-      # sway gives us swaymsg for window-geometry queries on sway sessions;
-      # niri uses its own IPC and isn't bundled because it's the running
-      # compositor.
-      sway
-      jq
-    ]
-  );
-in
-
+# spectacle, swaymsg and niri ship with the desktop/compositor, so they are
+# left off PATH to avoid dragging KDE (spectacle -> qtbase/kio/kservice) onto
+# everyone. grim is standalone and may be missing, so it stays bundled.
 buildPythonApplication {
   pname = "screenshot-cli";
   version = "0.1.0";
@@ -39,15 +23,14 @@ buildPythonApplication {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux makeWrapper;
 
   postInstall = ''
     mkdir -p $out/share/skills
     cp -r ${./skill} $out/share/skills/screenshot-cli
   ''
-  + lib.optionalString (runtimeDeps != [ ]) ''
-    wrapProgram $out/bin/screenshot-cli \
-      --prefix PATH : ${lib.makeBinPath runtimeDeps}
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/screenshot-cli --prefix PATH : ${lib.makeBinPath [ grim ]}
   '';
 
   meta = {

--- a/screenshot-cli/screenshot_cli.py
+++ b/screenshot-cli/screenshot_cli.py
@@ -7,6 +7,7 @@ pointer, so those paths were indefinite hangs in disguise.
 """
 
 import argparse
+import json
 import os
 import platform
 import shutil
@@ -114,6 +115,19 @@ def capture_niri(mode: str, output: str, delay: int) -> None:
     raise RuntimeError("niri screenshot action returned but file never appeared")
 
 
+def focused_window_geometry(node: dict) -> str | None:
+    """Return the focused swaymsg node's rect as a grim -g "X,Y WxH" string."""
+    if node.get("focused"):
+        rect = node.get("rect", {})
+        return f"{rect['x']},{rect['y']} {rect['width']}x{rect['height']}"
+    for key in ("nodes", "floating_nodes"):
+        for child in node.get(key, []):
+            geom = focused_window_geometry(child)
+            if geom is not None:
+                return geom
+    return None
+
+
 def capture_grim(mode: str, output: str, delay: int) -> None:
     if delay > 0:
         time.sleep(delay)
@@ -126,19 +140,8 @@ def capture_grim(mode: str, output: str, delay: int) -> None:
                 tree = subprocess.run(
                     ["swaymsg", "-t", "get_tree"], capture_output=True, text=True, check=True
                 )
-                jq = subprocess.run(
-                    [
-                        "jq",
-                        "-r",
-                        r'.. | select(.focused?) | .rect | "\(.x),\(.y) \(.width)x\(.height)"',
-                    ],
-                    input=tree.stdout,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                geom = jq.stdout.strip().split("\n")[0]
-            except subprocess.CalledProcessError:
+                geom = focused_window_geometry(json.loads(tree.stdout))
+            except (subprocess.CalledProcessError, json.JSONDecodeError):
                 pass
         if geom:
             run(["grim", "-g", geom, output])

--- a/screenshot-cli/test_screenshot_cli.py
+++ b/screenshot-cli/test_screenshot_cli.py
@@ -62,3 +62,32 @@ def test_geometry_parse_grim_format() -> None:
 def test_geometry_parse_rejects_garbage() -> None:
     with pytest.raises(SystemExit):
         sc.parse_geometry("10,20,300,400")
+
+
+def test_focused_window_geometry_finds_nested_focus() -> None:
+    # Focused window can sit arbitrarily deep in the swaymsg tree.
+    tree = {
+        "focused": False,
+        "nodes": [
+            {
+                "focused": False,
+                "nodes": [
+                    {"focused": False, "rect": {"x": 0, "y": 0, "width": 1, "height": 1}},
+                    {"focused": True, "rect": {"x": 10, "y": 20, "width": 300, "height": 400}},
+                ],
+            }
+        ],
+    }
+    assert sc.focused_window_geometry(tree) == "10,20 300x400"
+
+
+def test_focused_window_geometry_finds_floating() -> None:
+    tree = {
+        "focused": False,
+        "floating_nodes": [{"focused": True, "rect": {"x": 5, "y": 6, "width": 7, "height": 8}}],
+    }
+    assert sc.focused_window_geometry(tree) == "5,6 7x8"
+
+
+def test_focused_window_geometry_none_when_unfocused() -> None:
+    assert sc.focused_window_geometry({"focused": False, "nodes": []}) is None


### PR DESCRIPTION
The package wrapped grim, spectacle, sway and jq onto PATH. spectacle alone pulls qtbase, kio, kservice and kwidgetsaddons, so every user carried a KDE closure regardless of their desktop.

spectacle, swaymsg and niri all ship with the running desktop or compositor, so they are dropped from PATH; the tool already selects a backend at runtime via $XDG_CURRENT_DESKTOP and shutil.which. grim is standalone and may be absent, so it stays bundled.

jq was only used to read the focused window rect out of swaymsg's JSON. Python's json module does the same, so it is dropped too, with tests for the replacement.

Also removes the spectacle override arg added in #65, now unneeded.