### PR TITLE
browser-cli: make go() error usefully in exec API

### DIFF
--- a/browser-cli/extension/content.js
+++ b/browser-cli/extension/content.js
@@ -2445,6 +2445,12 @@ if (!window.__browserCliInjected) {
     is,
     scroll,
     upload,
+    // Agents guess go() exists; error must point at the real mechanism.
+    go() {
+      throw new Error(
+        "go() is not a JS API. Navigate with: browser-cli --go URL",
+      );
+    },
   };
   const execApiNames = Object.keys(execApi);
   const execApiValues = Object.values(execApi);


### PR DESCRIPTION

Agents assume go() exists for navigation and only get a ReferenceError.
Add a stub that throws and points at browser-cli --go URL.
